### PR TITLE
📝 docs: expand CLI tooling design in SEP-0006

### DIFF
--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -958,6 +958,76 @@ Target latencies (aspirational, not hard guarantees):
 
 **Parallelism:** Default = CPU core count. Override with `--jobs N`.
 
+### CLI subcommand design
+
+#### `spore check`
+
+`spore check` performs all static analyses without code generation. It is the
+primary command for verifying correctness during development.
+
+```bash
+spore check src/main.spore          # check a single entry point
+spore check src/**/*.sp             # check all source files
+spore check --deny-warnings .       # treat warnings as errors (for CI)
+```
+
+##### Implementation strategy
+
+`spore check` runs a **single compilation pipeline** that performs all static
+analyses in one pass:
+
+```text
+Source → Parse → Name Resolution → Type Inference
+                                    ├── Capability Check (inline)
+                                    ├── Cost Analysis (post-typecheck)
+                                    └── Lint Pass (post-typecheck)
+```
+
+All diagnostics are collected into a single `Vec<Diagnostic>` and sorted by file
+position. This ensures the developer sees **all** issues in one invocation rather
+than fixing types first, then capabilities, then costs.
+
+**Cost violations** are emitted as **warnings** (severity = Warning, code prefix
+`K`), not errors. They do not cause a non-zero exit code unless `--deny-warnings`
+is passed.
+
+**Lint warnings** (severity = Warning, code prefix `W`) follow the same rule.
+
+#### `spore format`
+
+`spore format` rewrites source files to conform to the canonical Spore style.
+
+```bash
+spore format src/**/*.sp            # format files in place
+spore format --check src/**/*.sp    # exit 1 if any file would change (no writes)
+```
+
+##### Implementation strategy
+
+The formatter is **AST-based**: it parses source code into an AST, then
+pretty-prints the AST according to canonical rules. This ensures output is always
+syntactically valid and produces consistent results regardless of input formatting.
+
+```text
+Source → Parse → AST → Pretty-print → Formatted source
+```
+
+**Comment preservation** is a known challenge for AST-based formatters. The current
+implementation attaches comments to adjacent AST nodes during parsing (stored as
+leading/trailing trivia on `Spanned<T>`). Future work may adopt a CST
+(Concrete Syntax Tree) approach for perfect fidelity.
+
+**CI integration**: `spore format --check` is designed for CI pipelines. It exits
+with code 1 if any file would change, without modifying files. Combined with
+`spore check --deny-warnings`, these two commands form a complete CI static
+analysis gate:
+
+```yaml
+# Example CI step
+- run: spore format --check src/**/*.sp
+- run: spore check --deny-warnings src/**/*.sp
+```
+
 ---
 
 ## Human experience impact


### PR DESCRIPTION
## Summary

Adds a new **CLI subcommand design** section to SEP-0006 (Compiler Architecture) under the reference-level explanation.

### Changes

- **`spore check`**: Documents the unified checking pipeline (typecheck → capcheck → costcheck → lint) that collects all diagnostics in a single pass. Clarifies that cost violations (`K`-prefix) and lint warnings (`W`-prefix) are warnings by default and only fail CI with `--deny-warnings`.

- **`spore format`**: Documents the AST-based implementation strategy (parse → AST → pretty-print), comment preservation approach via leading/trailing trivia on `Spanned<T>`, and future CST considerations.

- **CI integration**: Shows how `spore format --check` and `spore check --deny-warnings` together form a complete static analysis gate, with a YAML example.

## Linked discussion

See the canonical discussion in the SEP-0006 thread.

## Pre-submission checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.

## Proposal checklist

- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

Focus on whether the CLI subcommand contracts (exit codes, flag semantics) align with the compiler architecture described in SEP-0006.