### PR TITLE
👷 ci: standardize zendev checks across spore-evolution

### DIFF
--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Check PR title
-        uses: zrr1999/zendev/.github/actions/validate-title@97cdfad7f11bfb4d4b4fc3a09769b3d8494600a5
+        uses: zrr1999/zendev/.github/actions/validate-title@086b8b6059bc680c356726b5955780aab532fa05
         with:
           text: ${{ github.event.pull_request.title }}
 

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -28,13 +28,31 @@ jobs:
     name: PR template
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.12"
-
       - name: Validate PR template checklist
-        run: uv run scripts/check_pr_template.py
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          REQUIRED_CHECKBOXES = [
+              "- [x] I linked the canonical discussion thread.",
+              "- [x] I used the correct SEP template for this proposal type.",
+              "- [x] I updated front matter metadata and required sections.",
+          ]
+
+          payload = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          body = (payload.get("pull_request") or {}).get("body") or ""
+          missing = [item for item in REQUIRED_CHECKBOXES if item not in body]
+
+          if missing:
+              print("Pull request body is missing required checked items:\n", file=sys.stderr)
+              for item in missing:
+                  print(f"- {item}", file=sys.stderr)
+              raise SystemExit(1)
+
+          print("Pull request template checklist looks good.")
+          PY

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Check PR title
-        uses: zrr1999/zendev/.github/actions/validate-title@e2a5243899467d0df1cb1ab0ddcb18f3ef33d97b
+        uses: zrr1999/zendev/.github/actions/validate-title@97cdfad7f11bfb4d4b4fc3a09769b3d8494600a5
         with:
           text: ${{ github.event.pull_request.title }}
 

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Check PR title
-        uses: zrr1999/zendev/.github/actions/validate-title@086b8b6059bc680c356726b5955780aab532fa05
+        uses: zrr1999/zendev-actions/validate-title@9013ad848b32d287d0258fdbc9f51e350b8eca33
         with:
           text: ${{ github.event.pull_request.title }}
 

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -1,0 +1,40 @@
+name: "CI - PR Checks"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    name: PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check PR title
+        uses: zrr1999/zendev/.github/actions/validate-title@e2a5243899467d0df1cb1ab0ddcb18f3ef33d97b
+        with:
+          text: ${{ github.event.pull_request.title }}
+
+  pr-template:
+    name: PR template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Validate PR template checklist
+        run: uv run scripts/check_pr_template.py

--- a/.github/workflows/ci-static-checks.yml
+++ b/.github/workflows/ci-static-checks.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   prek:
     name: prek

--- a/.github/workflows/ci-static-checks.yml
+++ b/.github/workflows/ci-static-checks.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -35,20 +37,3 @@ jobs:
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_TOKEN: ${{ github.token }}
-
-  pr-template:
-    name: pr template
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.12"
-
-      - name: Validate PR template checklist
-        run: uv run scripts/check_pr_template.py

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,37 @@
+name: "CI - Tests"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repo-checks:
+    name: repo-checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Check SEP index
+        run: uv run scripts/check_sep_index.py
+
+      - name: Validate SEP documents
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: uv run scripts/validate_sep_documents.py

--- a/prek.toml
+++ b/prek.toml
@@ -52,7 +52,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/zrr1999/zendev"
-rev = "v0.0.4"
+rev = "e2a5243899467d0df1cb1ab0ddcb18f3ef33d97b"
 hooks = [
   { id = "zendev-commit-msg" },
 ]


### PR DESCRIPTION
## Summary

Bring `spore-evolution` onto the same zendev-style CI shape used across the ecosystem while preserving SEP-specific validation.

### What changed
- pin `zendev-commit-msg` to the merged strict-emoji revision
- keep `CI - Static Checks` focused on `prek`
- add `CI - Tests` for SEP index and document validation
- add `CI - PR Checks` for PR title and PR-template enforcement
- harden PR-template validation so the gate lives in immutable workflow code, not mutable PR code
- add explicit read-only permissions to static checks

### Local validation
- `uvx prek run --all-files`
- `uv run scripts/check_sep_index.py`
- `GITHUB_BASE_REF=main uv run scripts/validate_sep_documents.py`

### Checklist
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

This keeps the zendev workflow shape consistent across repos without flattening away docs-repo-specific checks.
