### PR TITLE
📝 SEP-0001/0003: centralize effect grammar surface

### DIFF
--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -487,6 +487,8 @@ Key design properties:
 - **Current amendment scope**: This amendment defines `spec` for ordinary function declarations and `impl` methods with bodies. Trait-method `spec` syntax and inheritance semantics are deferred to a later amendment.
 - **MissingSpec warning**: `pub` functions without a `spec` block emit a compiler warning (not error), encouraging behavioral documentation without forcing it.
 
+Effect operations and handler binding are also centralized here. `perform` is a reserved keyword for effect-operation expressions. `handle` accepts one or more `with` clauses. SEP-0003 defines the effect algebra and handler semantics; this SEP only fixes the settled outer syntax. The grammar intentionally leaves each handler operand as an expression because the richer handler/`handle` model is still pending the item-3 decision.
+
 ### Struct and type definitions
 
 ```spore
@@ -681,6 +683,7 @@ The complete reserved keyword table:
 | `trait` | Type interface definition (trait) |
 | `effect` | Effect definition / effect alias |
 | `handler` | Effect handler implementation |
+| `perform` | Invoke an effect operation |
 | `impl` | Trait implementation block |
 | `pub` / `pub(pkg)` | Visibility modifiers (public / package-visible) |
 | `module` | Module definition |
@@ -830,6 +833,8 @@ t"Dear {customer}, order {id}"    // template string
 
 ### EBNF Grammar
 
+For effect handling, the settled outer grammar is `perform <expr>` and `handle <expr>` followed by one or more `with <handler-expr>` clauses. The handler side remains expression-shaped here until the richer handler model is finalized.
+
 ```ebnf
 (* ═══════════════════════════════════════════════════ *)
 (*  Spore v0.1 — Complete EBNF Grammar                *)
@@ -912,7 +917,10 @@ EffectAlias     = Ident { "|" Ident } ;
 HandlerDecl     = "handler" Ident [ "(" ParamList ")" ] "for" Ident
                   "{" { FunctionDecl } "}" ;
 
-HandleExpr      = "handle" Expr "with" Expr ;
+PerformExpr     = "perform" Expr ;
+
+HandleExpr      = "handle" Expr HandlerClause { HandlerClause } ;
+HandlerClause   = "with" Expr ;
 
 (* ─── Impl (Trait Implementation) ─────────────────── *)
 
@@ -997,6 +1005,7 @@ Expr            = LetExpr
                 | LambdaExpr
                 | ReturnExpr
                 | ThrowExpr
+                | PerformExpr
                 | SpawnExpr
                 | SelectExpr
                 | ParallelScopeExpr

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -714,7 +714,7 @@ handler RealFileRead for FileRead {
 
 #### Handler binding
 
-The `handle ... with` expression binds a handler to a computation:
+The `handle ... with` expression binds one or more handler expressions to a computation. SEP-0001 fixes the settled outer grammar as `handle <expr>` followed by one or more `with <handler-expr>` clauses; the richer handler model remains under item-3 discussion.
 
 ```spore
 // Bind a single handler


### PR DESCRIPTION
## Proposal summary

- Reserve `perform` in SEP-0001 and add it to the core expression grammar.
- Fix the settled outer `handle <expr> with <handler-expr>+` grammar in SEP-0001 so subsystem SEPs can reference it instead of re-specifying it.
- Update SEP-0003 handler binding text to point back to SEP-0001 while leaving the richer handler model to item 3.

## Linked discussion

- Primary: https://github.com/spore-lang/spore-evolution/discussions/3
- Related context: https://github.com/spore-lang/spore-evolution/discussions/7

## Pre-submission checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.

## Proposal checklist

- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

This is the narrow item-4 follow-up from the PR14/PR15 merge: it centralizes the settled `perform` / `handle ... with` surface grammar in SEP-0001 and reduces SEP-0003 to a semantic cross-reference while the richer handler model remains pending item 3.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
