### PR TITLE
📝 SEP keyword redesign: trait/effect/handler split

### DIFF
--- a/seps-index.json
+++ b/seps-index.json
@@ -51,7 +51,7 @@
     {
       "path": "seps/SEP-0003-effect-capability-system.md",
       "sep": 3,
-      "title": "SEP-0003: Effect & Capability System",
+      "title": "SEP-0003: Effect System",
       "status": "Draft",
       "type": "Standards Track",
       "authors": [

--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -14,11 +14,11 @@ superseded_by: null
 
 # SEP-0001: Core Syntax & Signatures
 
-> **Executive Summary**: Defines Spore's core syntax as an expressions-only language with no statements or loops — all iteration uses recursion and higher-order functions (map/fold/filter/each). Introduces unified function signatures with a fixed clause order (return → errors → where → cost → uses → body), pattern matching as the primary control flow, and a clean separation between pure computation and effectful operations.
+> **Executive Summary**: Defines Spore's core syntax as an expressions-only language with no statements or loops — all iteration uses recursion and higher-order functions (map/fold/filter/each). Introduces unified function signatures with a fixed clause order (return → errors → where → cost → uses → body), pattern matching as the primary control flow, and a clean separation between pure computation and effectful operations. Traits define type interfaces while effects track external operations; the compiler infers purity and determinism from the declared effect set.
 
 ## Summary
 
-This proposal defines the complete core syntax and function signature system for the Spore programming language v0.1. Spore is an expression-based, statically typed language with capability-based security, explicit resource cost tracking, and guaranteed tail-call optimization. The language draws from Rust, OCaml, Roc, Gleam, and Elm, combining curly-brace block scoping with Rust-style semicolon semantics, algebraic data types, exhaustive pattern matching, and a novel function signature system that encodes generic constraints (`where`), capability requirements (`uses`), error sets (`!`), and cost bounds (`cost`) as composable clauses. Spore deliberately eliminates loops in favor of recursion and higher-order functions, uses square brackets for generics (`List[Int]`), auto-infers effect properties from the `uses` set, and provides a pipe operator (`|>`) for readable data-flow composition.
+This proposal defines the complete core syntax and function signature system for the Spore programming language v0.1. Spore is an expression-based, statically typed language with effect tracking, explicit resource cost tracking, and guaranteed tail-call optimization. The language draws from Rust, OCaml, Roc, Gleam, and Elm, combining curly-brace block scoping with Rust-style semicolon semantics, algebraic data types, exhaustive pattern matching, and a novel function signature system that encodes generic constraints (`where`), effect requirements (`uses`), error sets (`!`), and cost bounds (`cost`) as composable clauses. Spore deliberately eliminates loops in favor of recursion and higher-order functions, uses square brackets for generics (`List[Int]`), auto-infers effect properties from the `uses` set, and provides a pipe operator (`|>`) for readable data-flow composition.
 
 ## Motivation
 
@@ -30,7 +30,7 @@ Spore aims to occupy a unique design point:
 
 2. **Agent-friendly structure**: A fixed operator set (no custom operators), regular grammar, and explicit function metadata (`uses`, `cost`, `where`) make Spore code trivially parseable by AI agents and static analysis tools. Every function signature is a structured contract.
 
-3. **Capability safety by default**: Rather than bolting on an effect system after the fact, Spore makes capability requirements a first-class part of function signatures. The compiler infers properties like `pure` and `deterministic` from the declared `uses` set, eliminating manual annotation burden while maintaining full transparency.
+3. **Effect safety by default**: Rather than bolting on an effect system after the fact, Spore makes effect requirements a first-class part of function signatures. The compiler infers properties like `pure` and `deterministic` from the declared `uses` set, eliminating manual annotation burden while maintaining full transparency.
 
 4. **No loops — recursion with TCO guarantee**: By removing `for`, `while`, `loop`, `break`, and `continue`, Spore encourages a purely functional iteration style via recursion and higher-order functions (`map`, `fold`, `filter`). The compiler guarantees tail-call optimization, making recursion safe and efficient.
 
@@ -52,7 +52,7 @@ fn add(a: Int, b: Int) -> Int {
 }
 ```
 
-Note: no `return` keyword is needed. The last expression in a block is its value. The compiler automatically infers that this function is `pure`, `deterministic`, and `total` because it uses no capabilities.
+Note: no `return` keyword is needed. The last expression in a block is its value. The compiler automatically infers that this function is `pure`, `deterministic`, and `total` because it uses no effects.
 
 ### Variables and immutability
 
@@ -71,7 +71,7 @@ let x = 10;
 let x = x + 5;  // shadows the previous x
 ```
 
-For mutable state, use `Ref[T]` (which requires the `StateWrite` capability):
+For mutable state, use `Ref[T]` (which requires the `StateWrite` effect):
 
 ```spore
 let counter = Ref.new(0);
@@ -263,7 +263,7 @@ fn load_config(path: String) -> Config ! [ConfigError] {
 }
 ```
 
-The compiler looks for a `From` capability implementation (e.g., `impl From[FileError] for ConfigError`) to perform the conversion. If no conversion exists, the error type must be listed in the function's error set directly.
+The compiler looks for a `From` trait implementation (e.g., `impl From[FileError] for ConfigError`) to perform the conversion. If no conversion exists, the error type must be listed in the function's error set directly.
 
 #### Error recovery patterns
 
@@ -324,7 +324,7 @@ The full signature order is:
 ```text
 fn name[T](params) -> ReturnType ! [ErrorSet]
 where T: Bound
-uses [capabilities]
+uses [effects]
 cost ≤ N
 {
     body
@@ -363,24 +363,31 @@ cost ≤ 8500
 }
 ```
 
-### Capabilities and the `uses` clause
+### Traits, effects, and the `uses` clause
 
-Capabilities are Spore's unified trait/interface/effect mechanism:
+Spore separates type interfaces from effect tracking:
 
 ```spore
-capability Display {
-    fn to_string(self) -> String;
+// trait: type interface
+trait Display {
+    fn show(self) -> Str
 }
 
-capability Serialize {
-    fn serialize(self) -> String ! [SerializeError];
+trait Serialize {
+    fn serialize(self) -> Bytes ! [SerializeError]
 }
 
-// Custom composite capabilities
-capability DatabaseAccess = [NetRead, NetWrite, StateRead, StateWrite];
+// effect: external world operations
+effect Console {
+    fn println(msg: Str) -> Unit
+    fn read_line() -> Str ! IOError
+}
+
+// effect alias (uses | for union)
+effect DatabaseAccess = NetRead | NetWrite | StateRead | StateWrite
 ```
 
-The `uses` clause declares what capabilities a function requires. The compiler **auto-infers** effect properties from this set:
+The `uses` clause declares what effects a function requires. The compiler **auto-infers** effect properties from this set:
 
 | `uses` set | Inferred properties |
 |---|---|
@@ -390,7 +397,7 @@ The `uses` clause declares what capabilities a function requires. The compiler *
 
 The `idempotent` property cannot be inferred and is annotated via doc comment: `/// @idempotent`.
 
-The `uses` clause can mix capability names with specific resource instance bindings:
+The `uses` clause can mix effect names with specific resource instance bindings:
 
 ```spore
 fn query_database(sql: String) -> Data ! [DbError]
@@ -597,23 +604,25 @@ The complete reserved keyword table:
 | `match` | Pattern matching expression |
 | `struct` | Struct type definition |
 | `type` | Type alias / sum type definition |
-| `capability` | Capability (trait) definition |
+| `trait` | Type interface definition (trait) |
+| `effect` | Effect definition / effect alias |
+| `handler` | Effect handler implementation |
 | `impl` | Trait implementation block |
 | `pub` / `pub(pkg)` | Visibility modifiers (public / package-visible) |
 | `module` | Module definition |
 | `import` | Module import |
-| `alias` | Type or item alias |
+| `alias` | Type alias |
 | `where` | Generic type constraints |
-| `uses` | Capability requirement declaration |
+| `uses` | Effect requirement declaration |
 | `cost` | Cost bound clause |
-| `effects` | Effect declaration (reserved for future use) |
 | `spawn` | Spawn concurrent task |
 | `select` | Channel multiplex expression |
 | `parallel_scope` | Structured concurrency scope |
 | `const` | Compile-time constant definition |
 | `return` | Early return from function |
 | `throw` | Throw an error value |
-| `trait` | Reserved (use `capability`) |
+| `handle` | Bind effect handler expression |
+| `with` | Handler binding (with handle) |
 | `implements` | Reserved (use `impl ... for ...`) |
 | `as` | Rename in imports |
 | `in` | Reserved |
@@ -622,7 +631,7 @@ The complete reserved keyword table:
 | `async` / `await` | Async task operations |
 | `move` | Reserved |
 | `ref` | Reserved |
-| `self` | Current instance in capability methods (regular identifier) |
+| `self` | Current instance in trait/handler methods (regular identifier) |
 | `super` | Parent module reference |
 | `crate` | Crate root reference |
 | `enum` | Reserved (use `type` with variants) |
@@ -739,7 +748,7 @@ t"Dear {customer}, order {id}"    // template string
 | Convention | Used for | Examples |
 |---|---|---|
 | `snake_case` | Variables, functions, modules | `user_name`, `calculate_total`, `http_client` |
-| `PascalCase` | Types, capabilities, enum variants | `UserAccount`, `Serialize`, `Some` |
+| `PascalCase` | Types, traits, effects, enum variants | `UserAccount`, `Serialize`, `Some` |
 | `SCREAMING_SNAKE_CASE` | Constants | `MAX_BUFFER_SIZE`, `PI` |
 
 ### EBNF Grammar
@@ -758,7 +767,9 @@ TopLevelItem    = ImportDecl
                 | ModuleDecl
                 | StructDecl
                 | TypeDecl
-                | CapabilityDecl
+                | TraitDecl
+                | EffectDecl
+                | HandlerDecl
                 | ImplDecl
                 | ConstDecl
                 | FunctionDecl ;
@@ -799,18 +810,32 @@ VariantList     = [ "|" ] Variant { "|" Variant } ;
 Variant         = Ident [ "(" FieldList ")" ]
                 | Ident [ "(" TypeList ")" ] ;
 
-(* ─── Capability ──────────────────────────────────── *)
+(* ─── Trait ────────────────────────────────────────── *)
 
-CapabilityDecl  = [ Visibility ] "capability" Ident [ TypeParams ]
-                  ( CapabilityBlock | "=" "[" CapabilityList "]" ";" ) ;
+TraitDecl       = [ Visibility ] "trait" Ident [ TypeParams ]
+                  [ ":" BoundList ]
+                  "{" { TraitItem } "}" ;
 
-CapabilityBlock = "{" { CapabilityItem } "}" ;
-CapabilityItem  = AssocType
+TraitItem       = AssocType
                 | FunctionDecl ;              (* may have default body *)
 
 AssocType       = "type" Ident ";" ;
 
-CapabilityList  = Ident { "," Ident } ;
+(* ─── Effect ──────────────────────────────────────── *)
+
+EffectDecl      = [ Visibility ] "effect" Ident [ TypeParams ]
+                  ( EffectBlock | "=" EffectAlias ";" ) ;
+
+EffectBlock     = "{" { FunctionDecl } "}" ;
+
+EffectAlias     = Ident { "|" Ident } ;
+
+(* ─── Handler ─────────────────────────────────────── *)
+
+HandlerDecl     = "handler" Ident [ "(" ParamList ")" ] "for" Ident
+                  "{" { FunctionDecl } "}" ;
+
+HandleExpr      = "handle" Expr "with" Expr ;
 
 (* ─── Impl (Trait Implementation) ─────────────────── *)
 
@@ -848,7 +873,8 @@ ErrorClause     = "!" "[" TypeList "]" ;
 WhereClause     = { "where" Ident ":" BoundList } ;
 BoundList       = Ident { "+" Ident } ;
 
-UsesClause      = "uses" "[" [ CapabilityList ] "]" ;
+UsesClause      = "uses" "[" [ EffectList ] "]" ;
+EffectList      = Ident { "," Ident } ;
 
 CostClause      = "cost" "≤" CostExpr ;
 CostExpr        = IntLiteral
@@ -862,7 +888,7 @@ CostExpr        = IntLiteral
 TypeExpr        = Ident [ "[" TypeList "]" ]           (* named type, optionally generic *)
                 | "fn" "(" [ TypeList ] ")" "->" TypeExpr  (* function type *)
                 | "(" TypeList ")"                      (* tuple type *)
-                | "Self"                                (* self type in capabilities *)
+                | "Self"                                (* self type in traits/handlers *)
                 | "?" ;                                 (* type hole *)
 
 TypeList        = TypeExpr { "," TypeExpr } [ "," ] ;
@@ -880,6 +906,7 @@ Expr            = LetExpr
                 | SpawnExpr
                 | SelectExpr
                 | ParallelScopeExpr
+                | HandleExpr
                 | PipeExpr ;
 
 PipeExpr        = OrExpr { "|>" OrExpr } ;
@@ -1041,7 +1068,7 @@ The function signature system is the heart of Spore's design. The clauses appear
 ```text
 fn <name>[<generics>](<params>) -> <ReturnType> [! [<ErrorTypes>]]
 [where <GenericName>: <Constraint>, ...]
-[uses [<Capability>, ...]]
+[uses [<Effect>, ...]]
 [cost ≤ <N>]
 {
     <body>
@@ -1056,7 +1083,7 @@ fn <name>[<generics>](<params>) -> <ReturnType> [! [<ErrorTypes>]]
 
 3. **`where T: Bound`** — Generic constraints. Multiple bounds use `+` syntax: `where T: Eq + Hash`. Each `where` clause is on its own line.
 
-4. **`uses [Capabilities]`** — The capability set required by this function. The compiler auto-infers effect properties:
+4. **`uses [Effects]`** — The effect set required by this function. The compiler auto-infers effect properties:
    - `uses []` → `pure`, `deterministic`, `total`
    - `uses [Compute]` → `deterministic`
    - If `uses` contains `Random` or `Clock` → not deterministic
@@ -1068,14 +1095,14 @@ fn <name>[<generics>](<params>) -> <ReturnType> [! [<ErrorTypes>]]
 
 **Clause ordering** is not enforced by the grammar but is enforced by the formatter: `where` → `uses` → `cost`.
 
-**`self` in capability methods:** The `self` identifier is a regular parameter name used as the first parameter in capability method signatures. It is not a keyword with special scoping rules.
+**`self` in trait and handler methods:** The `self` identifier is a regular parameter name used as the first parameter in trait method signatures. It is not a keyword with special scoping rules.
 
 ```spore
-capability Display {
+trait Display {
     fn to_string(self) -> String;
 }
 
-capability Collection {
+trait Collection {
     type Item;
     fn len(self) -> Int;
     fn is_empty(self) -> Bool {
@@ -1213,7 +1240,7 @@ When queried (`sporec --query-hole ?name`), the compiler emits a structured repo
     "amount": "Money",
     "method": "PaymentMethod"
   },
-  "available_capabilities": ["NetRead"],
+  "available_effects": ["NetRead"],
   "candidate_functions": [
     "payment_gateway.charge(amount: Money, method: PaymentMethod) -> Receipt ! [Declined, InsufficientFunds]"
   ],
@@ -1404,7 +1431,7 @@ Spore's syntax prioritizes scannability. The fixed operator set means readers ne
 
 ### Progressive disclosure
 
-Simple functions require zero ceremony — `fn add(a: Int, b: Int) -> Int { a + b }` has no clauses to learn. Capabilities, error sets, and cost bounds are introduced only when the code actually needs them.
+Simple functions require zero ceremony — `fn add(a: Int, b: Int) -> Int { a + b }` has no clauses to learn. Effects, error sets, and cost bounds are introduced only when the code actually needs them.
 
 ## Agent experience impact
 
@@ -1428,10 +1455,10 @@ Function signatures are machine-readable contracts. An agent can extract:
 
 This enables agents to:
 
-1. Select appropriate functions by matching capability requirements
+1. Select appropriate functions by matching effect requirements
 2. Estimate execution cost before generating call sequences
 3. Verify error handling completeness
-4. Compose pipelines with compatible capability sets
+4. Compose pipelines with compatible effect sets
 
 ### Code generation
 
@@ -1450,7 +1477,7 @@ Any change to the following signature components produces a new snapshot hash an
 | Return type | `Config` → `Settings` |
 | Error type set | add/remove any error type |
 | Cost bound | `≤ 200` → `≤ 300` |
-| Capability set | add/remove any capability |
+| Effect set | add/remove any effect |
 | Generic constraints | `T: Eq` → `T: Eq + Hash` |
 
 ## Structured representation / protocol impact
@@ -1464,9 +1491,11 @@ Program
 ├── ImportDecl { path, alias? }
 ├── ModuleDecl { name, uses, items[] }
 ├── StructDecl { name, type_params[], fields[] }
-├── ImplDecl { capability, type_params[], target_type, methods[] }
+├── ImplDecl { trait, type_params[], target_type, methods[] }
 ├── TypeDecl { name, type_params[], body: TypeAlias | SumType | Refinement }
-├── CapabilityDecl { name, type_params[], items[] }
+├── TraitDecl { name, type_params[], items[] }
+├── EffectDecl { name, type_params[], operations[] }
+├── HandlerDecl { name, effect, methods[] }
 ├── ConstDecl { name, type, value }
 └── FunctionDecl
     ├── name
@@ -1510,8 +1539,8 @@ The regular, keyword-delimited syntax supports straightforward LSP provider impl
 
 - **Go to definition**: Every identifier resolves unambiguously through module paths and lexical scoping.
 - **Hover information**: Function signatures (including `uses`, `cost`, inferred properties) can be displayed in full.
-- **Completions**: After `|>`, suggest functions whose first parameter matches the pipe source type. Inside `uses [...]`, suggest available capabilities.
-- **Diagnostics**: Missing match arms, undeclared capabilities, cost violations, and incomplete error handling can all be reported as structured diagnostics.
+- **Completions**: After `|>`, suggest functions whose first parameter matches the pipe source type. Inside `uses [...]`, suggest available effects.
+- **Diagnostics**: Missing match arms, undeclared effects, cost violations, and incomplete error handling can all be reported as structured diagnostics.
 - **Signature help**: The ordered clause structure (`where` → `uses` → `cost`) enables progressive parameter info display.
 
 ### Serialization
@@ -1524,17 +1553,17 @@ The AST serializes naturally to JSON, S-expressions, or any tree-structured form
 
 Spore's explicit syntax enables highly specific error messages:
 
-**Missing capability:**
+**Missing effect:**
 
 ```text
-error[E0301]: function `fetch_data` uses capability `NetRead` but does not declare it
+error[E0301]: function `fetch_data` uses effect `NetRead` but does not declare it
   --> src/api.spore:12:5
    |
 12 | fn fetch_data(url: Url) -> Data ! [NetworkError] {
    |    ^^^^^^^^^^ missing `uses` clause
    |
    = help: add `uses [NetRead]` to the function signature
-   = note: detected capability dependency via call to `http.get`
+   = note: detected effect dependency via call to `http.get`
 ```
 
 **Non-exhaustive match:**
@@ -1635,7 +1664,7 @@ Rejected in favor of the `?` operator and `|>` pipes because:
 
 The original design used Roc-style inline `implements [...]` on struct declarations. This was replaced by Rust-style `impl Trait for Type { ... }` blocks because:
 
-- Separate `impl` blocks allow implementing third-party capabilities for existing types.
+- Separate `impl` blocks allow implementing third-party traits for existing types.
 - Multiple implementations are visually distinct rather than packed into a single line.
 - It aligns with the Rust mental model that most Spore users already know.
 - The `implements` keyword is reserved for potential future use.
@@ -1658,7 +1687,7 @@ Departed from: Spore removes lifetime annotations, borrowing semantics, `mut` ke
 
 ### Roc
 
-Influence on: expression-based design, capabilities as the unified trait mechanism, no-loop philosophy, the idea of making side effects visible in signatures.
+Influence on: expression-based design, the trait/effect split design, no-loop philosophy, the idea of making side effects visible in signatures.
 
 ### Gleam
 
@@ -1674,7 +1703,7 @@ Influence on: algebraic data types with `|` variant syntax, pattern matching wit
 
 ### Haskell
 
-Influence on: type classes (→ capabilities), purity by default, the idea of tracking effects in types, `where` clause syntax for constraints.
+Influence on: type classes (→ traits), purity by default, the idea of tracking effects in types, `where` clause syntax for constraints.
 
 ### TypeScript / Python
 
@@ -1704,7 +1733,7 @@ As this is the initial v0.1 specification, there are no backward compatibility c
 
 1. **Exact cost model semantics**: What units does `cost` measure? CPU cycles? Abstract "work units"? How does the compiler verify cost bounds, especially for recursive functions?
 
-2. **Capability composition rules**: When a function calls two sub-functions with different `uses` sets, is the resulting set the union? How are capability aliases expanded for comparison?
+2. **Effect composition rules**: When a function calls two sub-functions with different `uses` sets, is the resulting set the union? How are effect aliases expanded for comparison?
 
 3. **Refinement type checking**: How deeply does the compiler verify refinement predicates (`type Positive = Int if |n| n > 0`)? Is this compile-time only, or does it generate runtime checks?
 
@@ -1714,7 +1743,7 @@ As this is the initial v0.1 specification, there are no backward compatibility c
 
 6. **`self` method dispatch**: How does the compiler resolve method calls on `self` — is it static dispatch (monomorphized) or dynamic dispatch (vtable)? This affects performance characteristics.
 
-7. **Format string security**: What sanitization, if any, applies to `f"..."` expressions to prevent injection attacks? How do `t"..."` template objects interact with the capability system?
+7. **Format string security**: What sanitization, if any, applies to `f"..."` expressions to prevent injection attacks? How do `t"..."` template objects interact with the effect system?
 
 8. **Tail-call optimization scope**: Is TCO guaranteed only for direct self-recursion, or for mutual recursion and continuation-passing style as well?
 
@@ -1722,7 +1751,7 @@ As this is the initial v0.1 specification, there are no backward compatibility c
 
 10. **Pattern matching on strings**: The current spec shows string literal patterns. Should Spore support regex patterns or prefix/suffix matching in `match` arms?
 
-11. **Standard capability taxonomy**: What is the canonical set of built-in capabilities (`Compute`, `NetRead`, `NetWrite`, `FileRead`, `FileWrite`, `StateRead`, `StateWrite`, `Clock`, `Random`, etc.)? This needs a separate SEP.
+11. **Standard effect taxonomy**: What is the canonical set of built-in effects (`Compute`, `NetRead`, `NetWrite`, `FileRead`, `FileWrite`, `StateRead`, `StateWrite`, `Clock`, `Random`, etc.)? This needs a separate SEP.
 
 12. **Error type subtyping**: If function `f` declares `! [NetworkError]` and function `g` declares `! [NetworkError, ParseError]`, can `g` call `f` directly? How does error set subtyping work?
 
@@ -1736,7 +1765,7 @@ This appendix formalizes the evaluation rules for core Spore expressions using s
 - `v` — a value (fully evaluated: literal, closure, struct/enum instance, list)
 - `E[·]` — evaluation context (position where the next reduction occurs)
 - `σ` — runtime environment (variable → value mapping)
-- `H` — effect handler table (capability → handler mapping)
+- `H` — effect handler table (effect → handler mapping)
 - `e[x ↦ v]` — substitute `v` for `x` in `e`
 
 ### Values
@@ -1969,7 +1998,7 @@ Pattern matching sub-rules:
 
 ```text
 [E-ForeignCall]
-  H(capability, fn_name) = handler
+  H(effect, fn_name) = handler
   handler(v₁, ..., vₙ) ↝ᵢₒ v
   ──────────────────────────────────
   foreign_fn(v₁, ..., vₙ) ↝ v
@@ -2036,4 +2065,4 @@ In PoC, this is a no-op since spawn already evaluated.)
 
 3. **Progress**: If `Γ; S ⊢ e : T` and `e` is not a value, then either `e ↝ e'` for some `e'`, or `e` is a `foreign fn` call awaiting I/O. (Holes are ruled out at type-check time in complete programs.)
 
-4. **Capability soundness**: If a function has `uses []` (no capabilities), its evaluation never reaches an `[E-ForeignCall]` rule. (By the capability subset check in SEP-0003.)
+4. **Effect soundness**: If a function has `uses []` (no effects), its evaluation never reaches an `[E-ForeignCall]` rule. (By the effect subset check in SEP-0003.)

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -15,7 +15,7 @@ superseded_by: null
 
 # SEP-0002: Type System
 
-> **Executive Summary**: Defines Spore's nominal-primary type system with bidirectional inference, unifying capabilities as traits on execution context. Features three-tier refinement types (L0 decidable constraints → L1 abstract-interpretation → L2 proof obligations), 13 compiler-known traits, generics with where-clause bounds, and enum/struct/capability as the core type constructors. Includes formal typing judgments for the core language.
+> **Executive Summary**: Defines Spore's nominal-primary type system with bidirectional inference, separating traits (type interfaces) from effects (external operations). Features three-tier refinement types (L0 decidable constraints → L1 abstract-interpretation → L2 proof obligations), 13 compiler-known traits, generics with where-clause bounds, and enum/struct/trait/effect as the core type constructors. Includes formal typing judgments for the core language.
 
 ## Summary
 
@@ -51,7 +51,7 @@ Key design decisions:
 Spore is being co-developed by humans and AI Agents. Both audiences need precise, unambiguous rules for:
 
 1. **What programs are well-typed.** Agents generate code that must type-check. Vague rules produce vague code.
-2. **What information flows through signatures.** Signatures are the primary communication channel between components, between humans and Agents, and between Agents. They must encode types, capabilities, cost bounds, and error sets.
+2. **What information flows through signatures.** Signatures are the primary communication channel between components, between humans and Agents, and between Agents. They must encode types, effects, cost bounds, and error sets.
 3. **What the compiler guarantees.** Typed holes, structured diagnostics, and fill-suggestions all depend on a well-defined type lattice.
 4. **Where inference ends and annotation begins.** Signatures explicit, bodies inferred — but the boundary must be razor-sharp.
 
@@ -69,8 +69,8 @@ Without a specification:
 | Principle | Implication |
 |---|---|
 | **Signatures are gravity centers** | Signatures must be richly typed and explicit; bodies are inferred |
-| **Nominal-primary, structural escape** | Named types are nominal; anonymous records are structural; capabilities are always nominal |
-| **Capabilities = Traits** | Unified abstraction — `capability` is syntactic sugar for a trait on execution context |
+| **Nominal-primary, structural escape** | Named types are nominal; anonymous records are structural; traits and effects are always nominal |
+| **Traits ≠ Effects** | Separate abstractions — `trait` defines type interfaces, `effect` defines external operations; they are not unified |
 | **Decidable checking** | No SMT solver; refinements limited to decidable predicates and abstract interpretation |
 | **Agent-friendly** | Richer types help Agents more than they hurt humans; Agents absorb annotation complexity |
 | **Predictable** | No implicit conversions, no type-level computation, no SFINAE-style surprises |
@@ -112,11 +112,11 @@ type I32 = Int if -2147483648 <= self <= 2147483647
 type F32 = Float if self.precision == 32
 ```
 
-Platform capabilities determine the runtime representation; the type system reasons about logical constraints, and the codegen layer maps to machine types.
+Platform effects determine the runtime representation; the type system reasons about logical constraints, and the codegen layer maps to machine types.
 
 ### 3.2 Type annotations on functions
 
-Function signatures **must** be fully annotated. Parameters, return type, error set, capability set, and cost bound are all declared:
+Function signatures **must** be fully annotated. Parameters, return type, error set, effect set, and cost bound are all declared:
 
 ```spore
 fn add(a: Int, b: Int) -> Int {
@@ -188,7 +188,7 @@ greet(alice)   // OK: alice has name: String and age: Int (extra fields ignored)
 
 1. **Width subtyping**: A record with extra fields satisfies a type expecting fewer fields.
 2. **Exact field matching**: Field names and types must match exactly (no implicit conversion).
-3. **No trait implementation**: Anonymous records cannot implement traits or capabilities — nominal types are required for that.
+3. **No trait implementation**: Anonymous records cannot implement traits or effects — nominal types are required for that.
 4. **Nominal types do NOT satisfy anonymous record types**: `type Stats = { count: Int }` is nominal and is NOT compatible with `{ count: Int }`.
 
 ```spore
@@ -201,9 +201,9 @@ let named = Stats { count: 10, total: 95.5 }
 summarize(data: { count: named.count, total: named.total })   // OK
 ```
 
-### 3.5 Function types with capabilities
+### 3.5 Function types with effects
 
-Function types carry a **CapSet** — the set of capabilities (effects) the function requires:
+Function types carry a **CapSet** — the set of effects the function requires:
 
 ```spore
 type Logger = Fn(msg: String) -> () uses [FileWrite]
@@ -307,22 +307,22 @@ alias UserName = String    // alias: UserName == String (transparent)
 
 #### Trait definition
 
-Traits define named interfaces. Spore uses the `capability` keyword (which is syntactic sugar for trait). Traits are nominal — a type satisfies a trait only through an explicit `impl` declaration.
+Traits define named interfaces. Spore uses the `trait` keyword for type interfaces. Traits are nominal — a type satisfies a trait only through an explicit `impl` declaration.
 
 ```spore
-capability Eq {
+trait Eq {
     fn eq(self, other: Self) -> Bool
 }
 
-capability Ord: Eq {
+trait Ord: Eq {
     fn compare(self, other: Self) -> Ordering
 }
 
-capability Display {
+trait Display {
     fn display(self) -> String
 }
 
-capability Serialize {
+trait Serialize {
     fn serialize(self) -> Bytes ! [SerializeError]
     cost serialize <= 100
 }
@@ -362,7 +362,7 @@ impl Display for Shape {
 Default method implementations are supported:
 
 ```spore
-capability Collection {
+trait Collection {
     type Item
     fn len(self) -> Int
     fn is_empty(self) -> Bool { self.len() == 0 }   // default method
@@ -398,35 +398,57 @@ where T: Eq + Hash + Display
 }
 ```
 
-#### Capability = Trait (unified)
+#### Trait vs. Effect (separated)
 
-This is one of Spore's central design decisions. A **capability** is syntactic sugar for a trait on the execution context. `uses [X]` is equivalent to a trait bound on the implicit execution context.
+This is one of Spore's central design decisions. **Traits** and **effects** are separate constructs:
+
+- **`trait`** defines type interfaces — capabilities that types implement. Used with `where T: Trait` bounds.
+- **`effect`** defines external operations — ways a function interacts with the outside world. Used with `uses [Effect]` declarations.
+
+These two systems are never mixed: `where` is for traits, `uses` is for effects.
+
+##### Effect definitions
 
 ```spore
-// A capability is a trait on the execution context
-capability FileRead {
+// An effect defines operations that interact with the external world
+effect FileRead {
     fn read_file(path: Path) -> Bytes ! [IoError]
-    cost read_file <= 100
 }
 
-capability FileWrite {
+effect FileWrite {
     fn write_file(path: Path, data: Bytes) -> Unit ! [IoError]
-    cost write_file <= 200
 }
 ```
 
-**Composite capabilities**:
+##### Effect aliases
+
+Effect aliases use `|` for union, consistent with type union syntax:
 
 ```spore
-capability DatabaseAccess = [NetRead, NetWrite, StateRead, StateWrite]
-capability Analytics = [Compute, StateRead]
+effect FileIO = FileRead | FileWrite
+effect DatabaseAccess = NetRead | NetWrite | StateRead | StateWrite
 
 fn generate_report(org_id: OrgId, period: DateRange) -> Report ! [ConnectionLost]
-uses [DatabaseAccess, Analytics]
+uses [DatabaseAccess]
 cost <= 12000
 {
-    // can use any function requiring subsets of DatabaseAccess or Analytics
+    // can use any function requiring subsets of DatabaseAccess
 }
+```
+
+##### Effect handlers
+
+Effects can be intercepted and reinterpreted via handlers:
+
+```spore
+handler MockFileRead for FileRead {
+    fn read_file(path: Path) -> Bytes ! [IoError] {
+        self.mock_fs.get(path)
+    }
+}
+
+// Bind handler at call site
+handle load_config("app.toml") with MockFileRead { mock_fs: test_data }
 ```
 
 #### Associated types
@@ -434,7 +456,7 @@ cost <= 12000
 Traits may declare associated types — types determined by the implementing type:
 
 ```spore
-capability Iterator {
+trait Iterator {
     type Item
     fn next(self) -> Option[Self.Item]
     cost next <= 10
@@ -447,7 +469,7 @@ impl Iterator for LineReader {
     }
 }
 
-capability Collection {
+trait Collection {
     type Item
     type Iter: Iterator where Iter.Item == Self.Item
 
@@ -475,12 +497,12 @@ where
 GATs allow associated types to have their own generic parameters, enabling patterns like lending iterators and self-referential collections:
 
 ```spore
-capability LendingIterator {
+trait LendingIterator {
     type Item[lifetime]
     fn next[lifetime](self) -> Option[Self.Item[lifetime]]
 }
 
-capability Container {
+trait Container {
     type Elem[T]
     fn wrap[T](value: T) -> Self.Elem[T]
     fn unwrap[T](wrapped: Self.Elem[T]) -> T
@@ -789,7 +811,7 @@ cost <= 2000
 **Semantics of @allows**:
 
 - `@allows[f1, f2, ...]` annotates the immediately following hole.
-- The Agent, when filling this hole, may only call the listed functions (plus pure helper functions that require no capabilities).
+- The Agent, when filling this hole, may only call the listed functions (plus pure helper functions that require no effects).
 - The compiler verifies that the filling respects the `@allows` constraint.
 - `@allows` is **not** a type — it is a **synthesis constraint** that restricts the search space for hole-filling.
 
@@ -926,8 +948,8 @@ type Tree[T] = {
 |---|---|---|
 | Named types (`type X = ...`) | **Nominal** | `UserId ≠ String` even if same shape |
 | Enums | **Nominal** | Sealed, exhaustiveness-checked |
-| Traits / capabilities | **Nominal** | Explicit `impl` required |
-| Capabilities | **Nominal** (always) | Security boundary — no structural coincidence |
+| Traits / effects | **Nominal** | Explicit `impl` required |
+| Effects | **Nominal** (always) | Security boundary — no structural coincidence |
 | Anonymous records `{ ... }` | **Structural** | Flexibility for intermediate values |
 | Hole-filling search (internal) | **Structural** | Agent searches by shape, compiler enforces nominal at boundaries |
 | Function call boundaries | **Nominal** | Callee specifies named types, caller must provide them |
@@ -939,7 +961,7 @@ type Tree[T] = {
 | Function parameter types | **Yes** | Gravity center — the signature IS the API |
 | Function return type | **Yes** | Agent reads signatures for synthesis; human reads for understanding |
 | Error sets (`! [...]`) | **Yes** | Error contract — must be visible |
-| Effect/capability sets (`uses [...]`) | **Yes** | Security boundary — must be visible |
+| Effect sets (`uses [...]`) | **Yes** | Security boundary — must be visible |
 | Cost bounds (`cost <=`) | **Yes** | Performance contract — must be visible |
 | Struct/type field types | **Yes** | Data definition — must be explicit |
 | Trait method signatures | **Yes** | Interface contract |
@@ -989,7 +1011,7 @@ The internal type representation is the `Ty` enum, defined in `spore-typeck/src/
     | Named(n)                     // named type / type parameter
     | App(n, [τ₁, …, τₖ])         // generic type application
     | Record([(f₁, τ₁), …])       // anonymous record (structural)
-    | Fn([τ₁, …, τₙ], τᵣ, C)     // function type with capability set
+    | Fn([τ₁, …, τₙ], τᵣ, C)     // function type with effect set
     | Var(id)                      // unification variable
     | Hole(name)                   // typed hole placeholder
     | Error                        // error sentinel (recovery)
@@ -999,7 +1021,7 @@ Where:
 
 - `n` ranges over identifiers (strings).
 - `id` ranges over `u32` (unique unification variable IDs).
-- `C` is a **CapSet** = `BTreeSet<String>`, the set of capability names the function requires.
+- `C` is a **CapSet** = `BTreeSet<String>`, the set of effect names the function requires.
 - `f` ranges over field names (strings) in anonymous records.
 
 **Never type.** `Ty::Never` is the bottom type — a subtype of all types. It is produced by diverging expressions (`panic`, non-terminating recursion). During unification, `unify(τ, Never) = ok` for all `τ`.
@@ -1010,13 +1032,13 @@ Where:
 
 **Hole type.** `Ty::Hole(name)` represents an unfilled hole. During unification, holes are compatible with anything — the checker records the expected type for diagnostic purposes without blocking further checking.
 
-### 4.2 Capability sets (CapSet)
+### 4.2 Effect sets (CapSet)
 
 ```rust
 pub type CapSet = BTreeSet<String>;
 ```
 
-A `CapSet` is a sorted set of capability names. It appears as the third component of `Ty::Fn`:
+A `CapSet` is a sorted set of effect names. It appears as the third component of `Ty::Fn`:
 
 ```text
 Fn([τ₁, …, τₙ], τᵣ, { cap₁, cap₂, … })
@@ -1029,7 +1051,7 @@ Fn([τ₁, …, τₙ], τᵣ, { cap₁, cap₂, … })
 3. CapSets propagate through higher-order calls: passing a `Fn(...) uses [NetRead]` to a higher-order function requires the caller to declare `NetRead`.
 4. `uses [Cap1, Cap2]` in source syntax maps directly to `CapSet = {"Cap1", "Cap2"}`.
 
-**Formal capability checking rule:**
+**Formal effect checking rule:**
 
 ```text
 Γ ⊢ f : Fn([σ₁, …, σₙ], τᵣ, C_f)
@@ -1041,17 +1063,17 @@ C_caller ⊇ C_f
 If `C_f ⊄ C_caller`, the checker emits:
 
 ```text
-missing capabilities [X, Y]: caller does not declare them
+missing effects [X, Y]: caller does not declare them
 ```
 
 ### Formal typing judgments
 
-The core type system uses bidirectional typing with capability context.
+The core type system uses bidirectional typing with effect context.
 
 **Notation:**
 
 - `Γ` — type environment (variable → type mapping)
-- `S` — capability set (subset of all capabilities)
+- `S` — effect set (subset of all effects)
 - `e` — expression
 - `T` — type
 - `⊢` — "entails" / judgment turnstile
@@ -1146,11 +1168,11 @@ The core type system uses bidirectional typing with capability context.
   ─────────────────────────────
   Γ; S ⊢ await e ⇒ T
 
-[CapabilityCheck]
+[EffectCheck]
   Γ; S ⊢ e ⇒ T uses S_required
   S_required ⊆ S
   ─────────────────────────────
-  (e is valid in capability context S)
+  (e is valid in effect context S)
 
 [Sub]
   Γ; S ⊢ e ⇒ T₁
@@ -1169,7 +1191,7 @@ The core type system uses bidirectional typing with capability context.
   T₁' <: T₁    T₂ <: T₂'    S ⊆ S'
   ─────────────────────────────
   (T₁ → T₂ uses S) <: (T₁' → T₂' uses S')
-  (contravariant params, covariant return, covariant capabilities)
+  (contravariant params, covariant return, covariant effects)
 
 [Sub-Task]
   T <: T'
@@ -1298,7 +1320,7 @@ apply_subst(Record(fields))       = Record([(f, apply_subst(τ)) for (f, τ) in 
 apply_subst(τ)                    = τ                  for all other τ
 ```
 
-Note that `CapSet` is **not** subject to substitution — capabilities are always concrete strings, never type variables.
+Note that `CapSet` is **not** subject to substitution — effects are always concrete strings, never type variables.
 
 #### Unification algorithm
 
@@ -1350,7 +1372,7 @@ pub fn check_module(&mut self, module: &Module) {
 - **Functions:** Parameter types are resolved, return type is resolved (default `Unit`), CapSet is extracted from `uses` clause, and type parameters from `where` clause are recorded.
 - **Structs:** Field names and types are resolved and stored.
 - **Type defs (enums):** Variant names and field types are resolved and stored.
-- **Capabilities and imports:** Deferred (no registration needed).
+- **Effects and imports:** Deferred (no registration needed).
 
 **Pass 2 — `check_fn`:** For each function with a body:
 
@@ -1454,7 +1476,7 @@ Spore primarily uses **equality-based** type compatibility via unification, with
 - `Ty::Hole(name)` unifies with anything (hole placeholder only).
 - `Ty::Never` unifies with anything (`Never <: τ` for all `τ`).
 - Width subtyping for anonymous records: `{ a: Int, b: String, c: Bool } <: { a: Int, b: String }`.
-- Capability set subtyping: `C₁ ⊆ C₂ ⟹ Fn(ps, r, C₁) <: Fn(ps, r, C₂)` (a function needing fewer capabilities is more general).
+- Effect set subtyping: `C₁ ⊆ C₂ ⟹ Fn(ps, r, C₁) <: Fn(ps, r, C₂)` (a function needing fewer effects is more general).
 
 ### 4.10 Binary and unary operator typing
 
@@ -1785,7 +1807,7 @@ Type errors are emitted as structured JSON for Agent consumption:
 | Type mismatch | `type mismatch in function 'add': expected 'Int', got 'String'` |
 | Undefined variable | `undefined variable 'x'` |
 | Arity mismatch | `function 'add' expects 2 arguments, got 3` |
-| Missing capability | `missing capabilities [NetRead]: caller does not declare them` |
+| Missing effect | `missing effects [NetRead]: caller does not declare them` |
 | Non-exhaustive match | `non-exhaustive match: missing variant 'Triangle'` |
 | Cannot negate type | `cannot negate type 'String'` |
 | Cannot apply `!` | `cannot apply '!' to type 'Int'` |
@@ -1815,7 +1837,7 @@ Hole ?h1 in function `example`:
 
 1. **Nominal rigidity.** The nominal-primary design means newtypes require explicit wrap/unwrap. This adds verbosity for simple delegation patterns. Anonymous records provide a structural escape hatch, but they cannot implement traits.
 
-2. **CapSet as BTreeSet\<String\>.** String-based capability names lack static verification at the `Ty` level — a misspelled capability name is only caught when matching against registered capabilities, not during type construction.
+2. **CapSet as BTreeSet\<String\>.** String-based effect names lack static verification at the `Ty` level — a misspelled effect name is only caught when matching against registered effects, not during type construction.
 
 3. **No higher-kinded types.** GATs + associated types cover most use cases, but abstracting over container kinds generically (functor-map over any container) requires either code generation or per-container implementations.
 
@@ -1827,7 +1849,7 @@ Hole ?h1 in function `example`:
 
 ### Alternative 1: Structural typing as default (TypeScript / Go style)
 
-**Rejected.** Structural typing makes capability safety impossible — two structurally identical types could accidentally satisfy each other's capability requirements. It also produces confusing error messages when two semantically different types happen to share the same shape.
+**Rejected.** Structural typing makes effect safety impossible — two structurally identical types could accidentally satisfy each other's effect requirements. It also produces confusing error messages when two semantically different types happen to share the same shape.
 
 **Decision:** Nominal-primary with anonymous structural records as an escape hatch.
 
@@ -1845,7 +1867,7 @@ Hole ?h1 in function `example`:
 
 **Rejected.** HKTs would allow abstracting over `Option`, `List`, `Result`, etc. generically. However:
 
-- Capabilities replace the primary HKT use case (monad-based effect sequencing).
+- Effects replace the primary HKT use case (monad-based effect sequencing).
 - GATs cover 80% of the remaining use cases.
 - HKT error messages are notoriously difficult to understand.
 - Can be added later as an opt-in extension without breaking changes.
@@ -1864,15 +1886,15 @@ Hole ?h1 in function `example`:
 
 ### Alternative 5: Effect system via monads or algebraic effects
 
-**Rejected as primary mechanism.** Spore unifies capabilities and traits instead of using a separate effect system. This provides:
+**Rejected as primary mechanism.** Spore separates traits and effects instead of unifying them via monads or algebraic effects. This provides:
 
-- One mechanism for both "what does this type support" and "what does this context provide."
-- Reuse of the trait resolver and coherence checker.
+- Clear distinction between "what does this type support" (traits) and "what does this context require" (effects).
+- Reuse of the trait resolver and coherence checker for type interfaces.
 - Simpler mental model for users.
 
-**Decision:** Capabilities = Traits. `uses [Cap]` is syntactic sugar for a trait bound on execution context.
+**Decision:** Traits ≠ Effects. `trait` defines type interfaces, `effect` defines external operations, `uses [Effect]` declares effect requirements.
 
-### Alternative 6: Row-polymorphic capability sets
+### Alternative 6: Row-polymorphic effect sets
 
 **Considered for future.** Making CapSets row-polymorphic would allow:
 
@@ -1880,7 +1902,7 @@ Hole ?h1 in function `example`:
 fn apply[C](f: Fn(x: Int) -> Int uses C, x: Int) -> Int uses C
 ```
 
-This is compatible with the current design but not yet implemented. The string-based `BTreeSet` representation would need to be extended with capability variables.
+This is compatible with the current design but not yet implemented. The string-based `BTreeSet` representation would need to be extended with effect variables.
 
 ## Prior art
 
@@ -1893,7 +1915,7 @@ Spore's type system is most directly influenced by Rust:
 - Sealed enums with exhaustive pattern matching.
 - No implicit conversions.
 
-**Differences from Rust:** No lifetime system (Spore uses GC or region-based memory), no borrow checker, capabilities replace `unsafe` blocks, refinement types replace some `debug_assert!` patterns.
+**Differences from Rust:** No lifetime system (Spore uses GC or region-based memory), no borrow checker, effects replace `unsafe` blocks, refinement types replace some `debug_assert!` patterns.
 
 ### Haskell / GHC
 
@@ -1909,7 +1931,7 @@ Spore's type system is most directly influenced by Rust:
 ### TypeScript
 
 - Structural typing for anonymous records (Spore borrows this for the structural escape hatch).
-- Spore rejects structural typing as the default due to capability safety concerns.
+- Spore rejects structural typing as the default due to effect safety concerns.
 
 ### Elm
 
@@ -1933,7 +1955,7 @@ Since this is the first formal type system specification (v0.1 → SEP), there i
 
 1. **Ty enum stability.** The variants `Int`, `Float`, `Bool`, `Str`, `Char`, `Unit`, `Never`, `Named`, `App`, `Record`, `Fn`, `Var`, `Hole`, `Error` are stable. New variants may be added but existing variants will not be removed or renamed without a new SEP.
 
-2. **CapSet representation.** `BTreeSet<String>` is the current representation. Future SEPs may introduce capability variables for row-polymorphic effects, but the concrete string-based API will remain supported.
+2. **CapSet representation.** `BTreeSet<String>` is the current representation. Future SEPs may introduce effect variables for row-polymorphic effects, but the concrete string-based API will remain supported.
 
 3. **Two-pass checking.** The `register_item` → `check_fn` architecture is stable. Future passes (e.g., trait resolution, cost checking) will be added after these two, not replace them.
 
@@ -1945,11 +1967,11 @@ Since this is the first formal type system specification (v0.1 → SEP), there i
 |---|---|
 | Refinement types (L0) | Add `Ty::Refined(Box<Ty>, Predicate)` variant; extend `resolve_type` |
 | Const generics | Add `Ty::Const(value)` variant; extend `App` to accept const args |
-| Row-polymorphic capabilities | Extend CapSet with capability variables alongside concrete strings |
+| Row-polymorphic effects | Extend CapSet with effect variables alongside concrete strings |
 
 ## Unresolved questions
 
-1. **CapSet in unification.** Currently, function type unification ignores CapSets (the `_` in `Fn(p1, r1, _), Fn(p2, r2, _)`). Should CapSets participate in unification, or remain checked separately? Separate checking is simpler but could miss capability mismatches in higher-order function arguments.
+1. **CapSet in unification.** Currently, function type unification ignores CapSets (the `_` in `Fn(p1, r1, _), Fn(p2, r2, _)`). Should CapSets participate in unification, or remain checked separately? Separate checking is simpler but could miss effect mismatches in higher-order function arguments.
 
 2. **Generic syntax: square brackets vs angle brackets.** The implemented `Ty::App` uses parenthesized syntax in the AST (`List[Int]`), but some spec examples use angle brackets (`List<T>`). This SEP uses square brackets as the intended syntax; a separate SEP should finalize the concrete syntax.
 
@@ -1960,7 +1982,7 @@ Since this is the first formal type system specification (v0.1 → SEP), there i
 
 4. **Trait method type checking.** The two-pass architecture registers function signatures but does not yet handle trait method signatures, default methods, or `impl` blocks. How should these be integrated into `register_item` and `check_fn`? (See §4.12 for the specified approach.)
 
-5. **Row-polymorphic capabilities.** Should capability sets support variables (e.g., `uses [C]` where `C` is a capability set variable)? This would enable generic higher-order functions that preserve their argument's capability requirements.
+5. **Row-polymorphic effects.** Should effect sets support variables (e.g., `uses [C]` where `C` is an effect set variable)? This would enable generic higher-order functions that preserve their argument's effect requirements.
 
 6. **Variance.** Generic type parameters need variance annotations (covariant, contravariant, invariant) for soundness when subtyping is introduced. Should variance be inferred or declared?
 

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -1,6 +1,6 @@
 ---
 sep: 3
-title: "SEP-0003: Effect & Capability System"
+title: "SEP-0003: Effect System"
 status: Draft
 type: Standards Track
 authors:
@@ -13,15 +13,15 @@ pr: null
 superseded_by: null
 ---
 
-# SEP-0003: Effect & Capability System
+# SEP-0003: Effect System
 
-> **Executive Summary**: Defines Spore's effect system as a capability-based model with 11 atomic capabilities (Compute, FileRead, FileWrite, NetRead, NetWrite, StateRead, StateWrite, Spawn, Clock, Random, Exit). Capabilities compose algebraically (commutative, idempotent, associative) and are checked via subset inclusion — a function requiring capabilities S can only be called from a context providing S′ ⊇ S. Module-level `uses` declarations set the ambient capability ceiling.
+> **Executive Summary**: Defines Spore's effect system with 11 atomic effects (Compute, FileRead, FileWrite, NetRead, NetWrite, StateRead, StateWrite, Spawn, Clock, Random, Exit) and user-defined effects. Effects compose algebraically and are checked via subset inclusion. Effect handlers (`handler`/`handle ... with`) enable testability and platform abstraction. The `effect` keyword defines both atomic effects and effect aliases (using `|` for union).
 
 ## Summary
 
-This SEP introduces Spore's **capability-based effect system**: a compile-time mechanism that tracks how functions interact with the outside world. Every function declares — via a `uses [...]` clause — the set of *atomic capabilities* it requires. The compiler verifies that a function body never exercises a capability absent from its declared set, auto-infers semantic properties (pure, deterministic, total) from that set, and uses set-inclusion as the basis for subtyping and capability narrowing.
+This SEP introduces Spore's **effect system**: a compile-time mechanism that tracks how functions interact with the outside world. Every function declares — via a `uses [...]` clause — the set of *atomic effects* it requires. The compiler verifies that a function body never exercises an effect absent from its declared set, auto-infers semantic properties (pure, deterministic, total) from that set, and uses set-inclusion as the basis for subtyping and effect narrowing.
 
-The design is intentionally **flat and monomorphic**: capabilities are finite sets of atomic identifiers with no effect variables, no row types, and no effect polymorphism. Named aliases (`capability X = [A, B]`) provide ergonomics without adding expressiveness. Higher-order functions such as `map` accept only pure (`uses []`) closures; effectful iteration is expressed through `parallel_scope` + `spawn`.
+The design is intentionally **flat and monomorphic**: effects are finite sets of atomic identifiers with no effect variables, no row types, and no effect polymorphism. Named aliases (`effect X = A | B`) provide ergonomics without adding expressiveness. Higher-order functions such as `map` accept only pure (`uses []`) closures; effectful iteration is expressed through `parallel_scope` + `spawn`.
 
 ---
 
@@ -37,9 +37,9 @@ Modern programs interleave pure computation with diverse side effects — file I
 
 3. **Opaque higher-order functions.** When `map` or `fold` accept arbitrary closures, the caller loses all guarantees about the aggregate computation. A closure that performs network I/O inside `map` is a common source of performance surprises and non-determinism.
 
-4. **Capability escalation.** Concurrent sub-tasks should not silently acquire capabilities that their parent never held. Without a formal narrowing rule, library code can grant capabilities that the application developer never intended.
+4. **Effect escalation.** Concurrent sub-tasks should not silently acquire effects that their parent never held. Without a formal narrowing rule, library code can grant effects that the application developer never intended.
 
-5. **Agent-unfriendly code.** LLM-based code-generation agents filling Holes need machine-readable constraints on which effects are permissible at each program point. A formal capability set provides exactly this.
+5. **Agent-unfriendly code.** LLM-based code-generation agents filling Holes need machine-readable constraints on which effects are permissible at each program point. A formal effect set provides exactly this.
 
 ### Design goals
 
@@ -47,18 +47,18 @@ Modern programs interleave pure computation with diverse side effects — file I
 |------|-----------|
 | Explicit effect tracking | `uses [...]` clause on every function |
 | Zero-cost purity | Omitting `uses` ≡ `uses []` (pure) |
-| Composable aliases | `capability` keyword for named groups |
-| Sound subtyping | Set inclusion on capability sets |
+| Composable aliases | `effect` keyword for named groups and aliases |
+| Sound subtyping | Set inclusion on effect sets |
 | Auto-inferred properties | `pure`, `deterministic`, `total` derived from `uses` |
-| Agent integration | Capability set emitted in `HoleReport` JSON |
+| Agent integration | Effect set emitted in `HoleReport` JSON |
 
 ---
 
 ## Guide-level explanation
 
-### Declaring capabilities on functions
+### Declaring effects on functions
 
-Every Spore function may carry a `uses` clause listing the atomic capabilities it requires:
+Every Spore function may carry a `uses` clause listing the atomic effects it requires:
 
 ```spore
 fn read_config(path: String) -> Config ! [IoError, ParseError]
@@ -69,7 +69,7 @@ uses [FileRead]
 }
 ```
 
-If a function needs no capabilities it is *pure* and the `uses` clause may be omitted entirely:
+If a function needs no effects it is *pure* and the `uses` clause may be omitted entirely:
 
 ```spore
 fn add(a: Int, b: Int) -> Int {
@@ -78,11 +78,11 @@ fn add(a: Int, b: Int) -> Int {
 // equivalent to: fn add(a: Int, b: Int) -> Int uses [] { a + b }
 ```
 
-### Built-in atomic capabilities
+### Built-in atomic effects
 
-Spore ships with the following atomic capabilities:
+Spore ships with the following atomic effects:
 
-| Capability | Semantics | Typical operations |
+| Effect | Semantics | Typical operations |
 |---|---|---|
 | `FileRead` | Read from the filesystem | `read_file`, `list_dir` |
 | `FileWrite` | Write to the filesystem | `write_file`, `create_dir`, `delete` |
@@ -96,14 +96,14 @@ Spore ships with the following atomic capabilities:
 | `Compute` | Non-trivial pure computation | Compiler-implicit |
 | `Exit` | Terminate the process | `exit()`, `abort()` |
 
-### Defining capability aliases
+### Defining effect aliases
 
-The `capability` keyword creates a **named alias** that expands into a flat set of atomic capabilities:
+The `effect` keyword creates a **named alias** that expands into a flat set of atomic effects:
 
 ```spore
-capability FileIO = [FileRead, FileWrite]
-capability DatabaseAccess = [NetRead, NetWrite, StateRead, StateWrite]
-capability FullIO = [FileIO, NetRead, NetWrite]
+effect FileIO = FileRead | FileWrite
+effect DatabaseAccess = NetRead | NetWrite | StateRead | StateWrite
+effect FullIO = FileIO | NetRead | NetWrite
 ```
 
 Aliases expand recursively and flatten:
@@ -113,12 +113,12 @@ FullIO → {FileIO, NetRead, NetWrite}
        → {FileRead, FileWrite, NetRead, NetWrite}
 ```
 
-Aliases are purely syntactic sugar. After expansion, only atomic capabilities remain.
+Aliases are purely syntactic sugar. After expansion, only atomic effects remain.
 
-### Using capabilities in practice
+### Using effects in practice
 
 ```spore
-capability DatabaseAccess = [NetRead, NetWrite, StateRead, StateWrite]
+effect DatabaseAccess = NetRead | NetWrite | StateRead | StateWrite
 
 fn query_user(id: UserId) -> User ! [DbError, NotFound]
 uses [DatabaseAccess]
@@ -132,7 +132,7 @@ After alias expansion this is equivalent to `uses [NetRead, NetWrite, StateRead,
 
 ### Pure closures in higher-order functions
 
-Higher-order combinators such as `map`, `filter`, and `fold` accept **only pure closures** — closures whose capability set is empty:
+Higher-order combinators such as `map`, `filter`, and `fold` accept **only pure closures** — closures whose effect set is empty:
 
 ```spore
 fn process_scores(scores: List[Int]) -> List[String] {
@@ -182,7 +182,7 @@ Why does this type-check?
 
 ### Auto-inferred properties
 
-The compiler automatically derives semantic properties from the declared capability set. No manual annotation is required:
+The compiler automatically derives semantic properties from the declared effect set. No manual annotation is required:
 
 | Declared `uses` | Inferred properties |
 |---|---|
@@ -196,7 +196,7 @@ The compiler automatically derives semantic properties from the declared capabil
 
 ### Incomplete functions — missing `uses` declarations
 
-A function that calls operations requiring capabilities but does **not** declare a `uses` clause is an *incomplete function*. The compiler treats this as an error with a fix suggestion:
+A function that calls operations requiring effects but does **not** declare a `uses` clause is an *incomplete function*. The compiler treats this as an error with a fix suggestion:
 
 ```spore
 fn save_data(data: Data) -> Unit {
@@ -205,7 +205,7 @@ fn save_data(data: Data) -> Unit {
 ```
 
 ```text
-error[cap-violation]: function body uses undeclared capability
+error[cap-violation]: function body uses undeclared effect
   --> src/storage.spore:1:1
    |
  1 | fn save_data(data: Data) -> Unit {
@@ -227,7 +227,7 @@ Running `sporec --fixes` auto-inserts the missing `uses` clause.
 
 ### Module-level `uses` declarations
 
-A module may declare its capability ceiling with `module X uses [...]`:
+A module may declare its effect ceiling with `module X uses [...]`:
 
 ```spore
 module billing uses [NetRead, NetWrite, StateRead, StateWrite]
@@ -235,7 +235,7 @@ module billing uses [NetRead, NetWrite, StateRead, StateWrite]
 
 All functions within the module are constrained: their `uses` sets must be subsets of the module-level set. If a function exceeds the module ceiling the compiler emits a `cap-narrowing-violation` error.
 
-The module-level `uses` clause is **optional**. When omitted the compiler auto-infers the module's capability ceiling as the union of all its functions' capability sets. Running `sporec --fixes` inserts the inferred declaration.
+The module-level `uses` clause is **optional**. When omitted the compiler auto-infers the module's effect ceiling as the union of all its functions' effect sets. Running `sporec --fixes` inserts the inferred declaration.
 
 ### `@allows` — restricting Hole candidates
 
@@ -262,7 +262,7 @@ The generated `HoleReport` includes the restriction:
 }
 ```
 
-Without `@allows`, all functions matching the type and capability constraints appear. With `@allows`, the candidate list is further filtered to only the named functions.
+Without `@allows`, all functions matching the type and effect constraints appear. With `@allows`, the candidate list is further filtered to only the named functions.
 
 ### Pure recursive function example — fibonacci
 
@@ -291,11 +291,11 @@ cost ≤ O(2^n)
 
 ## Reference-level explanation
 
-### 1. Atomic capability set
+### 1. Atomic effect set
 
-Let **E** be the universe of atomic capabilities. Each element of **E** is an indivisible identifier representing one way a program may interact with the external world.
+Let **E** be the universe of atomic effects. Each element of **E** is an indivisible identifier representing one way a program may interact with the external world.
 
-A **capability set** *S* is a finite subset of **E**:
+An **effect set** *S* is a finite subset of **E**:
 
 $$S \subseteq E, \quad |S| < \infty$$
 
@@ -303,7 +303,7 @@ The empty set `{}` denotes a pure function — no interaction with the outside w
 
 ### 2. Formal effect algebra
 
-Capability sets obey standard finite-set algebra:
+Effect sets obey standard finite-set algebra:
 
 | Property | Formula | Consequence |
 |---|---|---|
@@ -317,23 +317,23 @@ Capability sets obey standard finite-set algebra:
 | Operation | Symbol | Use |
 |---|---|---|
 | Union | S₁ ∪ S₂ | Sequential composition, conditional branches |
-| Subset | S₁ ⊆ S₂ | Subtype check, capability narrowing |
+| Subset | S₁ ⊆ S₂ | Subtype check, effect narrowing |
 | Intersection | S₁ ∩ S₂ | Property inference |
 | Difference | S₁ \ S₂ | Reserved; not currently exposed in syntax |
 
-### 3. Capability alias definition and expansion
+### 3. Effect alias definition and expansion
 
 Given an alias definition:
 
-$$\texttt{capability } C = [A_1, A_2, \ldots, A_n]$$
+$$\texttt{effect } C = A_1 \mid A_2 \mid \ldots \mid A_n$$
 
 In any `uses` declaration:
 
 $$\texttt{uses } [C] \equiv \texttt{uses } [A_1, A_2, \ldots, A_n]$$
 
-Expansion is **recursive**: if any $A_i$ is itself an alias, it is expanded until every element is an atomic capability. The result is always a flat set.
+Expansion is **recursive**: if any $A_i$ is itself an alias, it is expanded until every element is an atomic effect. The result is always a flat set.
 
-**No capability variables exist.** All capability sets must be fully determined at compile time. There is no `uses E` generic parameter and no effect polymorphism.
+**No effect variables exist.** All effect sets must be fully determined at compile time. There is no `uses E` generic parameter and no effect polymorphism.
 
 ### 4. Function types and CapSet encoding
 
@@ -347,7 +347,7 @@ where:
 
 - `T₁ … Tₙ` — parameter types
 - `R` — return type
-- `S` — capability set (CapSet)
+- `S` — effect set (CapSet)
 - `[E₁ …]` — error type set
 
 #### 4.2 Internal representation
@@ -362,7 +362,7 @@ where `CapSet = BTreeSet<String>`. A `BTreeSet` is chosen over `HashSet` for det
 
 #### 4.3 Shorthand
 
-When the capability set is empty the `uses` clause may be omitted:
+When the effect set is empty the `uses` clause may be omitted:
 
 $$(T_1, T_2) \to R \equiv (T_1, T_2) \to R \ \textbf{uses}\ \{\}$$
 
@@ -378,19 +378,18 @@ $$\mathcal{P}(\text{total}, S) = \text{determined by a separate termination anal
 
 #### 5.0 Edge cases in the `pure` formula
 
-The `𝒫(pure, S)` function has a gap: when `S` is non-empty but contains only capabilities outside the I/O set `{FileRead, FileWrite, NetRead, NetWrite, StateRead, StateWrite}`, neither the `true` nor the `false` case applies directly. The following clarifications apply:
+The `𝒫(pure, S)` function has a gap: when `S` is non-empty but contains only effects outside the I/O set `{FileRead, FileWrite, NetRead, NetWrite, StateRead, StateWrite}`, neither the `true` nor the `false` case applies directly. The following clarifications apply:
 
-| Capability set S | pure? | Rationale |
+| Effect set S | pure? | Rationale |
 |---|---|---|
-| `{}` | true | No capabilities at all |
-| `{Compute}` | true | `Compute` is not an I/O capability; it marks non-trivial pure computation |
+| `{}` | true | No effects at all |
+| `{Compute}` | true | `Compute` is not an I/O effect; it marks non-trivial pure computation |
 | `{Clock}` | false | Clock reads the external world (system time) |
 | `{Random}` | false | Random reads external entropy |
 | `{Spawn}` | true | `spawn` merely creates a task descriptor (pure); the effect is deferred |
-| `{Exit}` | false | `exit` terminates the process — an observable external effect |
-| `{Compute, Spawn}` | true | Neither is an I/O capability |
+| `{Compute, Spawn}` | true | Neither is an I/O effect |
 
-The complete rule: `𝒫(pure, S) = true` iff `S ⊆ {Compute, Spawn}`. All other non-empty capability sets that intersect with any capability outside this "pure-compatible" subset yield `𝒫(pure, S) = false`.
+The complete rule: `𝒫(pure, S) = true` iff `S ⊆ {Compute, Spawn}`. All other non-empty effect sets that intersect with any effect outside this "pure-compatible" subset yield `𝒫(pure, S) = false`.
 
 #### 5.1 Implication chain
 
@@ -400,7 +399,7 @@ A pure function (`uses {}`) trivially satisfies the deterministic condition beca
 
 #### 5.2 Properties that cannot be statically inferred
 
-**Idempotency** cannot in general be derived from a capability set. It may be annotated via doc-comment:
+**Idempotency** cannot in general be derived from an effect set. It may be annotated via doc-comment:
 
 ```spore
 /// @idempotent
@@ -420,15 +419,15 @@ uses [NetRead, NetWrite]
 }
 ```
 
-### 6. Subtyping and capability narrowing
+### 6. Subtyping and effect narrowing
 
 #### 6.1 Subtype rule
 
-Capability sets induce subtyping via set inclusion. Function types are **contravariant** in their capability parameter:
+Effect sets induce subtyping via set inclusion. Function types are **contravariant** in their effect parameter:
 
 $$S_1 \subseteq S_2 \implies (\tau \to \rho \ \textbf{uses}\ S_1) <: (\tau \to \rho \ \textbf{uses}\ S_2)$$
 
-A function that requires *fewer* capabilities is more general and can be used wherever a more-capable function is expected.
+A function that requires *fewer* effects is more general and can be used wherever a more-capable function is expected.
 
 ```text
                     S₁ ⊆ S₂
@@ -443,13 +442,13 @@ As a corollary, pure functions are subtypes of all function types:
 (T → R uses {}) <: (T → R uses S)     ∀ S
 ```
 
-#### 6.2 Capability narrowing in `parallel_scope`
+#### 6.2 Effect narrowing in `parallel_scope`
 
-A child task's capability set must be a subset of its parent's:
+A child task's effect set must be a subset of its parent's:
 
 $$S_{\text{child}} \subseteq S_{\text{parent}}$$
 
-This guarantees that sub-tasks never acquire capabilities beyond those granted to their parent.
+This guarantees that sub-tasks never acquire effects beyond those granted to their parent.
 
 ### 7. Typing judgement
 
@@ -457,7 +456,7 @@ The standard judgement form is:
 
 $$\Gamma;\ S \vdash e : T$$
 
-Read: "Under type context Γ and capability set S, expression e has type T."
+Read: "Under type context Γ and effect set S, expression e has type T."
 
 #### Core rules
 
@@ -476,11 +475,11 @@ Read: "Under type context Γ and capability set S, expression e has type T."
 Γ; S ⊢ 42 : Int      ∀ S
 ```
 
-### 8. Capability composition rules
+### 8. Effect composition rules
 
-When multiple expressions are combined the compiler computes the composite capability set:
+When multiple expressions are combined the compiler computes the composite effect set:
 
-| Composition form | Capability computation |
+| Composition form | Effect computation |
 |---|---|
 | `A; B` | S_A ∪ S_B |
 | `if c then A else B` | S_c ∪ S_A ∪ S_B |
@@ -494,12 +493,12 @@ Formal rules for the two most important cases:
 ```text
 Γ; S ⊢ A : T₁    Γ; S ⊢ B : T₂
 ──────────────────────────────────  [SEQ-CAP]
-capabilities(A; B) = S_A ∪ S_B
+effects(A; B) = S_A ∪ S_B
 
 
 Γ; S ⊢ c : Bool    Γ; S ⊢ A : T    Γ; S ⊢ B : T
 ────────────────────────────────────────────────────  [COND-CAP]
-capabilities(if c then A else B) = S_c ∪ S_A ∪ S_B
+effects(if c then A else B) = S_c ∪ S_A ∪ S_B
 
 
 f : (T → R uses S_f)    S_f ⊆ S_scope
@@ -514,27 +513,27 @@ Spawn ∈ S_scope    S_body ⊆ S_scope
 
 > **Note on spawn purity.** The `spawn` expression itself is **pure** — it merely creates a task descriptor (of type `Task[T]`). No side effect is executed at the point of `spawn`; the effect occurs when the task is later scheduled. This is why a closure containing only `spawn { ... }` satisfies `uses []` when passed to `map` or other pure-closure-requiring combinators.
 
-### 9. Capability checking algorithm
+### 9. Effect checking algorithm
 
-The compiler performs capability checking during type-checking as a single pass:
+The compiler performs effect checking during type-checking as a single pass:
 
-1. **Alias expansion.** Every `uses` clause and every `capability` definition is recursively expanded to a flat set of atomic capabilities.
+1. **Alias expansion.** Every `uses` clause and every `effect` definition is recursively expanded to a flat set of atomic effects.
 
-2. **Body capability collection.** For each function body, the compiler walks the expression tree and collects the union of capabilities required by every sub-expression (using the composition rules in §8).
+2. **Body effect collection.** For each function body, the compiler walks the expression tree and collects the union of effects required by every sub-expression (using the composition rules in §8).
 
 3. **Subset check.** The collected set `S_body` is checked against the declared set `S_declared`:
 
 $$S_{\text{body}} \subseteq S_{\text{declared}}$$
 
-If the check fails, the compiler emits a `cap-violation` diagnostic listing the excess capabilities.
+If the check fails, the compiler emits a `cap-violation` diagnostic listing the excess effects.
 
-4. **Closure inference.** For closures, the compiler infers the minimal capability set from the closure body. This inferred set is used for subtype checking when the closure is passed to a higher-order function.
+4. **Closure inference.** For closures, the compiler infers the minimal effect set from the closure body. This inferred set is used for subtype checking when the closure is passed to a higher-order function.
 
-5. **`parallel_scope` narrowing.** Inside a `parallel_scope` block, each `spawn` body is checked to ensure its collected capabilities are a subset of the enclosing scope's declared set.
+5. **`parallel_scope` narrowing.** Inside a `parallel_scope` block, each `spawn` body is checked to ensure its collected effects are a subset of the enclosing scope's declared set.
 
-### 10. Closure capability capture
+### 10. Closure effect capture
 
-A closure defined within a context with capability set *S* has an inferred capability set *S'* where *S'* ⊆ *S*. The inference is determined by the capabilities actually exercised in the closure body:
+A closure defined within a context with effect set *S* has an inferred effect set *S'* where *S'* ⊆ *S*. The inference is determined by the effects actually exercised in the closure body:
 
 ```spore
 fn example() -> Unit
@@ -550,7 +549,7 @@ uses [FileRead, NetRead]
 
 ### 11. Interaction with the Hole system
 
-When the compiler encounters a Hole (`?name`), the generated `HoleReport` includes the capability set available at that program point:
+When the compiler encounters a Hole (`?name`), the generated `HoleReport` includes the effect set available at that program point:
 
 ```json
 {
@@ -560,7 +559,7 @@ When the compiler encounters a Hole (`?name`), the generated `HoleReport` includ
     "url": "Url",
     "timeout": "Duration"
   },
-  "available_capabilities": ["NetRead"],
+  "available_effects": ["NetRead"],
   "cost_budget": 5000,
   "candidate_functions": [
     "http.get(url: Url) -> Data ! [NetworkError] uses [NetRead]"
@@ -574,20 +573,20 @@ $$S_{\text{fill}} \subseteq S_{\text{available}}$$
 
 The Hole system filters candidate functions so that only those whose `uses S` satisfies `S ⊆ S_available` appear in the suggestion list.
 
-#### 11.1 Hole capability-violation diagnostic
+#### 11.1 Hole effect-violation diagnostic
 
-When an agent or developer fills a Hole with code that exceeds the available capabilities, the compiler emits a detailed diagnostic:
+When an agent or developer fills a Hole with code that exceeds the available effects, the compiler emits a detailed diagnostic:
 
 ```text
-ERROR [cap-violation] Hole ?fetch_logic filled code uses unauthorised capabilities:
+ERROR [cap-violation] Hole ?fetch_logic filled code uses unauthorised effects:
   --> src/service.spore:15:5
    |
 15 |     ?fetch_logic    // filled with: fetch_and_save(url)
-   |     ^^^^^^^^^^^^ hole fill exceeds available capabilities
+   |     ^^^^^^^^^^^^ hole fill exceeds available effects
    |
-   = available capabilities: [NetRead]
+   = available effects: [NetRead]
    = fill code requires:     [NetRead, FileWrite]
-   = excess capabilities:    [FileWrite]
+   = excess effects:    [FileWrite]
    = help: either add FileWrite to the enclosing function's `uses` clause,
      or choose a candidate that only requires [NetRead]
 ```
@@ -603,7 +602,7 @@ The cost model maintains a **four-dimensional cost vector**: `(compute, alloc, i
 | I/O | `W` | Side-effect / external call count | call |
 | Parallelism | `P` | Parallel execution width | lane |
 
-Capability sets provide hard upper-bound constraints on these cost dimensions:
+Effect sets provide hard upper-bound constraints on these cost dimensions:
 
 | Condition | Cost dimension constraint |
 |---|---|
@@ -612,36 +611,89 @@ Capability sets provide hard upper-bound constraints on these cost dimensions:
 | `Spawn ∈ S` | `parallel > 0` possible |
 | `uses [Compute]` | Only `compute` and `alloc` dimensions may be non-zero |
 
-The relationship is a **necessary condition**: if the capability set excludes all I/O capabilities, the cost model's I/O dimension is provably zero.
+The relationship is a **necessary condition**: if the effect set excludes all I/O effects, the cost model's I/O dimension is provably zero.
 
 $$S \cap \{\text{NetRead, NetWrite, FileRead, FileWrite}\} = \emptyset \implies \text{cost}_{\text{io}} = 0$$
 
-### 13. Capability as a trait-like construct
+### 13. Effects as typed constructs
 
-Capabilities are *not* merely string tags — each capability is a **trait-like construct** whose methods carry a `self` parameter representing the runtime token that grants the capability:
+Effects are not merely string tags — each effect is a **typed construct** whose methods define the operations available when the effect is in scope:
 
 ```spore
-capability FileRead {
-    fn read_file(self, path: String) -> Bytes ! [IoError]
-    fn list_dir(self, path: String) -> List[String] ! [IoError]
+effect FileRead {
+    fn read_file(path: String) -> Bytes ! [IoError]
+    fn list_dir(path: String) -> List[String] ! [IoError]
 }
 
-capability FileWrite {
-    fn write_file(self, path: String, data: Bytes) -> Unit ! [IoError]
-    fn create_dir(self, path: String) -> Unit ! [IoError]
-    fn delete(self, path: String) -> Unit ! [IoError]
+effect FileWrite {
+    fn write_file(path: String, data: Bytes) -> Unit ! [IoError]
+    fn create_dir(path: String) -> Unit ! [IoError]
+    fn delete(path: String) -> Unit ! [IoError]
 }
 ```
 
-When a function declares `uses [FileRead]`, the compiler makes the `FileRead` capability token available as an implicit `self` receiver for the methods defined in that capability. This design unifies capability tracking with method dispatch: calling `read_file(path)` is sugar for invoking the `read_file` method on the ambient `FileRead` token.
+When a function declares `uses [FileRead]`, the compiler makes the `FileRead` effect's operations available. This design unifies effect tracking with method dispatch: calling `read_file(path)` dispatches to the bound handler for the `FileRead` effect.
 
-Capability aliases remain purely syntactic:
+Effect aliases remain purely syntactic:
 
 ```spore
-capability FileIO = [FileRead, FileWrite]
+effect FileIO = FileRead | FileWrite
 ```
 
-This expands to the union of the two trait-like capabilities and does not define a new trait.
+This expands to the union of the two effects and does not define a new effect.
+
+### 14. Effect handlers
+
+Effect handlers provide concrete implementations for effect operations, enabling testability, mockability, and platform abstraction:
+
+#### Handler definition
+
+```spore
+handler MockConsole for Console {
+    fn println(msg: Str) -> Unit { self.output.push(msg) }
+    fn read_line() -> Str ! IOError { "mock input" }
+}
+
+handler RealFileRead for FileRead {
+    fn read_file(path: String) -> Bytes ! [IoError] {
+        platform.fs.read(path)
+    }
+    fn list_dir(path: String) -> List[String] ! [IoError] {
+        platform.fs.list(path)
+    }
+}
+```
+
+#### Handler binding
+
+The `handle ... with` expression binds a handler to a computation:
+
+```spore
+// Bind a single handler
+handle greet("world") with MockConsole { output: [] }
+
+// Bind multiple handlers
+handle app.run()
+    with RealFileRead {}
+    with MockConsole { output: [] }
+```
+
+#### User-defined effects (allowed from v1)
+
+Users may define their own effects from the first version of Spore:
+
+```spore
+effect RateLimit {
+    fn check_limit(key: Str) -> Bool
+}
+
+handler TokenBucketLimiter(rate: Int, per: Duration) for RateLimit {
+    fn check_limit(key: Str) -> Bool {
+        if self.tokens > 0 { self.tokens -= 1; true }
+        else { false }
+    }
+}
+```
 
 ---
 
@@ -655,13 +707,13 @@ The `uses` clause makes a function's external interactions visible at a glance. 
 
 - **Zero-annotation start.** Newcomers write pure functions with no annotation at all. The `uses` clause appears only when the first side effect is introduced.
 - **Flat model.** There are no effect variables, row types, or higher-kinded constructs to learn. The mental model is "list the things you need."
-- **Familiar concept.** The capability set is analogous to permission declarations in mobile OSes (Android manifest, iOS entitlements), a concept most developers already understand.
+- **Familiar concept.** The effect set is analogous to permission declarations in mobile OSes (Android manifest, iOS entitlements), a concept most developers already understand.
 
 ### Ergonomics
 
-- Capability aliases (`capability DatabaseAccess = [...]`) reduce boilerplate for common groups.
+- Effect aliases (`effect DatabaseAccess = NetRead | NetWrite | ...`) reduce boilerplate for common groups.
 - Auto-inferred properties eliminate the need for manual `pure` / `deterministic` annotations.
-- The compiler provides actionable diagnostics when a function body exceeds its declared capabilities.
+- The compiler provides actionable diagnostics when a function body exceeds its declared effects.
 
 ### Potential friction
 
@@ -672,21 +724,21 @@ The `uses` clause makes a function's external interactions visible at a glance. 
 
 ## Agent experience impact
 
-### Structured capability information in HoleReport
+### Structured effect information in HoleReport
 
-LLM-based agents filling Holes receive the `available_capabilities` field in the JSON `HoleReport`. This enables agents to:
+LLM-based agents filling Holes receive the `available_effects` field in the JSON `HoleReport`. This enables agents to:
 
-1. **Constrain code generation.** The agent knows which operations are permissible and avoids generating code that would fail capability checks.
+1. **Constrain code generation.** The agent knows which operations are permissible and avoids generating code that would fail effect checks.
 2. **Filter candidate functions.** Only functions whose `uses S` satisfies S ⊆ S_available are presented as candidates.
-3. **Self-verify before submission.** The agent can compare its generated code's capability requirements against the available set before proposing a fill.
+3. **Self-verify before submission.** The agent can compare its generated code's effect requirements against the available set before proposing a fill.
 
 ### Deterministic verification
 
-Because capability checking is a simple set-inclusion test, agents can perform the check locally without invoking the full compiler. This enables tight generate-verify loops.
+Because effect checking is a simple set-inclusion test, agents can perform the check locally without invoking the full compiler. This enables tight generate-verify loops.
 
 ### Reduced hallucination surface
 
-The explicit capability set narrows the space of valid completions, reducing the likelihood that an agent generates plausible-looking but capability-violating code.
+The explicit effect set narrows the space of valid completions, reducing the likelihood that an agent generates plausible-looking but effect-violating code.
 
 ---
 
@@ -701,7 +753,7 @@ The canonical serialised form of a function type includes the CapSet:
   "kind": "Fn",
   "params": ["Int", "Int"],
   "return": "Int",
-  "capabilities": [],
+  "effects": [],
   "errors": []
 }
 ```
@@ -711,14 +763,14 @@ The canonical serialised form of a function type includes the CapSet:
   "kind": "Fn",
   "params": ["Url"],
   "return": "Response",
-  "capabilities": ["NetRead"],
+  "effects": ["NetRead"],
   "errors": ["NetworkError"]
 }
 ```
 
-### Capability alias registry
+### Effect alias registry
 
-All capability alias definitions are collected into a structured registry available to tooling:
+All effect alias definitions are collected into a structured registry available to tooling:
 
 ```json
 {
@@ -733,9 +785,9 @@ All capability alias definitions are collected into a structured registry availa
 
 The language server protocol integration should expose:
 
-- Capability set in hover information for functions.
+- Effect set in hover information for functions.
 - Inferred properties (`pure`, `deterministic`, `total`) in hover tooltips.
-- Quick-fix suggestions when a capability violation is detected (e.g., "Add `FileWrite` to the `uses` clause").
+- Quick-fix suggestions when an effect violation is detected (e.g., "Add `FileWrite` to the `uses` clause").
 
 ---
 
@@ -745,29 +797,29 @@ The language server protocol integration should expose:
 
 | Code | Severity | Message template |
 |---|---|---|
-| `cap-violation` | Error | Function body uses capability `{cap}` not declared in `uses` clause. Declared: `{declared}`. Required: `{required}`. Excess: `{excess}`. |
+| `cap-violation` | Error | Function body uses effect `{cap}` not declared in `uses` clause. Declared: `{declared}`. Required: `{required}`. Excess: `{excess}`. |
 | `cap-closure-violation` | Error | Closure passed to `{fn_name}` must be pure (`uses []`), but it uses `{caps}`. |
-| `cap-spawn-missing` | Error | `spawn` expression requires `Spawn` capability, but current scope declares `uses {scope_caps}`. |
+| `cap-spawn-missing` | Error | `spawn` expression requires `Spawn` effect, but current scope declares `uses {scope_caps}`. |
 | `cap-narrowing-violation` | Error | Spawn body uses `{child_caps}` which is not a subset of parent scope `{parent_caps}`. Excess: `{excess}`. |
-| `cap-unknown` | Error | Unknown capability `{name}`. Did you mean `{suggestion}`? |
-| `cap-alias-cycle` | Error | Capability alias `{name}` contains a cycle: `{cycle_path}`. |
-| `cap-redundant` | Warning | Capability `{cap}` is declared but never used in the function body. |
+| `cap-unknown` | Error | Unknown effect `{name}`. Did you mean `{suggestion}`? |
+| `cap-alias-cycle` | Error | Effect alias `{name}` contains a cycle: `{cycle_path}`. |
+| `cap-redundant` | Warning | Effect `{cap}` is declared but never used in the function body. |
 
 ### Diagnostic quality guidelines
 
-1. **Always show the excess set.** When a subset check fails, display exactly which capabilities are missing from the declared set.
-2. **Suggest fixes.** If the fix is to add a capability to the `uses` clause, provide a machine-applicable quick-fix.
-3. **Show expansion.** When an alias is involved, show the expanded form so the user understands which atomic capability caused the violation.
+1. **Always show the excess set.** When a subset check fails, display exactly which effects are missing from the declared set.
+2. **Suggest fixes.** If the fix is to add an effect to the `uses` clause, provide a machine-applicable quick-fix.
+3. **Show expansion.** When an alias is involved, show the expanded form so the user understands which atomic effect caused the violation.
 
 Example diagnostic:
 
 ```text
-error[cap-violation]: function body uses undeclared capability
+error[cap-violation]: function body uses undeclared effect
   --> src/app.spore:12:5
    |
 10 | fn process(data: Data) -> Result
 11 | uses [FileRead]
-   |       ^^^^^^^^ declared capabilities
+   |       ^^^^^^^^ declared effects
 12 |     write_file("out.txt", transform(data))
    |     ^^^^^^^^^^ requires FileWrite
    |
@@ -784,17 +836,17 @@ error[cap-violation]: function body uses undeclared capability
 
 ## Drawbacks
 
-1. **Annotation overhead.** Functions with many capabilities require verbose `uses` clauses. Capability aliases mitigate this but do not eliminate it entirely.
+1. **Annotation overhead.** Functions with many effects require verbose `uses` clauses. Effect aliases mitigate this but do not eliminate it entirely.
 
-2. **No effect polymorphism.** The deliberate omission of effect variables means that generic middleware functions (e.g., `with_timeout`, `retry`) cannot abstract over arbitrary capability sets. Each concrete instantiation must list its capabilities explicitly. This may lead to some code duplication in highly generic library code.
+2. **No effect polymorphism.** The deliberate omission of effect variables means that generic middleware functions (e.g., `with_timeout`, `retry`) cannot abstract over arbitrary effect sets. Each concrete instantiation must list its effects explicitly. This may lead to some code duplication in highly generic library code.
 
 3. **Pure-only closures in combinators.** Requiring `map`/`filter`/`fold` to accept only pure closures is restrictive. The `parallel_scope` + `spawn` workaround is more verbose and requires understanding structured concurrency.
 
-4. **No capability subtraction.** Users cannot write `uses [All \ Spawn]` ("everything except Spawn"). This means that functions needing nearly all capabilities must enumerate them individually.
+4. **No effect subtraction.** Users cannot write `uses [All \ Spawn]` ("everything except Spawn"). This means that functions needing nearly all effects must enumerate them individually.
 
-5. **Alias is expansion only.** Capability aliases do not create new abstract capabilities. This prevents hiding implementation details behind an alias boundary — the caller always sees the expanded set.
+5. **Alias is expansion only.** Effect aliases do not create new abstract effects. This prevents hiding implementation details behind an alias boundary — the caller always sees the expanded set.
 
-6. **String-based CapSet.** Using `BTreeSet<String>` for the internal representation is simple but offers no compile-time interning or efficient bitset operations. This may need revisiting for large-scale codebases with many capabilities.
+6. **String-based CapSet.** Using `BTreeSet<String>` for the internal representation is simple but offers no compile-time interning or efficient bitset operations. This may need revisiting for large-scale codebases with many effects.
 
 ---
 
@@ -802,7 +854,7 @@ error[cap-violation]: function body uses undeclared capability
 
 ### 1. Effect polymorphism (effect variables / row types)
 
-Languages like Koka, Eff, and Frank support effect variables that allow abstracting over capability sets:
+Languages like Koka, Eff, and Frank support effect variables that allow abstracting over effect sets:
 
 ```text
 fn with_timeout[E](f: () -> T uses E) -> T uses [E, Clock]
@@ -810,9 +862,9 @@ fn with_timeout[E](f: () -> T uses E) -> T uses [E, Clock]
 
 **Why rejected:** Effect polymorphism dramatically increases type-inference complexity and produces error messages that are difficult for non-experts to understand. Spore prioritises approachability and agent-friendliness over maximum expressiveness. The flat-set model covers the vast majority of practical use cases. Effect variables may be reconsidered as a future opt-in advanced feature.
 
-### 2. Hierarchical capability model
+### 2. Hierarchical effect model
 
-Some systems organise capabilities into a hierarchy (e.g., `IO > FileIO > FileRead`). A function declaring `uses [IO]` would implicitly have all sub-capabilities.
+Some systems organise effects into a hierarchy (e.g., `IO > FileIO > FileRead`). A function declaring `uses [IO]` would implicitly have all sub-effects.
 
 **Why rejected:** Hierarchies introduce ordering disputes (is `Random` under `IO`?), make alias expansion non-trivial, and complicate subtype checks. The flat model avoids these issues entirely.
 
@@ -824,15 +876,24 @@ An earlier design included a `with [pure, deterministic]` clause for manual prop
 
 ### 4. Effect handlers
 
-Algebraic effect handlers (as in Koka or OCaml 5) allow capabilities to be intercepted and reinterpreted at runtime.
+Algebraic effect handlers (as in Koka or OCaml 5) allow effects to be intercepted and reinterpreted at runtime.
 
-**Why rejected:** Effect handlers require significant runtime support and make compilation and optimisation considerably harder. Spore targets ahead-of-time compilation with predictable performance. Capability checking in Spore is purely static.
+**Why accepted:** Effect handlers provide critical benefits that outweigh their implementation cost:
+
+1. **Testability** — Mock handlers enable deterministic testing of effectful code without special test frameworks.
+2. **Mockability** — Any effect can be replaced with a mock implementation at the call site.
+3. **Platform abstraction** — The same user code runs on different platforms by swapping handlers (e.g., browser vs. server filesystem).
+4. **Colorless functions** — Unlike async/await, effect handlers do not bifurcate the function space.
+
+Spore's handler model is intentionally simpler than full algebraic effects: handlers do not support continuations or resumptions beyond simple `resume()`. This keeps the runtime overhead minimal and compilation straightforward while capturing the most valuable use cases.
+
+Syntax: `effect` defines operations, `handler` provides implementations, `handle ... with` binds handlers at call sites. See §13-14 for full details.
 
 ### 5. Monadic effects (Haskell IO monad)
 
 Encoding effects in the type system via monads (e.g., `IO a`, `State s a`).
 
-**Why rejected:** Monad transformers are notoriously difficult to compose and produce deeply nested types. The flat capability set is simpler and more intuitive for the target audience.
+**Why rejected:** Monad transformers are notoriously difficult to compose and produce deeply nested types. The flat effect set is simpler and more intuitive for the target audience.
 
 ---
 
@@ -840,16 +901,16 @@ Encoding effects in the type system via monads (e.g., `IO a`, `State s a`).
 
 | System | Approach | Relation to this SEP |
 |---|---|---|
-| **Koka** | Algebraic effects with row-polymorphic effect types | Spore takes the same "effects in the type" philosophy but drops polymorphism in favour of flat sets |
-| **Eff** | First-class algebraic effects and handlers | Spore omits handlers entirely; capabilities are static-only |
-| **Rust** | No built-in effect system; `unsafe` is the only capability marker | Spore generalises `unsafe` to a full capability vocabulary |
+| **Koka** | Algebraic effects with row-polymorphic effect types | Spore takes the same "effects in the type" philosophy with flat sets and simplified handlers (no continuations) |
+| **Eff** | First-class algebraic effects and handlers | Spore adopts simplified handlers (no continuations); effects are statically checked with runtime handler dispatch |
+| **Rust** | No built-in effect system; `unsafe` is the only effect marker | Spore generalises `unsafe` to a full effect vocabulary |
 | **Haskell** | `IO` monad, mtl-style monad transformers | Spore replaces monadic encoding with flat set annotation |
-| **OCaml 5** | Algebraic effects for concurrency | Spore's `Spawn` capability is analogous but purely static |
+| **OCaml 5** | Algebraic effects for concurrency | Spore's `Spawn` effect is analogous; Spore adopts simplified handlers without continuations |
 | **Scala (ZIO)** | Environment type `R` in `ZIO[R, E, A]` | Similar in spirit; ZIO's `R` is an intersection type, Spore uses a flat set |
 | **Unison** | Ability types (algebraic effects) | Close conceptual ancestor; Spore simplifies by removing polymorphism |
 | **Android Manifest** | Permission declarations | Same "declare what you need" philosophy at the OS level |
-| **Wasm Component Model** | Import/export capabilities | Static capability declaration before instantiation |
-| **Java (checked exceptions)** | `throws` clause | Spore's `uses` is analogous but tracks capabilities rather than error types |
+| **Wasm Component Model** | Import/export capabilities | Static effect declaration before instantiation |
+| **Java (checked exceptions)** | `throws` clause | Spore's `uses` is analogous but tracks effects rather than error types |
 
 ---
 
@@ -868,53 +929,53 @@ enum Ty {
     Int,
     Bool,
     String,
-    Fn(Vec<Ty>, Box<Ty>, CapSet),  // params, return, capabilities
+    Fn(Vec<Ty>, Box<Ty>, CapSet),  // params, return, effects
     // ...
 }
 ```
 
 ### Future extensibility
 
-- **New atomic capabilities.** New capabilities (e.g., `GpuAccess`, `Audit`) can be added to the universe **E** without breaking existing code — functions that do not use them are unaffected.
-- **Platform capability ceilings.** A future SEP on the platform system may define module-level capability ceilings. Functions within such modules would be required to have `uses S` where S ⊆ S_platform_ceiling.
+- **New atomic effects.** New effects (e.g., `GpuAccess`, `Audit`) can be added to the universe **E** without breaking existing code — functions that do not use them are unaffected.
+- **Platform effect ceilings.** A future SEP on the platform system may define module-level effect ceilings. Functions within such modules would be required to have `uses S` where S ⊆ S_platform_ceiling.
 - **Effect variables (possible future SEP).** If demand arises for effect polymorphism, it can be introduced as an opt-in feature layered on top of the flat-set foundation without invalidating existing code.
 
 ---
 
 ## Unresolved questions
 
-### 1. Capability subtraction syntax
+### 1. Effect subtraction syntax
 
-Should Spore support a subtraction syntax such as `uses [All \ Spawn]`? This depends on the definition of the universal set **E**, which may vary across platforms. Current decision: **not supported**. Developers must enumerate capabilities explicitly.
+Should Spore support a subtraction syntax such as `uses [All \ Spawn]`? This depends on the definition of the universal set **E**, which may vary across platforms. Current decision: **not supported**. Developers must enumerate effects explicitly.
 
-### 2. Platform capability ceilings
+### 2. Platform effect ceilings
 
 How does a module-level `platform [Web]` declaration interact with function-level `uses` clauses? Two options:
 
-- **Intersection model:** The effective capability set is `S_function ∩ S_platform`.
+- **Intersection model:** The effective effect set is `S_function ∩ S_platform`.
 - **Constraint model:** The compiler checks `S_function ⊆ S_platform` and rejects violations.
 
 The constraint model (static rejection) is preferred but needs formal specification.
 
-### 3. Capability scoping and imports
+### 3. Effect scoping and imports
 
-Can third-party libraries define new atomic capabilities? If so, how are they scoped and imported? Should there be a namespace mechanism (`mylib::MyCapability`)?
+Can third-party libraries define new atomic effects? If so, how are they scoped and imported? Should there be a namespace mechanism (`mylib::MyEffect`)?
 
-### 4. Granularity of file-system capabilities
+### 4. Granularity of file-system effects
 
-Is `FileRead` / `FileWrite` the right granularity, or should capabilities be path-scoped (e.g., `FileRead("/etc/config")`)? Path-scoping adds expressiveness but complicates the set algebra.
+Is `FileRead` / `FileWrite` the right granularity, or should effects be path-scoped (e.g., `FileRead("/etc/config")`)? Path-scoping adds expressiveness but complicates the set algebra.
 
 ### 5. Relationship between `Compute` and `uses []`
 
 Currently `uses []` implies pure, and `uses [Compute]` allows non-trivial computation. Should `Compute` be implicit in all functions (since all functions compute), or should it be reserved for functions that perform expensive computation? The distinction matters for the cost model.
 
-### 6. Capability evolution and deprecation
+### 6. Effect evolution and deprecation
 
-When an atomic capability is deprecated or split (e.g., `FileIO` split into `FileRead` + `FileWrite`), what migration tooling is needed? Should the compiler support `@deprecated` annotations on capability definitions?
+When an atomic effect is deprecated or split (e.g., `FileIO` split into `FileRead` + `FileWrite`), what migration tooling is needed? Should the compiler support `@deprecated` annotations on effect definitions?
 
 ### 7. Interaction with generics
 
-How do generic type parameters interact with capability sets? For example:
+How do generic type parameters interact with effect sets? For example:
 
 ```spore
 fn apply[T, R](f: (T) -> R, x: T) -> R {
@@ -922,11 +983,11 @@ fn apply[T, R](f: (T) -> R, x: T) -> R {
 }
 ```
 
-This currently works only with pure `f`. If `f` has capabilities, should `apply` need to declare them? Without effect polymorphism, the answer is that `apply` must be specialised for each capability set, which may require monomorphisation or overloading.
+This currently works only with pure `f`. If `f` has effects, should `apply` need to declare them? Without effect polymorphism, the answer is that `apply` must be specialised for each effect set, which may require monomorphisation or overloading.
 
-### 8. Runtime capability tokens
+### 8. Runtime effect tokens
 
-Should capability tokens have a runtime representation (e.g., for dependency injection in tests), or are they purely a compile-time concept? A hybrid model where capabilities are erased by default but can be reified for testing purposes may be desirable.
+Should effect tokens have a runtime representation (e.g., for dependency injection in tests), or are they purely a compile-time concept? A hybrid model where effects are erased by default but can be reified for testing purposes may be desirable.
 
 ---
 
@@ -934,15 +995,15 @@ Should capability tokens have a runtime representation (e.g., for dependency inj
 
 | # | Notation | Meaning |
 |---|----------|---------|
-| 1 | **E** | Universe of atomic capabilities |
-| 2 | S, S₁, S₂ | Capability sets (finite subsets of **E**) |
-| 3 | {} or ∅ | Empty capability set (pure function) |
+| 1 | **E** | Universe of atomic effects |
+| 2 | S, S₁, S₂ | Effect sets (finite subsets of **E**) |
+| 3 | {} or ∅ | Empty effect set (pure function) |
 | 4 | S₁ ⊆ S₂ | S₁ is a subset of S₂ |
 | 5 | S₁ ∪ S₂ | Union of S₁ and S₂ |
 | 6 | S₁ ∩ S₂ | Intersection of S₁ and S₂ |
-| 7 | (T → R uses S) | Function type: parameter T, return R, capability set S |
-| 8 | Γ; S ⊢ e : T | Typing judgement: under context Γ and capability set S, expression e has type T |
-| 9 | 𝒫(prop, S) | Property inference function: determines property `prop` from capability set S |
+| 7 | (T → R uses S) | Function type: parameter T, return R, effect set S |
+| 8 | Γ; S ⊢ e : T | Typing judgement: under context Γ and effect set S, expression e has type T |
+| 9 | 𝒫(prop, S) | Property inference function: determines property `prop` from effect set S |
 | 10 | <: | Subtype relation |
 | 11 | (C, A, W, P) | Four-dimensional cost vector: compute(op), alloc(cell), io(call), parallel(lane) |
-| 12 | `capability C = [A₁, ..., Aₙ]` | Named alias definition expanding to a flat set of atomic capabilities |
+| 12 | `effect C = A₁ | A₂ | ... | Aₙ` | Named alias definition expanding to a flat set of atomic effects |

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -25,7 +25,7 @@ This proposal defines the concurrency model for the Spore programming language. 
 
 1. **Structured concurrency** — all concurrent tasks form a tree rooted in `parallel_scope`; no raw thread spawning, no `GlobalScope` escape hatches.
 2. **Effect handlers** — `Spawn` is a standard effect, not a keyword. Different handlers provide real parallelism, sequential testing execution, or compile-time cost simulation—without changing user code.
-3. **Capability narrowing** — a child task's capability set must be a subset of its parent's (`child.uses ⊆ parent.uses`), enforced at compile time.
+3. **Effect narrowing** — a child task's effect set must be a subset of its parent's (`child.uses ⊆ parent.uses`), enforced at compile time.
 4. **Cost budgets with a parallel dimension** — the cost model gains a fourth dimension `parallel(lane)` that the compiler statically tracks and verifies.
 
 The core formula is:
@@ -69,7 +69,7 @@ Structured concurrency, as articulated by Nathaniel J. Smith (*"Go statement con
 
 Raw threads are excluded for fundamental reasons:
 
-- They bypass the capability system: any thread can perform any operation.
+- They bypass the effect system: any thread can perform any operation.
 - They make cost analysis intractable: the compiler cannot statically enumerate an unbounded thread graph.
 - They conflict with Spore's philosophy of *"the compiler sees everything"*.
 
@@ -161,7 +161,7 @@ let response: Response = task.await
 
 `spawn` is **not** a standalone statement—it is always bound to an enclosing `parallel_scope`. Any `Task` not awaited when the scope exits is automatically cancelled.
 
-Capability narrowing is available at the spawn site:
+Effect narrowing is available at the spawn site:
 
 ```spore
 let task = spawn uses [NetRead] { fetch(url) }
@@ -317,7 +317,7 @@ uses [ChanRecv[Command], ChanRecv[Event], ChanRecv[Unit], Spawn]
 ### 3.7 Complete example: HTTP request handler
 
 ```spore
-capability HttpHandler = [Spawn, NetRead, NetWrite, DbRead, Clock]
+effect HttpHandler = Spawn | NetRead | NetWrite | DbRead | Clock
 
 fn handle_request(req: Request) -> Response ! [DbError, Timeout]
 cost ≤ 5000
@@ -417,7 +417,7 @@ main()
 The compiler builds this static task tree at compile time and uses it for:
 
 - Cost budget allocation verification
-- Capability set inheritance checking
+- Effect set inheritance checking
 - Lane consumption calculation
 
 #### `parallel_scope` formal semantics
@@ -455,7 +455,7 @@ Constraints:
 
 - `spawn` may only appear lexically inside a `parallel_scope`.
 - The enclosing function must declare `uses [Spawn]`.
-- Capability narrowing: `spawn uses [C₁, C₂] { e }` requires `{C₁, C₂} ⊆ parent.uses`.
+- Effect narrowing: `spawn uses [C₁, C₂] { e }` requires `{C₁, C₂} ⊆ parent.uses`.
 
 #### Error propagation
 
@@ -543,16 +543,16 @@ handler token_bucket_handler(rate: Int, per: Duration) for RateLimit {
 }
 ```
 
-#### Relationship between effects and capabilities
+#### Relationship between effects and the `uses` clause
 
-| Dimension | Capability (`uses [...]`) | Effect (`effect Foo`) |
+| Dimension | `uses [...]` clause | `effect` definition |
 |-----------|--------------------------|----------------------|
-| Definition layer | Signature metadata, compiler-verified | An operation interceptable by a handler |
-| Semantics | "What this function may do" | "How this operation is executed" |
-| Verification | Compile-time capability set check | Compile-time + handler binding time |
+| Definition layer | Signature metadata, compiler-verified | Declares operations interceptable by a handler |
+| Semantics | "What effects this function may perform" | "What operations this effect provides" |
+| Verification | Compile-time effect set check | Compile-time + handler binding time |
 | Example | `uses [Spawn]` permits calling `spawn` | `effect Spawn { fn spawn... }` defines the operation |
 
-Every effect automatically becomes a capability. Declaring `uses [Spawn]` is equivalent to "this function may perform the `Spawn` effect".
+Declaring `uses [Spawn]` means "this function may perform the `Spawn` effect". The `effect` keyword defines both the operations and makes the effect available for use in `uses` clauses.
 
 ### 4.3 Channel types
 
@@ -954,7 +954,7 @@ The replaceable handler model means concurrent code can be tested with `Sequenti
 
 Because the task tree mirrors the lexical scope tree, error messages and stack traces preserve the full causal chain from the spawning point to the failure point. This eliminates the "lost context" problem common in fire-and-forget concurrency.
 
-### Explicit capabilities as documentation
+### Explicit effects as documentation
 
 When a function signature says `uses [Spawn, NetRead]`, a human reader immediately knows the function is concurrent and performs network reads. This serves as machine-checked documentation.
 
@@ -982,9 +982,9 @@ Agents can use `sporec --query-cost` to obtain the parallel lane usage and total
 
 The constrained concurrency model (`parallel_scope` + `spawn` only, no raw threads) makes it significantly easier for agents to generate correct concurrent code. The structured scoping rules eliminate entire classes of concurrency bugs (leaked tasks, use-after-free in concurrent contexts) that agents are otherwise prone to producing.
 
-### Capability narrowing for safe delegation
+### Effect narrowing for safe delegation
 
-When an agent generates a spawned task, it can narrow the capability set (`spawn uses [NetRead] { ... }`), providing a compile-time guarantee that the generated subtask cannot exceed its intended permissions—a form of least-privilege that is checkable at compile time.
+When an agent generates a spawned task, it can narrow the effect set (`spawn uses [NetRead] { ... }`), providing a compile-time guarantee that the generated subtask cannot exceed its intended permissions—a form of least-privilege that is checkable at compile time.
 
 ---
 
@@ -1020,9 +1020,9 @@ At the application boundary (the `main` function or service entry point), handle
 
 | Spore subsystem | Interaction with the concurrency model |
 |-----------------|---------------------------------------|
-| Signature syntax | `uses [Spawn, ...]` declares concurrency capability; `cost ≤ N` bounds total cost |
+| Signature syntax | `uses [Spawn, ...]` declares concurrency effect; `cost ≤ N` bounds total cost |
 | Cost model | Fourth dimension `parallel(lane)` defined by this SEP |
-| Capability system | `Spawn` is a built-in capability; child task capabilities ⊆ parent |
+| Effect system | `Spawn` is a built-in effect; child task effects ⊆ parent |
 | Effect annotations | `pure` excludes `Spawn`; `deterministic` + `Spawn` requires schedule-independent results |
 | Hole system | Concurrent holes participate in cost budget analysis |
 | Platform | Platform provides production `Spawn` handler implementations |
@@ -1038,11 +1038,11 @@ The compiler reports the following concurrency-related diagnostics:
 | Diagnostic | Severity | Example |
 |------------|----------|---------|
 | `spawn` outside `parallel_scope` | Error | `spawn { ... }` at top level |
-| Missing `Spawn` capability | Error | Function calls `spawn` but does not declare `uses [Spawn]` |
+| Missing `Spawn` effect | Error | Function calls `spawn` but does not declare `uses [Spawn]` |
 | Lane budget exceeded | Error | `parallel_scope(lanes: 2)` with 5 spawns that cannot queue |
 | Cost budget exceeded due to parallelism | Error | Inferred parallel cost exceeds declared `cost ≤ N` |
 | Long recursion/iteration without cancellation checkpoint | Warning | CPU-bound computation > 100 iterations without `check_cancelled()` |
-| Capability widening in spawn | Error | `spawn uses [NetWrite] { ... }` when parent lacks `NetWrite` |
+| Effect widening in spawn | Error | `spawn uses [NetWrite] { ... }` when parent lacks `NetWrite` |
 | Unused `Task` (never awaited, never cancelled) | Warning | Task result is silently discarded |
 
 ### Runtime diagnostics
@@ -1090,7 +1090,7 @@ This timeline can be rendered as a Gantt chart, flame graph, or task dependency 
 
 ### Alternative 2: Green threads (Go, Java Loom)
 
-**Rejected.** Green threads are colorless (good) but lack effect tracking (bad). Any goroutine can perform any operation, violating Spore's capability constraint model. Additionally, goroutine leaks (Go's well-known problem) directly violate the resource safety guarantee.
+**Rejected.** Green threads are colorless (good) but lack effect tracking (bad). Any goroutine can perform any operation, violating Spore's effect constraint model. Additionally, goroutine leaks (Go's well-known problem) directly violate the resource safety guarantee.
 
 **Consequences of rejection:** Spore cannot easily adopt existing Go-style runtime implementations. The effect handler approach requires a custom runtime that understands continuations.
 
@@ -1172,7 +1172,7 @@ The concurrency model is introduced as a new language feature. There is no exist
 
 ### Interaction with existing SEPs
 
-- **SEP-0001 (Core Syntax, extended by SEP-0003 for capabilities):** The `uses [Spawn, ...]` clause and `cost ≤ N` declarations are extensions to the signature syntax defined in SEP-0001, with capability annotations from SEP-0003. No breaking changes to existing signatures are required; `uses` and `cost` are additive clauses.
+- **SEP-0001 (Core Syntax, extended by SEP-0003 for effects):** The `uses [Spawn, ...]` clause and `cost ≤ N` declarations are extensions to the signature syntax defined in SEP-0001, with effect annotations from SEP-0003. No breaking changes to existing signatures are required; `uses` and `cost` are additive clauses.
 - **SEP-0004 (Cost Model):** This SEP adds the fourth dimension `parallel(lane)` to the cost model. Existing cost annotations (which only use `C`, `A`, `W`) remain valid; the `P` dimension defaults to `0` for functions without `Spawn`.
 
 ### Migration path for developers from other languages
@@ -1237,7 +1237,7 @@ let task = spawn { <expr> }
 // Direct await
 let result = spawn { <expr> }.await
 
-// With capability narrowing
+// With effect narrowing
 let task = spawn uses [NetRead] { <expr> }
 ```
 
@@ -1331,7 +1331,7 @@ uses [Spawn, Channel, ...]
 ### A.9 Complete example: HTTP handler
 
 ```spore
-capability HttpHandler = [Spawn, NetRead, NetWrite, DbRead, Clock]
+effect HttpHandler = Spawn | NetRead | NetWrite | DbRead | Clock
 
 fn handle_request(req: Request) -> Response ! [DbError, Timeout]
 cost ≤ 5000


### PR DESCRIPTION
## Proposal summary

- Restack the keyword redesign on top of the merged intent-oriented effect taxonomy from PR #14.
- Keep the `trait` / `effect` / `handler` split and the `handle ... with` surface syntax direction.
- Move concrete grammar back toward SEP-0001 so SEP-0002, SEP-0003, and SEP-0007 reference the core syntax spec instead of re-specifying it.
- Align examples, aliases, HoleReport/protocol fields, and concurrency examples with the current effect vocabulary (`Console`, `Env`, `NetConnect`, `NetListen`, etc.).

## Linked discussion

- Primary: https://github.com/spore-lang/spore-evolution/discussions/3
- Related context: https://github.com/spore-lang/spore-evolution/discussions/1, https://github.com/spore-lang/spore-evolution/discussions/2, https://github.com/spore-lang/spore-evolution/discussions/7

## Pre-submission checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.

## Proposal checklist

- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

This branch now includes the capability/effect taxonomy from PR #14 plus the keyword/syntax cleanup from this PR. Review focus should be whether SEP-0001 is now the primary home for surface syntax and whether SEP-0002 / SEP-0003 / SEP-0007 read consistently after the merge.
