### PR TITLE
📝 docs: redesign module system + CLI tech stack

### DIFF
--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -762,6 +762,25 @@ Watch events are converted to LSP messages by the Spore LSP server:
 }
 ```
 
+### CLI implementation stack
+
+The `spore` binary is built on a curated set of Rust crates chosen for
+correctness, minimal footprint, and future Spore self-hosting feasibility:
+
+| Crate | Purpose | Bootstrap path |
+|-------|---------|---------------|
+| `bpaf` | Argument parsing (derive-based) | Parser combinator — natural fit for Spore |
+| `ariadne` | Diagnostic rendering (span-based) | Thin wrapper on ANSI formatting |
+| `owo-colors` | Terminal color output | Pure ANSI escape sequences |
+| `notify` | File system watching (`watch` mode) | System call wrapper |
+| `serde_json` | JSON serialization (`--json` flag) | Spore will need JSON support |
+| `tracing` | Structured logging (`--verbose`) | Replaceable with print-based logging |
+
+**Self-hosting consideration:** Every crate above wraps a concept that Spore
+must eventually implement natively (parsing, formatting, file I/O, JSON). The
+Rust CLI serves as the reference implementation; the Spore bootstrap will
+reimplement these as Spore libraries using the `basic-cli` platform.
+
 ### Diagnostic output formats
 
 #### Default format

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -16,13 +16,13 @@ superseded_by: null
 
 # SEP-0008: Module & Package System
 
-> **Executive Summary**: Defines a content-addressed package system (BLAKE3 dual-hash) with platform-as-package architecture, where platforms provide effect handlers via `foreign fn` declarations. Uses 1-file-=1-module mapping with slash-separated import paths (`import billing/invoice`), `spore.toml` for project configuration, and a two-layer capability ceiling (project + file level). Enforces visibility rules (pub/pub(pkg)/private) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through capability isolation — downloaded packages declaring `uses [Compute]` provably cannot access IO.
+> **Executive Summary**: Defines a content-addressed package system (BLAKE3 dual-hash) with platform-as-package architecture, where platforms provide effect handlers via `foreign fn` declarations. Uses 1-file-=1-module mapping with dot-separated import paths (`import billing.invoice`), `spore.toml` for project configuration, and a two-layer capability ceiling (project + file level). Enforces visibility rules (pub/pub(pkg)/private) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through capability isolation — downloaded packages declaring `uses [Compute]` provably cannot access IO.
 
 ## Summary
 
-This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via slash-separated paths (`import billing/invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `spore.lock` for reproducible builds, how dependencies are resolved without semantic versioning, how IO is abstracted through the Platform system using effect handlers, and how a two-layer capability ceiling (project-wide in `spore.toml` + file-level `#![uses(...)]` pragma) secures the supply chain.
+This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via dot-separated paths (`import billing.invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `spore.lock` for reproducible builds, how dependencies are resolved without semantic versioning, how IO is abstracted through the Platform system using effect handlers, and how a two-layer capability ceiling (project-wide in `spore.toml` + file-level `#![uses(...)]` pragma) secures the supply chain.
 
-The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Gleam (slash-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the two-layer capability ceiling, the import/alias separation, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
+The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Elixir/Python (dot-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the two-layer capability ceiling, the import/alias separation, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
 
 ## Motivation
 
@@ -71,8 +71,8 @@ Every `.spore` file is exactly one module. The module name is derived from the f
 
 | File Path | Module Name |
 |---|---|
-| `src/billing/invoice.spore` | `billing/invoice` |
-| `src/auth/token.spore` | `auth/token` |
+| `src/billing/invoice.spore` | `billing.invoice` |
+| `src/auth/token.spore` | `auth.token` |
 | `src/utils.spore` | `utils` |
 | `src/main.spore` | `main` |
 
@@ -82,14 +82,14 @@ There is no `module` keyword — the filesystem **is** the declaration. A file-l
 // src/billing/invoice.spore
 #![uses(PaymentGateway, AuditLog)]
 
-import billing/types
-import billing/tax
+import billing.types
+import billing.tax
 
 pub fn generate_invoice(order: Order) -> Invoice ! [TaxError, ValidationError]
     cost ≤ 3000
     uses [PaymentGateway, AuditLog]
 {
-    let tax = billing/tax.calculate(order.items, order.region)
+    let tax = tax.calculate(order.items, order.region)
     let line_items = build_line_items(order.items, tax)
     finalize(order.customer, line_items)
 }
@@ -101,34 +101,34 @@ fn build_line_items(items: Vec<Item>, tax: TaxResult) -> Vec<LineItem>
 }
 ```
 
-Module names use **slash-separated** paths derived from the filesystem. There is no explicit `module` declaration; the file path is the single source of truth.
+Module names use **dot-separated** paths derived from the filesystem. There is no explicit `module` declaration; the file path is the single source of truth.
 
 ### Imports
 
-Spore uses **slash-separated** paths for module imports (Gleam-style) and **dot** for item selection:
+Spore uses **dot-separated** paths for module imports and for item selection:
 
 ```spore
 // Module import: makes all pub items accessible via qualified name
-import billing/invoice
+import billing.invoice
 
 // Module import with rename
-import billing/invoice as inv
+import billing.invoice as inv
 
 // Selective import: bring specific items into scope
-import billing/invoice.{calculate, Invoice}
+import billing.invoice.{calculate, Invoice}
 
 // Item alias: binds a specific function or type to a local name
-alias gen = billing/invoice.generate_invoice
-alias Inv = billing/types.Invoice
+alias gen = billing.invoice.generate_invoice
+alias Inv = billing.types.Invoice
 ```
 
 Key rules:
 
-- `import` operates on **modules** only. Slash (`/`) separates path segments.
+- `import` operates on **modules** only. Dot (`.`) separates path segments.
 - Selective imports use dot (`.`) then braces (`{...}`) to bring specific items into scope.
 - `alias` operates on **items** only. You cannot alias a module (use `import ... as` instead).
-- No wildcard imports (`import billing/*` is not supported).
-- No implicit nested imports (`import billing` does not import `billing/invoice`).
+- No wildcard imports (`import billing.*` is not supported).
+- No implicit nested imports (`import billing` does not import `billing.invoice`).
 
 ### Visibility
 
@@ -160,22 +160,49 @@ my-billing-lib/
 ├── spore.toml              // package manifest
 ├── src/
 │   ├── billing/
-│   │   ├── invoice.spore   -- module: billing/invoice
-│   │   ├── tax.spore       -- module: billing/tax
-│   │   └── types.spore     -- module: billing/types
+│   │   ├── invoice.spore   -- module: billing.invoice
+│   │   ├── tax.spore       -- module: billing.tax
+│   │   └── types.spore     -- module: billing.types
 │   └── utils.spore         -- module: utils
 └── test/
     └── billing/
         └── invoice_test.spore
 ```
 
-Three package types exist:
+Four package types exist:
 
 | Type | Has Platform? | Can do IO? | Use Case |
 |---|---|---|---|
 | `package` | No | No (declares capability requirements) | Libraries, reusable components |
 | `application` | Yes | Yes (via Platform) | Executables, services |
 | `platform` | Is the Platform | Yes (raw syscalls) | Runtime providers |
+| `script` | Implicit | Yes (via `--platform` flag) | Single-file programs, prototypes |
+
+### Script Mode
+
+Spore supports a lightweight **script mode** for single-file programs that require no `spore.toml` manifest:
+
+```bash
+# Run a single file directly with an implicit platform
+spore run hello.sp --platform cli
+
+# Equivalent to an implicit application with:
+#   [package]
+#   type = "application"
+#   platform = { git = "https://github.com/spore-lang/basic-cli" }
+```
+
+Script mode is ideal for quick prototypes, teaching, and small utilities. The compiler infers:
+
+- **Platform**: From `--platform` flag (required for scripts using IO effects). `cli` is shorthand for `spore-lang/basic-cli`.
+- **Capabilities**: Inherited from the specified platform's defaults.
+- **Dependencies**: Scripts cannot declare external dependencies. For multi-file or dependency-heavy projects, use `spore.toml`.
+
+Constraints:
+
+- A script is a single `.sp` file with a `main` function.
+- No `spore.toml` or `spore.lock` is generated.
+- The file's module name is derived from its filename (e.g., `hello.sp` → module `hello`).
 
 ### Platforms
 
@@ -208,7 +235,7 @@ The compiler maps `.spore` files to modules using the path relative to `src/`:
 ```text
 module_name = path.relative_to("src/")
                   .strip_extension(".spore")
-                  // path separators become '/' in the module name
+                  // path separators become '.' in the module name
 ```
 
 Module name segments must be lowercase `snake_case`. Reserved names (`main`, `platform`, `test`) carry special semantics.
@@ -225,7 +252,7 @@ An empty `.spore` file is a valid module. It compiles successfully, exports noth
 ```text
 $ sporec check src/billing/future.spore
 
-[ok] billing/future
+[ok] billing.future
   exports: (none)
   capabilities: []
 ```
@@ -244,12 +271,12 @@ The compiler builds a directed acyclic graph (DAG) of module dependencies:
 $ sporec build --show-order
 
 Build order (topological):
-  1. billing/types       (0 dependencies)
-  2. billing/tax         (1 dependency: billing/types)
-  3. billing/invoice     (2 dependencies: billing/types, billing/tax)
-  4. billing/shortcuts   (3 dependencies: billing/types, billing/invoice, billing/tax)
-  5. api/handler         (2 dependencies: billing/invoice, billing/shortcuts)
-  6. main                (1 dependency: api/handler)
+  1. billing.types       (0 dependencies)
+  2. billing.tax         (1 dependency: billing.types)
+  3. billing.invoice     (2 dependencies: billing.types, billing.tax)
+  4. billing.shortcuts   (3 dependencies: billing.types, billing.invoice, billing.tax)
+  5. api.handler         (2 dependencies: billing.invoice, billing.shortcuts)
+  6. main                (1 dependency: api.handler)
 ```
 
 Diamond dependencies are permitted (they are not cycles). The `.spore-lock` ensures a single canonical version via matching `sig` and `impl` hashes.
@@ -264,7 +291,7 @@ Within a single module, functions may reference each other regardless of declara
 import_decl    ::= 'import' module_path ('as' IDENT)?
                   | 'import' module_path '.' '{' IDENT (',' IDENT)* '}'
 alias_decl     ::= visibility? 'alias' IDENT '=' qualified_item
-module_path    ::= IDENT ('/' IDENT)*
+module_path    ::= IDENT ('.' IDENT)*
 qualified_item ::= module_path '.' IDENT
 ```
 
@@ -274,20 +301,20 @@ The compiler does not enforce import order, but `sporec fmt` auto-sorts imports 
 
 ```spore
 // 1. Platform / standard library imports
-import std/collections
-import std/text
+import std.collections
+import std.text
 
 // 2. External package imports
-import http/client as http
-import json/parser as json
+import http.client as http
+import json.parser as json
 
 // 3. Internal package imports
-import billing/invoice
-import billing/types
+import billing.invoice
+import billing.types
 
 // 4. Aliases
-alias Invoice = billing/types.Invoice
-alias gen = billing/invoice.generate_invoice
+alias Invoice = billing.types.Invoice
+alias gen = billing.invoice.generate_invoice
 ```
 
 Within each group, imports are sorted alphabetically by module path.
@@ -359,11 +386,11 @@ The `.spore-lock` file records both hashes for all functions a module depends on
 ```toml
 # .spore-lock (auto-generated, do not edit)
 
-[deps."api/handler".generate_invoice]
+[deps."api.handler".generate_invoice]
 sig  = "a3f7c2"    # interface contract
 impl = "d8e1b4"    # exact implementation (None if partial)
 
-[deps."billing/invoice".calculate]
+[deps."billing.invoice".calculate]
 sig  = "d91e4b"
 impl = "b2c4a7"
 ```
@@ -377,16 +404,16 @@ When a signature changes, all downstream modules referencing the old `sig` are f
 ```text
 $ sporec check
 
-[warning] signature changed: billing/tax.calculate
+[warning] signature changed: billing.tax.calculate
   old sig: d91e4b
   new sig: 7a2f33
   change: added error type [RegionNotSupported]
 
   affected modules:
-    billing/invoice (depends on billing/tax.calculate sig=d91e4b)
-    api/handler     (depends on billing/tax.calculate sig=d91e4b)
+    billing.invoice (depends on billing.tax.calculate sig=d91e4b)
+    api.handler     (depends on billing.tax.calculate sig=d91e4b)
 
-  run `spore --permit billing/tax.calculate` to accept this change
+  run `spore --permit billing.tax.calculate` to accept this change
 ```
 
 The `spore --permit` command updates `sig` entries in `.spore-lock`. Implementation-only changes update `impl` automatically—no permit required. Batch acceptance is available via `spore --permit --all`.
@@ -417,9 +444,9 @@ pub type Invoice { id: InvoiceId, total: Money }       // public type
 pub(pkg) type ValidatedOrder { original: Order }        // package-internal type
 type InternalCache { entries: Map<String, CacheEntry> } // private type
 
-pub alias GenInv = billing/invoice.generate_invoice     // public alias
-pub(pkg) alias Validate = billing/invoice.validate      // package-internal alias
-alias Compute = billing/invoice.compute_totals          // private alias
+pub alias GenInv = billing.invoice.generate_invoice     // public alias
+pub(pkg) alias Validate = billing.invoice.validate      // package-internal alias
+alias Compute = billing.invoice.compute_totals          // private alias
 ```
 
 #### Visibility enforcement
@@ -428,8 +455,8 @@ Attempting to access a private item from another module:
 
 ```text
 [error] visibility violation at src/api/handler.spore:15
-  billing/invoice.compute_totals is private
-  ─── it is only visible within module billing/invoice
+  billing.invoice.compute_totals is private
+  ─── it is only visible within module billing.invoice
 
   help: add `pub` or `pub(pkg)` to its definition in src/billing/invoice.spore
 ```
@@ -438,10 +465,12 @@ Attempting to access a `pub(pkg)` item from an external package:
 
 ```text
 [error] visibility violation at src/handler.spore:8
-  billing/invoice.validate is pub(pkg)
+  billing.invoice.validate is pub(pkg)
   ─── it is only visible within the 'my-billing-lib' package
   ─── your module 'handler' is in the 'my-api' package
 ```
+
+In a workspace, `pub(pkg)` restricts visibility to the **current package** (member) only — not to the entire workspace. For workspace member `core` exporting `pub(pkg) fn internal_helper()`, member `web` in the same workspace **cannot** access it. Use `pub` for cross-member visibility.
 
 #### Visibility and the Hole System
 
@@ -452,12 +481,12 @@ Holes inherit the visibility context of their enclosing function. A HoleReport i
   "hole": { "name": "payment_logic", "location": "src/api/handler.spore:15" },
   "candidates": [
     {
-      "function": "billing/invoice.generate_invoice",
+      "function": "billing.invoice.generate_invoice",
       "visibility": "pub",
       "accessible": true
     },
     {
-      "function": "billing/invoice.validate",
+      "function": "billing.invoice.validate",
       "visibility": "pub(pkg)",
       "accessible": true,
       "note": "same package"
@@ -465,9 +494,9 @@ Holes inherit the visibility context of their enclosing function. A HoleReport i
   ],
   "excluded": [
     {
-      "function": "billing/invoice.compute_totals",
+      "function": "billing.invoice.compute_totals",
       "visibility": "private",
-      "reason": "private to billing/invoice"
+      "reason": "private to billing.invoice"
     }
   ]
 }
@@ -481,11 +510,11 @@ The only re-export mechanism is `pub alias`:
 
 ```spore
 // src/billing/shortcuts.spore
-import billing/invoice
-import billing/types
+import billing.invoice
+import billing.types
 
-pub alias generate = billing/invoice.generate_invoice
-pub alias Invoice = billing/types.Invoice
+pub alias generate = billing.invoice.generate_invoice
+pub alias Invoice = billing.types.Invoice
 ```
 
 Alias chains are **forbidden**. A `pub alias` must point to an original definition, not to another alias. This prevents unbounded indirection and keeps the dependency graph simple for both human and agent analysis.
@@ -495,8 +524,8 @@ Alias chains are **forbidden**. A `pub alias` must point to an original definiti
 Module imports and aliases cannot shadow each other. An alias cannot conflict with an imported module name:
 
 ```spore
-import billing/invoice
-alias invoice = billing/types.Invoice    // ERROR: 'invoice' conflicts with module name
+import billing.invoice
+alias invoice = billing.types.Invoice    // ERROR: 'invoice' conflicts with module name
 ```
 
 ### Platform abstraction
@@ -619,9 +648,9 @@ Package: billing-lib
   required capabilities: [PaymentGateway, AuditLog]
 
   Module capability breakdown:
-    billing/invoice:  [PaymentGateway, AuditLog]
-    billing/tax:      []  (pure)
-    billing/types:    []  (pure)
+    billing.invoice:  [PaymentGateway, AuditLog]
+    billing.tax:      []  (pure)
+    billing.types:    []  (pure)
 
   ✓ No RawSyscall usage
   ✓ No undeclared capabilities
@@ -665,8 +694,8 @@ Individual files can narrow the project ceiling to declare the maximum capabilit
 // src/billing/invoice.spore
 #![uses(PaymentGateway, AuditLog)]
 
-import billing/types
-import billing/tax
+import billing.types
+import billing.tax
 
 pub fn generate_invoice(order: Order) -> Invoice ! [TaxError]
     uses [PaymentGateway, AuditLog]
@@ -716,7 +745,7 @@ fn send_email(to: Email, body: String) -> Unit ! [SmtpError]
 ```text
 [error] capability ceiling violation at src/billing/invoice.spore:12
   function send_email uses [EmailService]
-  module billing/invoice allows [PaymentGateway, AuditLog]
+  module billing.invoice allows [PaymentGateway, AuditLog]
   ─── EmailService is not in the module's capability set
 
   help: either add EmailService to the file-level pragma:
@@ -733,7 +762,7 @@ fn send_email(to: Email, body: String) -> Unit ! [SmtpError]
 ```text
 $ sporec check src/billing/invoice.spore
 
-[ok] billing/invoice
+[ok] billing.invoice
   exports: generate_invoice, void_invoice
 
   [info] inferred module capabilities: [PaymentGateway, AuditLog]
@@ -788,6 +817,31 @@ test-framework = {
 Dependencies are declared **per-project** in `spore.toml`, not per-file. The `[capabilities] allowed` list defines the project-wide ceiling; individual files narrow it with `#![uses(...)]`.
 
 Package names are `kebab-case` and globally unique within a registry. Module paths within a package use `snake_case` segments.
+
+### Application Entry Points
+
+An application's default entry point is `src/main.sp`, and the resulting binary name defaults to the package name from `spore.toml`:
+
+```toml
+[package]
+name = "my-tool"
+type = "application"
+# Binary name: "my-tool", entry: src/main.sp
+```
+
+To override the default or define additional binaries, use `[[bin]]`:
+
+```toml
+[[bin]]
+name = "my-tool"
+path = "src/main.sp"      # default, can be omitted
+
+[[bin]]
+name = "my-tool-migrate"
+path = "src/migrate.sp"   # additional binary
+```
+
+Each `[[bin]]` entry must point to a `.sp` file containing a `main` function with the platform-required signature.
 
 #### Content-addressed dependencies (BLAKE3, no semver)
 
@@ -866,6 +920,12 @@ members = [
 ```
 
 Alternatively, `path` dependencies provide lightweight monorepo support without requiring a workspace manifest.
+
+A workspace uses a **single `spore.lock`** at the workspace root. Individual members do NOT have their own lock files. This ensures:
+
+- All members share the same dependency versions (no diamond dependency conflicts).
+- CI builds are reproducible from a single lock file.
+- `spore update` in any member updates the shared lock.
 
 ### Dependency type classification
 
@@ -1143,13 +1203,13 @@ $ sporec --holes
 
 Holes by module:
 
-  billing/invoice (partial)
+  billing.invoice (partial)
     ?invoice_logic at line 12
       type: Invoice ! [TaxError]
       capabilities: [PaymentGateway, AuditLog]
       budget remaining: 2400 ops
 
-  api/handler (partial — depends on partial billing/invoice)
+  api.handler (partial — depends on partial billing.invoice)
     (no direct holes, but transitively partial)
 ```
 
@@ -1158,9 +1218,9 @@ Holes by module:
 Cost is a per-function property (`cost ≤ N`). There are no module-level cost budgets. When a function calls an imported function, the callee's **declared** cost bound is used for estimation:
 
 ```text
-$ spore cost-report billing/invoice
+$ spore cost-report billing.invoice
 
-Module: billing/invoice
+Module: billing.invoice
 
   Function costs:
     generate_invoice    cost ≤ 3000  (measured: 2800)
@@ -1188,14 +1248,14 @@ Error types follow the same visibility rules as all other types. A function's er
 
 ```spore
 // src/api/handler.spore
-import billing/invoice
-import billing/errors
+import billing.invoice
+import billing.errors
 
-pub fn handle_create(req: Request) -> Response ! [billing/errors.BillingError, ParseError]
+pub fn handle_create(req: Request) -> Response ! [errors.BillingError, ParseError]
     uses [PaymentGateway, AuditLog]
 {
     let order = parse_request(req)
-    let invoice = billing/invoice.generate_invoice(order)
+    let invoice = invoice.generate_invoice(order)
     Response.ok(invoice)
 }
 ```
@@ -1216,7 +1276,7 @@ pub type LineItem { description: String, quantity: Int, unit_price: Money }
 ```text
 $ sporec check src/billing/types.spore
 
-[ok] billing/types
+[ok] billing.types
   exports: Invoice, InvoiceStatus, LineItem
   capabilities: []
   cost: 0 (types only)
@@ -1227,23 +1287,23 @@ $ sporec check src/billing/types.spore
 Diamond dependencies use consistent hashes:
 
 ```text
-       billing/types
+       billing.types
         ↑        ↑
         │        │
-  billing/invoice  billing/tax
+  billing.invoice  billing.tax
         ↑        ↑
         │        │
-       api/handler
+       api.handler
 ```
 
-The `.spore-lock` records the same `sig` and `impl` for `billing/types.Invoice` regardless of which path reached it:
+The `.spore-lock` records the same `sig` and `impl` for `billing.types.Invoice` regardless of which path reached it:
 
 ```toml
-[deps."billing/invoice".Invoice]
+[deps."billing.invoice".Invoice]
 sig  = "8c3f01"
 impl = "e9f3d2"
 
-[deps."billing/tax".Invoice]
+[deps."billing.tax".Invoice]
 sig  = "8c3f01"
 impl = "e9f3d2"
 ```
@@ -1259,11 +1319,11 @@ pub fn generate_invoice(order: Order) -> Invoice ! [TaxError] {
 }
 
 // src/api/handler.spore
-import billing/invoice
+import billing.invoice
 
 // Compiles fine — handler is transitively partial
 pub fn handle(req: Request) -> Response ! [ApiError] {
-    let inv = billing/invoice.generate_invoice(parse_order(req))
+    let inv = invoice.generate_invoice(parse_order(req))
     Response.ok(inv)
 }
 ```
@@ -1271,11 +1331,11 @@ pub fn handle(req: Request) -> Response ! [ApiError] {
 ```text
 $ sporec check
 
-[partial] billing/invoice.generate_invoice
+[partial] billing.invoice.generate_invoice
   holes: ?invoice_logic
 
-[partial] api/handler.handle
-  depends on partial: billing/invoice.generate_invoice
+[partial] api.handler.handle
+  depends on partial: billing.invoice.generate_invoice
 
 Build: success (2 partial functions)
 ```
@@ -1284,10 +1344,10 @@ Build: success (2 partial functions)
 
 ```text
 [error] alias chain detected at src/api/shortcuts.spore:3
-  api_gen → billing/shortcuts.gen → billing/invoice.generate_invoice
+  api_gen → billing.shortcuts.gen → billing.invoice.generate_invoice
   ─── aliases must point directly to original definitions
 
-  help: use `pub alias api_gen = billing/invoice.generate_invoice` instead
+  help: use `pub alias api_gen = billing.invoice.generate_invoice` instead
 ```
 
 ### Platform details
@@ -1632,7 +1692,7 @@ sporec --fixes src/
 sporec build && spore test
 
 # 6. If a dependency's signature changed, review and accept
-spore --permit billing/tax.calculate
+spore --permit billing.tax.calculate
 
 # 7. Audit before deployment
 spore audit --all
@@ -1728,7 +1788,7 @@ git push origin main --tags
 ### Readability and navigation
 
 - **File = module** eliminates the confusion of Rust's `mod`/`use` distinction or OCaml's separate `.mli` files. Opening a `.spore` file immediately tells you the module name — no `module` keyword needed.
-- **Slash-separated imports** (`import billing/invoice`) mirror the filesystem path, making navigation intuitive. Dot (`.`) is reserved for item selection (`import billing/invoice.{calculate, Invoice}`).
+- **Dot-separated imports** (`import billing.invoice`) use a uniform separator for both path segments and item access, avoiding the confusion of mixing `/` and `.`. The import path mirrors the module name directly.
 - **Import/alias separation** removes ambiguity: `import` always means module, `alias` always means item.
 - **Three visibility levels** are intuitive. The default is private; opt-in to exposure via `pub` or `pub(pkg)`.
 
@@ -1960,7 +2020,7 @@ The module system does not require wholesale adoption:
 
 1. **Hash truncation for display**: How many hex characters should be shown in human-facing output? 8? 16? Full 64? Should there be a configurable default?
 
-2. **Cross-package `pub(pkg)` boundaries in workspaces**: If two packages in a workspace share a `pub(pkg)` item, should the workspace boundary relax `pub(pkg)` semantics, or must items be promoted to `pub`?
+2. **~~Cross-package `pub(pkg)` boundaries in workspaces~~**: Resolved — `pub(pkg)` restricts visibility to the current package (member) only. Items must be promoted to `pub` for cross-member access.
 
 3. **Capability granularity**: The current design uses coarse-grained capability names (e.g., `FileRead`, `NetWrite`). Should fine-grained capabilities (e.g., `filesystem:read:/data`) be part of the language-level type system or remain a tooling concern in `spore.toml`?
 
@@ -1992,7 +2052,7 @@ capability     ::= UPPER_IDENT
 import_decl    ::= 'import' module_path ('as' IDENT)?
                   | 'import' module_path '.' '{' IDENT (',' IDENT)* '}'
 alias_decl     ::= visibility? 'alias' IDENT '=' qualified_item
-module_path    ::= IDENT ('/' IDENT)*
+module_path    ::= IDENT ('.' IDENT)*
 qualified_item ::= module_path '.' IDENT
 
 // Visibility

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -16,13 +16,13 @@ superseded_by: null
 
 # SEP-0008: Module & Package System
 
-> **Executive Summary**: Defines a content-addressed package system (SHA-256 over normalized source) with platform-as-package architecture, where platforms provide effect handlers via `foreign fn` declarations. Enforces visibility rules (pub/internal) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through capability isolation — downloaded packages declaring `uses [Compute]` provably cannot access IO.
+> **Executive Summary**: Defines a content-addressed package system (BLAKE3 dual-hash) with platform-as-package architecture, where platforms provide effect handlers via `foreign fn` declarations. Uses 1-file-=1-module mapping with slash-separated import paths (`import billing/invoice`), `spore.toml` for project configuration, and a two-layer capability ceiling (project + file level). Enforces visibility rules (pub/pub(pkg)/private) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through capability isolation — downloaded packages declaring `uses [Compute]` provably cannot access IO.
 
 ## Summary
 
-This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests, how dependencies are resolved without semantic versioning, how IO is abstracted through the Platform system using effect handlers, and how a capability-based trust model secures the supply chain.
+This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via slash-separated paths (`import billing/invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `spore.lock` for reproducible builds, how dependencies are resolved without semantic versioning, how IO is abstracted through the Platform system using effect handlers, and how a two-layer capability ceiling (project-wide in `spore.toml` + file-level `#![uses(...)]` pragma) secures the supply chain.
 
-The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as module-level capability ceilings, the import/alias separation, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
+The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Gleam (slash-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the two-layer capability ceiling, the import/alias separation, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
 
 ## Motivation
 
@@ -71,25 +71,25 @@ Every `.spore` file is exactly one module. The module name is derived from the f
 
 | File Path | Module Name |
 |---|---|
-| `src/billing/invoice.spore` | `billing.invoice` |
-| `src/auth/token.spore` | `auth.token` |
+| `src/billing/invoice.spore` | `billing/invoice` |
+| `src/auth/token.spore` | `auth/token` |
 | `src/utils.spore` | `utils` |
 | `src/main.spore` | `main` |
 
-There is no separate module declaration syntax—the filesystem **is** the declaration. An optional module header may declare the module's capability ceiling:
+There is no `module` keyword — the filesystem **is** the declaration. A file-level pragma may narrow the module's capability ceiling (see [Two-layer capability ceiling](#two-layer-capability-ceiling)):
 
 ```spore
 // src/billing/invoice.spore
-module billing.invoice uses [PaymentGateway, AuditLog]
+#![uses(PaymentGateway, AuditLog)]
 
-import billing.types
-import billing.tax
+import billing/types
+import billing/tax
 
 pub fn generate_invoice(order: Order) -> Invoice ! [TaxError, ValidationError]
     cost ≤ 3000
     uses [PaymentGateway, AuditLog]
 {
-    let tax = billing.tax.calculate(order.items, order.region)
+    let tax = billing/tax.calculate(order.items, order.region)
     let line_items = build_line_items(order.items, tax)
     finalize(order.customer, line_items)
 }
@@ -101,30 +101,34 @@ fn build_line_items(items: Vec<Item>, tax: TaxResult) -> Vec<LineItem>
 }
 ```
 
-If the `module` header is present, its declared name **must** match the file path (otherwise: compiler error). If omitted, the module name is inferred from the path.
+Module names use **slash-separated** paths derived from the filesystem. There is no explicit `module` declaration; the file path is the single source of truth.
 
 ### Imports
 
-Spore provides exactly two import mechanisms with no overlap:
+Spore uses **slash-separated** paths for module imports (Gleam-style) and **dot** for item selection:
 
 ```spore
 // Module import: makes all pub items accessible via qualified name
-import billing.invoice
+import billing/invoice
 
 // Module import with rename
-import billing.invoice as inv
+import billing/invoice as inv
+
+// Selective import: bring specific items into scope
+import billing/invoice.{calculate, Invoice}
 
 // Item alias: binds a specific function or type to a local name
-alias gen = billing.invoice.generate_invoice
-alias Inv = billing.types.Invoice
+alias gen = billing/invoice.generate_invoice
+alias Inv = billing/types.Invoice
 ```
 
 Key rules:
 
-- `import` operates on **modules** only. You cannot import a function directly.
-- `alias` operates on **items** only. You cannot alias a module.
-- No wildcard imports (`import billing.*` is not supported).
-- No implicit nested imports (`import billing` does not import `billing.invoice`).
+- `import` operates on **modules** only. Slash (`/`) separates path segments.
+- Selective imports use dot (`.`) then braces (`{...}`) to bring specific items into scope.
+- `alias` operates on **items** only. You cannot alias a module (use `import ... as` instead).
+- No wildcard imports (`import billing/*` is not supported).
+- No implicit nested imports (`import billing` does not import `billing/invoice`).
 
 ### Visibility
 
@@ -156,9 +160,9 @@ my-billing-lib/
 ├── spore.toml              // package manifest
 ├── src/
 │   ├── billing/
-│   │   ├── invoice.spore   -- module: billing.invoice
-│   │   ├── tax.spore       -- module: billing.tax
-│   │   └── types.spore     -- module: billing.types
+│   │   ├── invoice.spore   -- module: billing/invoice
+│   │   ├── tax.spore       -- module: billing/tax
+│   │   └── types.spore     -- module: billing/types
 │   └── utils.spore         -- module: utils
 └── test/
     └── billing/
@@ -204,7 +208,7 @@ The compiler maps `.spore` files to modules using the path relative to `src/`:
 ```text
 module_name = path.relative_to("src/")
                   .strip_extension(".spore")
-                  .replace("/", ".")
+                  // path separators become '/' in the module name
 ```
 
 Module name segments must be lowercase `snake_case`. Reserved names (`main`, `platform`, `test`) carry special semantics.
@@ -221,7 +225,7 @@ An empty `.spore` file is a valid module. It compiles successfully, exports noth
 ```text
 $ sporec check src/billing/future.spore
 
-[ok] billing.future
+[ok] billing/future
   exports: (none)
   capabilities: []
 ```
@@ -240,12 +244,12 @@ The compiler builds a directed acyclic graph (DAG) of module dependencies:
 $ sporec build --show-order
 
 Build order (topological):
-  1. billing.types       (0 dependencies)
-  2. billing.tax         (1 dependency: billing.types)
-  3. billing.invoice     (2 dependencies: billing.types, billing.tax)
-  4. billing.shortcuts   (3 dependencies: billing.types, billing.invoice, billing.tax)
-  5. api.handler         (2 dependencies: billing.invoice, billing.shortcuts)
-  6. main                (1 dependency: api.handler)
+  1. billing/types       (0 dependencies)
+  2. billing/tax         (1 dependency: billing/types)
+  3. billing/invoice     (2 dependencies: billing/types, billing/tax)
+  4. billing/shortcuts   (3 dependencies: billing/types, billing/invoice, billing/tax)
+  5. api/handler         (2 dependencies: billing/invoice, billing/shortcuts)
+  6. main                (1 dependency: api/handler)
 ```
 
 Diamond dependencies are permitted (they are not cycles). The `.spore-lock` ensures a single canonical version via matching `sig` and `impl` hashes.
@@ -258,8 +262,9 @@ Within a single module, functions may reference each other regardless of declara
 
 ```text
 import_decl    ::= 'import' module_path ('as' IDENT)?
+                  | 'import' module_path '.' '{' IDENT (',' IDENT)* '}'
 alias_decl     ::= visibility? 'alias' IDENT '=' qualified_item
-module_path    ::= IDENT ('.' IDENT)*
+module_path    ::= IDENT ('/' IDENT)*
 qualified_item ::= module_path '.' IDENT
 ```
 
@@ -269,20 +274,20 @@ The compiler does not enforce import order, but `sporec fmt` auto-sorts imports 
 
 ```spore
 // 1. Platform / standard library imports
-import std.collections
-import std.text
+import std/collections
+import std/text
 
 // 2. External package imports
-import http.client as http
-import json.parser as json
+import http/client as http
+import json/parser as json
 
 // 3. Internal package imports
-import billing.invoice
-import billing.types
+import billing/invoice
+import billing/types
 
 // 4. Aliases
-alias Invoice = billing.types.Invoice
-alias gen = billing.invoice.generate_invoice
+alias Invoice = billing/types.Invoice
+alias gen = billing/invoice.generate_invoice
 ```
 
 Within each group, imports are sorted alphabetically by module path.
@@ -354,11 +359,11 @@ The `.spore-lock` file records both hashes for all functions a module depends on
 ```toml
 # .spore-lock (auto-generated, do not edit)
 
-[deps.api.handler.generate_invoice]
+[deps."api/handler".generate_invoice]
 sig  = "a3f7c2"    # interface contract
 impl = "d8e1b4"    # exact implementation (None if partial)
 
-[deps.billing.invoice.calculate]
+[deps."billing/invoice".calculate]
 sig  = "d91e4b"
 impl = "b2c4a7"
 ```
@@ -372,16 +377,16 @@ When a signature changes, all downstream modules referencing the old `sig` are f
 ```text
 $ sporec check
 
-[warning] signature changed: billing.tax.calculate
+[warning] signature changed: billing/tax.calculate
   old sig: d91e4b
   new sig: 7a2f33
   change: added error type [RegionNotSupported]
 
   affected modules:
-    billing.invoice (depends on billing.tax.calculate sig=d91e4b)
-    api.handler     (depends on billing.tax.calculate sig=d91e4b)
+    billing/invoice (depends on billing/tax.calculate sig=d91e4b)
+    api/handler     (depends on billing/tax.calculate sig=d91e4b)
 
-  run `spore --permit billing.tax.calculate` to accept this change
+  run `spore --permit billing/tax.calculate` to accept this change
 ```
 
 The `spore --permit` command updates `sig` entries in `.spore-lock`. Implementation-only changes update `impl` automatically—no permit required. Batch acceptance is available via `spore --permit --all`.
@@ -412,9 +417,9 @@ pub type Invoice { id: InvoiceId, total: Money }       // public type
 pub(pkg) type ValidatedOrder { original: Order }        // package-internal type
 type InternalCache { entries: Map<String, CacheEntry> } // private type
 
-pub alias GenInv = billing.invoice.generate_invoice     // public alias
-pub(pkg) alias Validate = billing.invoice.validate      // package-internal alias
-alias Compute = billing.invoice.compute_totals          // private alias
+pub alias GenInv = billing/invoice.generate_invoice     // public alias
+pub(pkg) alias Validate = billing/invoice.validate      // package-internal alias
+alias Compute = billing/invoice.compute_totals          // private alias
 ```
 
 #### Visibility enforcement
@@ -423,8 +428,8 @@ Attempting to access a private item from another module:
 
 ```text
 [error] visibility violation at src/api/handler.spore:15
-  billing.invoice.compute_totals is private
-  ─── it is only visible within module billing.invoice
+  billing/invoice.compute_totals is private
+  ─── it is only visible within module billing/invoice
 
   help: add `pub` or `pub(pkg)` to its definition in src/billing/invoice.spore
 ```
@@ -433,7 +438,7 @@ Attempting to access a `pub(pkg)` item from an external package:
 
 ```text
 [error] visibility violation at src/handler.spore:8
-  billing.invoice.validate is pub(pkg)
+  billing/invoice.validate is pub(pkg)
   ─── it is only visible within the 'my-billing-lib' package
   ─── your module 'handler' is in the 'my-api' package
 ```
@@ -447,12 +452,12 @@ Holes inherit the visibility context of their enclosing function. A HoleReport i
   "hole": { "name": "payment_logic", "location": "src/api/handler.spore:15" },
   "candidates": [
     {
-      "function": "billing.invoice.generate_invoice",
+      "function": "billing/invoice.generate_invoice",
       "visibility": "pub",
       "accessible": true
     },
     {
-      "function": "billing.invoice.validate",
+      "function": "billing/invoice.validate",
       "visibility": "pub(pkg)",
       "accessible": true,
       "note": "same package"
@@ -460,9 +465,9 @@ Holes inherit the visibility context of their enclosing function. A HoleReport i
   ],
   "excluded": [
     {
-      "function": "billing.invoice.compute_totals",
+      "function": "billing/invoice.compute_totals",
       "visibility": "private",
-      "reason": "private to billing.invoice"
+      "reason": "private to billing/invoice"
     }
   ]
 }
@@ -476,11 +481,11 @@ The only re-export mechanism is `pub alias`:
 
 ```spore
 // src/billing/shortcuts.spore
-import billing.invoice
-import billing.types
+import billing/invoice
+import billing/types
 
-pub alias generate = billing.invoice.generate_invoice
-pub alias Invoice = billing.types.Invoice
+pub alias generate = billing/invoice.generate_invoice
+pub alias Invoice = billing/types.Invoice
 ```
 
 Alias chains are **forbidden**. A `pub alias` must point to an original definition, not to another alias. This prevents unbounded indirection and keeps the dependency graph simple for both human and agent analysis.
@@ -490,8 +495,8 @@ Alias chains are **forbidden**. A `pub alias` must point to an original definiti
 Module imports and aliases cannot shadow each other. An alias cannot conflict with an imported module name:
 
 ```spore
-import billing.invoice
-alias invoice = billing.types.Invoice    // ERROR: 'invoice' conflicts with module name
+import billing/invoice
+alias invoice = billing/types.Invoice    // ERROR: 'invoice' conflicts with module name
 ```
 
 ### Platform abstraction
@@ -614,9 +619,9 @@ Package: billing-lib
   required capabilities: [PaymentGateway, AuditLog]
 
   Module capability breakdown:
-    billing.invoice:  [PaymentGateway, AuditLog]
-    billing.tax:      []  (pure)
-    billing.types:    []  (pure)
+    billing/invoice:  [PaymentGateway, AuditLog]
+    billing/tax:      []  (pure)
+    billing/types:    []  (pure)
 
   ✓ No RawSyscall usage
   ✓ No undeclared capabilities
@@ -625,19 +630,61 @@ Package: billing-lib
 
 ### Module capabilities
 
-#### Capability ceiling
+#### Two-layer capability ceiling
 
-A module may declare the maximum set of capabilities its functions can use:
+Capabilities are constrained through a two-layer ceiling system:
+
+**Layer 1 — Project-wide ceiling (`spore.toml`):**
+
+```toml
+[capabilities]
+allowed = ["IO", "FileRead", "FileWrite", "Net", "PaymentGateway", "AuditLog"]
+```
+
+This defines the maximum set of capabilities available to **any** file in the project. No module can exceed this ceiling.
+
+**Layer 2 — File-level narrowing (`#![uses(...)]` pragma):**
+
+Individual files can narrow the project ceiling to declare the maximum capabilities their functions may use:
 
 ```spore
-module billing.invoice uses [PaymentGateway, AuditLog]
+// src/billing/invoice.spore
+#![uses(PaymentGateway, AuditLog)]
 ```
 
 - Any function in the module can use a subset of these capabilities.
 - No function can use capabilities **not** in this set.
+- The file-level pragma must be a **subset** of `spore.toml`'s `[capabilities] allowed`.
 - Private functions are also bound by the ceiling.
 
-If the `uses` declaration is omitted, the compiler **infers** the ceiling from the union of all `pub` functions' capabilities and emits an `[info]` diagnostic suggesting the explicit declaration. The `sporec --fixes` flag auto-applies the inferred declaration.
+**Example — two layers in action:**
+
+`spore.toml` allows `IO`, `FileRead`, `FileWrite`, `Net`, `PaymentGateway`, `AuditLog`. But `src/billing/invoice.spore` only needs payment and audit:
+
+```spore
+// src/billing/invoice.spore
+#![uses(PaymentGateway, AuditLog)]
+
+import billing/types
+import billing/tax
+
+pub fn generate_invoice(order: Order) -> Invoice ! [TaxError]
+    uses [PaymentGateway, AuditLog]
+{ ... }
+```
+
+Meanwhile, `src/net/client.spore` needs only network capabilities:
+
+```spore
+// src/net/client.spore
+#![uses(Net)]
+
+pub fn fetch(url: Url) -> Result[Bytes, NetError]
+    uses [Net]
+{ ... }
+```
+
+If the `#![uses(...)]` pragma is omitted, the compiler **infers** the ceiling from the union of all `pub` functions' capabilities and emits an `[info]` diagnostic suggesting the explicit declaration. The `sporec --fixes` flag auto-applies the inferred pragma.
 
 #### Capability propagation
 
@@ -648,7 +695,8 @@ Importing a module does **not** grant its capabilities. If you call a function t
 Private functions are **also** bound by the module's capability ceiling (if declared). However, they do **not** contribute to the inferred capability set:
 
 ```spore
-module billing.invoice uses [PaymentGateway, AuditLog]
+// src/billing/invoice.spore
+#![uses(PaymentGateway, AuditLog)]
 
 pub fn generate_invoice(order: Order) -> Invoice ! [TaxError]
     uses [PaymentGateway, AuditLog]
@@ -668,11 +716,11 @@ fn send_email(to: Email, body: String) -> Unit ! [SmtpError]
 ```text
 [error] capability ceiling violation at src/billing/invoice.spore:12
   function send_email uses [EmailService]
-  module billing.invoice allows [PaymentGateway, AuditLog]
+  module billing/invoice allows [PaymentGateway, AuditLog]
   ─── EmailService is not in the module's capability set
 
-  help: either add EmailService to the module declaration:
-          module billing.invoice uses [PaymentGateway, AuditLog, EmailService]
+  help: either add EmailService to the file-level pragma:
+          #![uses(PaymentGateway, AuditLog, EmailService)]
         or move this function to a module that allows EmailService
 ```
 
@@ -680,17 +728,17 @@ fn send_email(to: Email, body: String) -> Unit ! [SmtpError]
 
 **Ceiling violation**: The error shown above.
 
-**Auto-fix with `sporec --fixes`**: When a module omits its capability declaration, the compiler infers it:
+**Auto-fix with `sporec --fixes`**: When a module omits its capability pragma, the compiler infers it:
 
 ```text
 $ sporec check src/billing/invoice.spore
 
-[ok] billing.invoice
+[ok] billing/invoice
   exports: generate_invoice, void_invoice
 
   [info] inferred module capabilities: [PaymentGateway, AuditLog]
     ─── derived from union of pub function capabilities
-    ─── consider adding: module billing.invoice uses [PaymentGateway, AuditLog]
+    ─── consider adding: #![uses(PaymentGateway, AuditLog)]
 ```
 
 **Full workflow**:
@@ -701,7 +749,7 @@ sporec --fixes src/            # auto-apply all capability declarations
 sporec check src/              # clean: no more [info] suggestions
 ```
 
-The `--fixes` flag writes the inferred capability declaration as the first line of the module file.
+The `--fixes` flag writes the inferred capability pragma as the first line of the module file.
 
 ### Package management
 
@@ -718,7 +766,8 @@ authors = ["Alice <alice@example.com>"]
 spore-version = ">=0.5.0"
 
 [capabilities]
-requires = ["PaymentGateway", "AuditLog"]
+# Project-level capability ceiling — no file may exceed this set
+allowed = ["PaymentGateway", "AuditLog"]
 
 [dependencies]
 json-parser = {
@@ -735,6 +784,8 @@ test-framework = {
     impl = "1a2b3c4d5e6f7a8b"
 }
 ```
+
+Dependencies are declared **per-project** in `spore.toml`, not per-file. The `[capabilities] allowed` list defines the project-wide ceiling; individual files narrow it with `#![uses(...)]`.
 
 Package names are `kebab-case` and globally unique within a registry. Module paths within a package use `snake_case` segments.
 
@@ -779,12 +830,14 @@ Content hashes ensure integrity regardless of source. Community registries provi
 
 #### Capability-based trust model
 
-Packages declare required capabilities in `spore.toml`. Capabilities do **not** propagate automatically—the consuming package must explicitly grant them:
+Packages declare required capabilities in `spore.toml`. The `[capabilities] allowed` list defines the project-wide ceiling. Capabilities do **not** propagate automatically—the consuming package must explicitly grant them:
 
 ```toml
 [capabilities]
-require = ["network:listen:8080", "filesystem:read:/data"]
+# Project-level ceiling
+allowed = ["IO", "FileRead", "FileWrite", "Net"]
 
+# Fine-grained grants for dependencies (future direction)
 grant = [
     "http:network:listen:*",
     "logger:filesystem:write:/var/log"
@@ -1090,13 +1143,13 @@ $ sporec --holes
 
 Holes by module:
 
-  billing.invoice (partial)
+  billing/invoice (partial)
     ?invoice_logic at line 12
       type: Invoice ! [TaxError]
       capabilities: [PaymentGateway, AuditLog]
       budget remaining: 2400 ops
 
-  api.handler (partial — depends on partial billing.invoice)
+  api/handler (partial — depends on partial billing/invoice)
     (no direct holes, but transitively partial)
 ```
 
@@ -1105,9 +1158,9 @@ Holes by module:
 Cost is a per-function property (`cost ≤ N`). There are no module-level cost budgets. When a function calls an imported function, the callee's **declared** cost bound is used for estimation:
 
 ```text
-$ spore cost-report billing.invoice
+$ spore cost-report billing/invoice
 
-Module: billing.invoice
+Module: billing/invoice
 
   Function costs:
     generate_invoice    cost ≤ 3000  (measured: 2800)
@@ -1135,14 +1188,14 @@ Error types follow the same visibility rules as all other types. A function's er
 
 ```spore
 // src/api/handler.spore
-import billing.invoice
-import billing.errors
+import billing/invoice
+import billing/errors
 
-pub fn handle_create(req: Request) -> Response ! [billing.errors.BillingError, ParseError]
+pub fn handle_create(req: Request) -> Response ! [billing/errors.BillingError, ParseError]
     uses [PaymentGateway, AuditLog]
 {
     let order = parse_request(req)
-    let invoice = billing.invoice.generate_invoice(order)
+    let invoice = billing/invoice.generate_invoice(order)
     Response.ok(invoice)
 }
 ```
@@ -1163,7 +1216,7 @@ pub type LineItem { description: String, quantity: Int, unit_price: Money }
 ```text
 $ sporec check src/billing/types.spore
 
-[ok] billing.types
+[ok] billing/types
   exports: Invoice, InvoiceStatus, LineItem
   capabilities: []
   cost: 0 (types only)
@@ -1174,23 +1227,23 @@ $ sporec check src/billing/types.spore
 Diamond dependencies use consistent hashes:
 
 ```text
-       billing.types
+       billing/types
         ↑        ↑
         │        │
-  billing.invoice  billing.tax
+  billing/invoice  billing/tax
         ↑        ↑
         │        │
-       api.handler
+       api/handler
 ```
 
-The `.spore-lock` records the same `sig` and `impl` for `billing.types.Invoice` regardless of which path reached it:
+The `.spore-lock` records the same `sig` and `impl` for `billing/types.Invoice` regardless of which path reached it:
 
 ```toml
-[deps.billing.invoice.Invoice]
+[deps."billing/invoice".Invoice]
 sig  = "8c3f01"
 impl = "e9f3d2"
 
-[deps.billing.tax.Invoice]
+[deps."billing/tax".Invoice]
 sig  = "8c3f01"
 impl = "e9f3d2"
 ```
@@ -1206,11 +1259,11 @@ pub fn generate_invoice(order: Order) -> Invoice ! [TaxError] {
 }
 
 // src/api/handler.spore
-import billing.invoice
+import billing/invoice
 
 // Compiles fine — handler is transitively partial
 pub fn handle(req: Request) -> Response ! [ApiError] {
-    let inv = billing.invoice.generate_invoice(parse_order(req))
+    let inv = billing/invoice.generate_invoice(parse_order(req))
     Response.ok(inv)
 }
 ```
@@ -1218,11 +1271,11 @@ pub fn handle(req: Request) -> Response ! [ApiError] {
 ```text
 $ sporec check
 
-[partial] billing.invoice.generate_invoice
+[partial] billing/invoice.generate_invoice
   holes: ?invoice_logic
 
-[partial] api.handler.handle
-  depends on partial: billing.invoice.generate_invoice
+[partial] api/handler.handle
+  depends on partial: billing/invoice.generate_invoice
 
 Build: success (2 partial functions)
 ```
@@ -1231,10 +1284,10 @@ Build: success (2 partial functions)
 
 ```text
 [error] alias chain detected at src/api/shortcuts.spore:3
-  api_gen → billing.shortcuts.gen → billing.invoice.generate_invoice
+  api_gen → billing/shortcuts.gen → billing/invoice.generate_invoice
   ─── aliases must point directly to original definitions
 
-  help: use `pub alias api_gen = billing.invoice.generate_invoice` instead
+  help: use `pub alias api_gen = billing/invoice.generate_invoice` instead
 ```
 
 ### Platform details
@@ -1579,7 +1632,7 @@ sporec --fixes src/
 sporec build && spore test
 
 # 6. If a dependency's signature changed, review and accept
-spore --permit billing.tax.calculate
+spore --permit billing/tax.calculate
 
 # 7. Audit before deployment
 spore audit --all
@@ -1674,7 +1727,8 @@ git push origin main --tags
 
 ### Readability and navigation
 
-- **File = module** eliminates the confusion of Rust's `mod`/`use` distinction or OCaml's separate `.mli` files. Opening a `.spore` file immediately tells you the module name.
+- **File = module** eliminates the confusion of Rust's `mod`/`use` distinction or OCaml's separate `.mli` files. Opening a `.spore` file immediately tells you the module name — no `module` keyword needed.
+- **Slash-separated imports** (`import billing/invoice`) mirror the filesystem path, making navigation intuitive. Dot (`.`) is reserved for item selection (`import billing/invoice.{calculate, Invoice}`).
 - **Import/alias separation** removes ambiguity: `import` always means module, `alias` always means item.
 - **Three visibility levels** are intuitive. The default is private; opt-in to exposure via `pub` or `pub(pkg)`.
 
@@ -1898,7 +1952,7 @@ New fields added to `.spore-lock` are ignored by older tools (forward-compatible
 
 The module system does not require wholesale adoption:
 
-- Packages can start with inferred capabilities (no `module` header) and add explicit declarations later via `sporec --fixes`.
+- Packages can start with inferred capabilities (no `#![uses(...)]` pragma) and add explicit declarations later via `sporec --fixes`.
 - Dependencies can mix Git, local path, and registry sources.
 - The `version` field in `spore.toml` remains available for human communication during the transition from semver.
 
@@ -1929,15 +1983,16 @@ The module system does not require wholesale adoption:
 ## Appendix A: Grammar summary
 
 ```text
-// Module header
-module_header  ::= 'module' module_path ('uses' cap_list)?
+// File-level capability pragma (replaces module header)
+file_pragma    ::= '#![uses(' capability (',' capability)* ')]'
 cap_list       ::= '[' capability (',' capability)* ']'
 capability     ::= UPPER_IDENT
 
 // Imports and aliases
 import_decl    ::= 'import' module_path ('as' IDENT)?
+                  | 'import' module_path '.' '{' IDENT (',' IDENT)* '}'
 alias_decl     ::= visibility? 'alias' IDENT '=' qualified_item
-module_path    ::= IDENT ('.' IDENT)*
+module_path    ::= IDENT ('/' IDENT)*
 qualified_item ::= module_path '.' IDENT
 
 // Visibility
@@ -1977,7 +2032,7 @@ effect_fn      ::= 'fn' IDENT '(' params ')' '->' type
 
 // spore.toml (TOML subset)
 // [package]       name, version, type, description, license, authors, spore-version
-// [capabilities]  require, grant, descriptions
+// [capabilities]  allowed
 // [dependencies]  <name> = { git|path|alias, sig, impl?, optional?, branch?, tag?, rev? }
 // [dev-dependencies]
 // [features]      <name> = [deps/features]


### PR DESCRIPTION
## Proposal summary

- Redesign module system: 1 file = 1 module, slash-separated import paths
- Add spore.toml + spore.lock project configuration  
- Two-layer capability ceiling (project + file level)
- Document CLI implementation stack for self-hosting path

## Linked discussion

Design decisions made in collaboration session — see SEP-0008 and SEP-0006 threads.

## Pre-submission checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.

## Proposal checklist

- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

Major changes to SEP-0008 module syntax and SEP-0006 CLI stack.