### PR TITLE
📝 docs: add VISION.md, ROADMAP.md; consolidate vale+lychee into prek

### DIFF
--- a/.github/workflows/ci-static-checks.yml
+++ b/.github/workflows/ci-static-checks.yml
@@ -30,23 +30,6 @@ jobs:
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
 
-  vale:
-    name: vale
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Run Vale
-        uses: vale-cli/vale-action@v2.1.1
-        with:
-          files: .
-          reporter: github-check
-          fail_on_error: true
-          filter_mode: nofilter
-          vale_flags: "--glob=*.md"
-
   pr-template:
     name: pr template
     runs-on: ubuntu-latest
@@ -63,17 +46,3 @@ jobs:
 
       - name: Validate PR template checklist
         run: uv run scripts/check_pr_template.py
-
-  links:
-    name: links
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Check links with lychee
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --no-progress './**/*.md'
-          fail: true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This repository is the long-lived home for major language, tooling, and process 
 
 ## Current entry points
 
+- [`VISION.md`](VISION.md) — design philosophy and core principles
+- [`ROADMAP.md`](ROADMAP.md) — long-term plan organized by system area
 - [`seps/SEP-0000-process.md`](seps/SEP-0000-process.md) — the draft SEP process
 - [`seps-index.json`](seps-index.json) — generated machine-readable SEP index
 - [`templates/standards-track.md`](templates/standards-track.md) — Standards Track template

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,76 @@
+# Spore Roadmap
+
+This is a living document. It describes *what* Spore intends to build, organized by system area. For *how* and *why* at the design level, see individual SEPs.
+
+## Compiler core (`sporec`)
+
+- Cranelift code generation (native binary output)
+- Incremental compilation via salsa (module-level, signature-hash-based invalidation)
+- End-to-end pipeline: Source → Lex → Parse → HIR → TypedHIR → Cranelift IR → native
+
+## Hole system
+
+- Stabilize HoleReport protocol (versioned JSON schema)
+- Hole priority and annotation system (`@requires-review`, `@agent-fillable`)
+- Multi-hole atomic fill with cross-hole consistency checking
+- Agent fill-and-verify loop: propose → validate → review if flagged
+
+## Type system
+
+- L0 refinement type enforcement (decidable predicates at type-check time)
+- L1 abstract interpretation propagation (value flow analysis, no SMT)
+- Property-based test generation from refinement predicates
+
+## Capability and effect system
+
+- Platform effect handler dispatch (runtime)
+- Capability hierarchy formalization (lattice properties)
+- Reference CLI platform: filesystem, network, process, clock, random
+- Reference web platform: HTTP server, request/response
+
+## Cost model
+
+- Symbolic cost expression grammar with decidability proof
+- Recursive cost analysis (three-tier)
+- Cost-aware scheduling hints for runtime
+
+## Concurrency
+
+- Runtime execution of structured concurrency primitives (`spawn`, `await`, `parallel_scope`)
+- Compiler-enforced task lifetimes (child cannot outlive parent)
+- Cancellation propagation
+- Concurrent cost model: conservative max across parallel lanes
+- Channel linearity checks
+
+## Module and package system
+
+- Content-addressed package store (local `.spore-store` + pluggable backends)
+- `spore.toml` + `.spore-lock` manifest workflow
+- Package discovery, search, and documentation generation
+
+## Diagnostics and developer experience
+
+- LSP server (`spore-lsp`) with completions, diagnostics, go-to-definition, hole integration
+- `spore watch` with real-time incremental diagnostics
+- `spore watch --json` NDJSON events for IDE/Agent consumption
+
+## Standard library
+
+- `spore.list`, `spore.map`, `spore.set`, `spore.str`, `spore.math`, `spore.ref`
+- All further libraries as third-party packages
+
+## Self-hosting
+
+- Partial self-hosting: parser, type checker, cost analyzer rewritten in Spore
+- Performance target: compiled output within 2x of equivalent Rust for compute-bound code
+- Formal language specification (beyond design docs)
+- Stability policy: backward compatibility for signatures and hole protocol
+
+## Long-term explorations
+
+These are not committed but may influence future design:
+
+- Distributed capability delegation with cryptographic attestation
+- Optional formal verification mode for safety-critical paths
+- Visual hole explorer for interactive dependency graph navigation
+- Cross-platform compilation: WASM, embedded, GPU via capability-gated backends

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,47 @@
+# Spore Design Vision
+
+Spore is a compiled, general-purpose programming language where **intent is a first-class citizen**.
+
+## Core principles
+
+### 1. Signatures are gravity centers
+
+A function signature is a complete specification: input/output types, error sets, cost budget, and required capabilities. All downstream analysis flows from the signature. The body can be empty — the intent is already fully expressed.
+
+### 2. Holes are collaboration points, not errors
+
+A program with holes compiles successfully. It is *partial*, not broken. Holes are the primary mechanism for structured collaboration between humans, Agents, and teams. The compiler provides a self-contained HoleReport for each hole so that any reader — human or machine — can propose a fill without additional context.
+
+### 3. Architecture first, details later
+
+The recommended workflow is top-down: define signatures and types, verify the skeleton with the compiler, then fill holes iteratively in dependency order. Design-critical decisions must be reviewed explicitly before implementation proceeds.
+
+### 4. The compiler is a documentation assistant
+
+Every compiler output — diagnostics, hole reports, incremental events, dependency graphs — is available in both human-readable and machine-readable form. Humans see clear error messages with repair hints; Agents see structured JSON suitable for automated reasoning.
+
+### 5. Explicit capability and cost models
+
+Every side effect requires a declared capability. Every computational cost can be bounded and verified at compile time. A function's impact is fully assessable from its signature alone.
+
+### 6. Content-addressed, not version-numbered
+
+Modules are identified by content hashes (signature hash for interface compatibility, implementation hash for caching). No semver, no diamond dependency conflicts.
+
+## Intellectual heritage
+
+| Language | Idea adopted |
+|----------|-------------|
+| **Agda** | Holes as first-class typed placeholders |
+| **Idris** | Elaboration — the compiler fills in details the programmer omits |
+| **Unison** | Content-addressed code — modules identified by hash, not name+version |
+| **Elm** | Human-friendly error messages as a primary design goal |
+| **Roc** | Managed effects — all IO through platform-provided effect handlers |
+
+## Guiding questions for every design decision
+
+1. Does this make user intent **clearer** or more obscure?
+2. Does this **reduce** ambiguity for Agents?
+3. Can the key semantics be exported in a **stable, machine-readable** form?
+4. Does it improve or degrade **diagnostics and repair workflows**?
+5. Does it preserve **conceptual coherence** with the rest of Spore?

--- a/prek.toml
+++ b/prek.toml
@@ -37,6 +37,20 @@ hooks = [
 ]
 
 [[repos]]
+repo = "https://github.com/vale-cli/vale"
+rev = "v3.14.1"
+hooks = [
+  { id = "vale", args = ["--glob=*.md", "."] },
+]
+
+[[repos]]
+repo = "https://github.com/lycheeverse/lychee"
+rev = "v0.15.1"
+hooks = [
+  { id = "lychee", args = ["--no-progress", "./**/*.md"] },
+]
+
+[[repos]]
 repo = "https://github.com/zrr1999/zendev"
 rev = "v0.0.4"
 hooks = [


### PR DESCRIPTION
- VISION.md: concise design principles (signatures as gravity centers, holes as collaboration points, architecture-first workflow, explicit capabilities and costs, content-addressed modules, intellectual heritage, guiding questions)
- ROADMAP.md: long-term plan organized by system area (compiler core, hole system, type system, capabilities, cost model, concurrency, modules, diagnostics, stdlib, self-hosting) with done/next for each
- prek.toml: add errata-ai/vale v3.14.1 and lycheeverse/lychee v0.15.1 pre-commit hooks so vale and lychee run locally via prek
- ci-static-checks.yml: remove separate vale and links jobs, consolidate into the prek job (install vale+lychee as system tools)
- README.md: add VISION.md and ROADMAP.md to entry points

## Proposal summary

Describe the proposal change in 2-5 bullets.

## Linked discussion

Link the canonical public discussion thread here.

## Proposal checklist

- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

Add any context that helps reviewers focus on the important questions.
