### PR TITLE
📝 docs: apply syntax unification decisions across SEPs

### DIFF
--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -244,7 +244,7 @@ type FileError =
     | PermissionDenied(path: String)
     | IoError(message: String);
 
-fn read_config(path: String) -> Config ! [FileError, ParseError] {
+fn read_config(path: String) -> Config ! FileError | ParseError {
     let content = read_file(path)?;     // propagates FileError
     let config = parse_toml(content)?;  // propagates ParseError
     config
@@ -256,7 +256,7 @@ fn read_config(path: String) -> Config ! [FileError, ParseError] {
 When a function's error set differs from a callee's, Spore can automatically convert errors if a conversion exists:
 
 ```spore
-fn load_config(path: String) -> Config ! [ConfigError] {
+fn load_config(path: String) -> Config ! ConfigError {
     let content = read_file(path)?;       // FileError -> ConfigError (auto-converted)
     let config = parse_toml(content)?;    // ParseError -> ConfigError (auto-converted)
     config
@@ -279,8 +279,8 @@ fn get_config() -> Config {
 }
 
 // Retry with tail recursion (TCO guaranteed)
-fn fetch_with_retry(url: String, max_retries: Int) -> Data ! [NetworkError] {
-    fn retry(url: String, attempts: Int, max: Int) -> Data ! [NetworkError] {
+fn fetch_with_retry(url: String, max_retries: Int) -> Data ! NetworkError {
+    fn retry(url: String, attempts: Int, max: Int) -> Data ! NetworkError {
         match fetch(url) {
             Ok(data) => data,
             Err(NetworkError.Timeout) if attempts < max => {
@@ -322,7 +322,7 @@ fn identity[T](x: T) -> T {
 The full signature order is:
 
 ```text
-fn name[T](params) -> ReturnType ! [ErrorSet]
+fn name[T](params) -> ReturnType ! ErrorSet
 where T: Bound
 uses [effects]
 cost ≤ N
@@ -344,12 +344,12 @@ fn add(a: Int, b: Int) -> Int {
 }
 
 // 2. Function with errors
-fn parse_int(input: String) -> Int ! [InvalidFormat] {
+fn parse_int(input: String) -> Int ! InvalidFormat {
     ...
 }
 
 // 3. With generic constraints and behavioral spec
-fn serialize[T](value: T) -> Bytes ! [SerializeError]
+fn serialize[T](value: T) -> Bytes ! SerializeError
 where T: Serialize
 cost ≤ 500
 spec {
@@ -361,7 +361,7 @@ spec {
 
 // 4. Side-effectful function with intent examples
 /// @idempotent
-fn sync_user_data(user_id: UserId, source: DataSource) -> SyncReport ! [NetworkTimeout, AuthExpired]
+fn sync_user_data(user_id: UserId, source: DataSource) -> SyncReport ! NetworkTimeout | AuthExpired
 uses [NetConnect, FileRead, Clock]
 cost ≤ 8500
 spec {
@@ -393,7 +393,7 @@ trait Display {
 }
 
 trait Serialize {
-    fn serialize(self) -> Bytes ! [SerializeError]
+    fn serialize(self) -> Bytes ! SerializeError
 }
 
 // effect: external world operations
@@ -406,6 +406,8 @@ effect Console {
 effect HttpClient = NetConnect | Clock
 effect CLI = Console | FileRead | FileWrite | Env | Spawn | Exit
 ```
+
+Effect operations and handler binding are also centralized here. `perform` is a reserved keyword for effect-operation expressions. `handle` accepts one or more `with` clauses. SEP-0003 defines the effect algebra and handler semantics; this SEP only fixes the settled outer syntax. The grammar intentionally leaves each handler operand as an expression because the richer handler/`handle` model is still pending the item-3 decision.
 
 The `uses` clause declares what effects a function requires. The compiler **auto-infers** effect properties from this set:
 
@@ -420,13 +422,13 @@ The `idempotent` property cannot be inferred and is annotated via doc comment: `
 The `uses` clause can mix atomic effect names with named effect aliases:
 
 ```spore
-fn query_database(sql: String) -> Data ! [DbError, Timeout]
+fn query_database(sql: String) -> Data ! DbError | Timeout
 uses [NetConnect]
 {
     ...
 }
 
-fn run_cli(config_path: String) -> Unit ! [Error]
+fn run_cli(config_path: String) -> Unit ! Error
 uses [CLI]
 {
     ...
@@ -468,7 +470,7 @@ example "handles leap year" {
 **`property` items** express universally quantified assertions using explicitly typed lambda syntax. The compiler generates random inputs for property-based testing:
 
 ```spore
-fn parse_date(s: String) -> Result[Date, ParseError] ! [ParseError]
+fn parse_date(s: String) -> Result[Date, ParseError] ! ParseError
 spec {
     example "ISO 8601":          parse_date("2024-01-15") == Ok(Date(2024, 1, 15))
     example "rejects ambiguous": parse_date("01/15/24")   == Err(AmbiguousFormat)
@@ -506,7 +508,7 @@ impl Display for User {
 }
 
 impl Serialize for User {
-    fn serialize(self) -> String ! [SerializeError] {
+    fn serialize(self) -> String ! SerializeError {
         ...
     }
 }
@@ -846,7 +848,6 @@ Program         = { TopLevelItem } ;
 
 TopLevelItem    = ImportDecl
                 | AliasDecl
-                | ModuleDecl
                 | StructDecl
                 | TypeDecl
                 | TraitDecl
@@ -859,13 +860,13 @@ TopLevelItem    = ImportDecl
 (* ─── Imports & Aliases ───────────────────────────── *)
 
 ImportDecl      = "import" ImportPath [ "as" Ident ] ";" ;
-ImportPath      = Ident { "." Ident } [ "." "{" Ident { "," Ident } "}" ] ;
+ImportPath      = Ident { "." Ident } ;
 
 AliasDecl       = "alias" Ident "=" QualifiedIdent ";" ;
 
 (* ─── Module ──────────────────────────────────────── *)
-
-ModuleDecl      = "module" Ident [ UsesClause ] "{" { TopLevelItem } "}" ;
+(* REMOVED (D7): Module names are derived from file paths (see SEP-0008).
+   The `module` keyword is not part of the surface syntax. *)
 
 (* ─── Struct ──────────────────────────────────────── *)
 
@@ -954,7 +955,7 @@ TypeParam       = Ident
 ParamList       = Param { "," Param } [ "," ] ;
 Param           = Ident ":" TypeExpr ;
 
-ErrorClause     = "!" "[" TypeList "]" ;
+ErrorClause     = "!" TypeExpr { "|" TypeExpr } ;
 
 WhereClause     = { "where" Ident ":" BoundList } ;
 BoundList       = Ident { "+" Ident } ;
@@ -1169,7 +1170,7 @@ BinDigit        = "0" | "1" ;
 The function signature system is the heart of Spore's design. The clauses appear in this canonical order:
 
 ```text
-fn <name>[<generics>](<params>) -> <ReturnType> [! [<ErrorTypes>]]
+fn <name>[<generics>](<params>) -> <ReturnType> [! <ErrorTypes>]
 [where <GenericName>: <Constraint>, ...]
 [uses [<Effect>, ...]]
 [cost ≤ <N>]
@@ -1183,7 +1184,7 @@ fn <name>[<generics>](<params>) -> <ReturnType> [! [<ErrorTypes>]]
 
 1. **`-> ReturnType`** — The return type. Omitted for functions returning `Unit`.
 
-2. **`! [ErrorTypes]`** — The error set. A function with `! [E1, E2]` may produce errors of type `E1` or `E2`. Absence of `!` means the function cannot fail.
+2. **`! ErrorTypes`** — The error set. A function with `! E1 | E2` may produce errors of type `E1` or `E2`. Absence of `!` means the function cannot fail.
 
 3. **`where T: Bound`** — Generic constraints. Multiple bounds use `+` syntax: `where T: Eq + Hash`. Each `where` clause is on its own line.
 
@@ -1313,7 +1314,7 @@ The `@allows` annotation constrains which functions the compiler (or an AI agent
 
 ```spore
 @allows[validate, sanitize, format]
-fn process_input(raw: String) -> String ! [ValidationError] {
+fn process_input(raw: String) -> String ! ValidationError {
     let validated = validate(raw)?;
     let sanitized = sanitize(validated);
     ?final_step  // this hole can only call validate/sanitize/format
@@ -1355,7 +1356,7 @@ When queried (`sporec --query-hole ?name`), the compiler emits a structured repo
   },
   "available_capabilities": ["NetConnect"],
   "candidate_functions": [
-    "payment_gateway.charge(amount: Money, method: PaymentMethod) -> Receipt ! [Declined, InsufficientFunds] uses [NetConnect]"
+    "payment_gateway.charge(amount: Money, method: PaymentMethod) -> Receipt ! Declined | InsufficientFunds uses [NetConnect]"
   ],
   "error_types_to_handle": ["Declined", "InsufficientFunds"],
   "spec": {
@@ -1404,7 +1405,7 @@ type EvalError =
     | TypeError(message: String);
 
 // Evaluator — pure recursion, no loops
-fn eval(expr: Expr, env: Env) -> Int ! [EvalError]
+fn eval(expr: Expr, env: Env) -> Int ! EvalError
 cost ≤ expr_size(expr) * 10
 {
     match expr {
@@ -1446,7 +1447,7 @@ cost ≤ expr_size(expr) * 10
     }
 }
 
-fn eval_binop(op: Op, left: Int, right: Int) -> Int ! [EvalError] {
+fn eval_binop(op: Op, left: Int, right: Int) -> Int ! EvalError {
     match op {
         Add => left + right,
         Sub => left - right,
@@ -1577,7 +1578,7 @@ Spore is designed with AI code generation agents as first-class consumers:
 Function signatures are machine-readable contracts. An agent can extract:
 
 - **Input/output types** from the parameter list and return type
-- **Failure modes** from the `! [ErrorSet]`
+- **Failure modes** from the `! ErrorSet`
 - **Side effect profile** from `uses [...]`
 - **Performance budget** from `cost ≤ N`
 - **Generic requirements** from `where` clauses
@@ -1628,7 +1629,6 @@ The Spore AST is designed as a regular tree with strongly typed nodes. Key node 
 ```text
 Program
 ├── ImportDecl { path, alias? }
-├── ModuleDecl { name, uses, items[] }
 ├── StructDecl { name, type_params[], fields[] }
 ├── ImplDecl { trait, type_params[], target_type, methods[] }
 ├── TypeDecl { name, type_params[], body: TypeAlias | SumType | Refinement }
@@ -1705,7 +1705,7 @@ Spore's explicit syntax enables highly specific error messages:
 error[E0301]: function `fetch_data` uses effect `NetConnect` but does not declare it
   --> src/api.spore:12:5
    |
-12 | fn fetch_data(url: Url) -> Data ! [NetworkError] {
+12 | fn fetch_data(url: Url) -> Data ! NetworkError {
    |    ^^^^^^^^^^ missing `uses` clause
    |
    = help: add `uses [NetConnect]` to the function signature
@@ -1780,7 +1780,7 @@ spec counterexample: `parse_date` — property "round-trip"
 warning[W0501]: public function `parse_date` has no `spec` block
   --> src/dates.spore:3:1
    |
- 3 | pub fn parse_date(s: String) -> Result[Date, ParseError] ! [ParseError] {
+ 3 | pub fn parse_date(s: String) -> Result[Date, ParseError] ! ParseError {
    |        ^^^^^^^^^^ no behavioral contract declared
    |
    = help: add a `spec { example "...": ... }` block before the function body
@@ -1801,7 +1801,7 @@ The parser can recover from common errors:
 
 1. **No loops**: Developers with imperative backgrounds may find the no-loop constraint frustrating initially, especially for simple counting patterns. The learning curve for converting loop-based thinking to recursion + HOFs is non-trivial.
 
-2. **Verbose error sets**: Functions that can fail in many ways produce long `! [E1, E2, E3, ...]` lists. This is deliberate (errors are visible) but can clutter signatures.
+2. **Verbose error sets**: Functions that can fail in many ways produce long `! E1 | E2 | E3 | ...` lists. This is deliberate (errors are visible) but can clutter signatures.
 
 3. **`cost` clause expressiveness**: The cost model is inherently limited — expressing accurate cost bounds for complex algorithms may be impractical. Wrong bounds are worse than no bounds.
 
@@ -1949,7 +1949,7 @@ As this is the initial v0.1 specification, there are no backward compatibility c
 
 11. **Standard effect taxonomy evolution**: SEP-0003 now defines the initial built-in effect vocabulary (`Console`, `FileRead`, `FileWrite`, `NetConnect`, `NetListen`, `Env`, `Spawn`, `Clock`, `Random`, `Exit`). Future SEPs may extend it, but changes should preserve the intent-oriented classification.
 
-12. **Error type subtyping**: If function `f` declares `! [NetworkError]` and function `g` declares `! [NetworkError, ParseError]`, can `g` call `f` directly? How does error set subtyping work?
+12. **Error type subtyping**: If function `f` declares `! NetworkError` and function `g` declares `! NetworkError | ParseError`, can `g` call `f` directly? How does error set subtyping work?
 
 13. **`property` with `uses`**: If a property calls a function that has side effects, what capability scope applies? Current proposal: property items inherit the enclosing function's `uses` set.
 

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -107,9 +107,9 @@ All primitives are nominal — `Int` ≠ `Float` even when their bit patterns co
 **Numeric sub-types via refinement.** Rather than proliferating primitive numeric types (i8, u16, f32, …), Spore uses refinement types on `Int` and `Float`:
 
 ```spore
-type U8  = Int if 0 <= self <= 255
-type I32 = Int if -2147483648 <= self <= 2147483647
-type F32 = Float if self.precision == 32
+type U8  = Int when 0 <= self <= 255
+type I32 = Int when -2147483648 <= self <= 2147483647
+type F32 = Float when self.precision == 32
 ```
 
 Platform effects determine the runtime representation; the type system reasons about logical constraints, and the codegen layer maps to machine types.
@@ -123,7 +123,7 @@ fn add(a: Int, b: Int) -> Int {
     a + b
 }
 
-fn fetch_page(url: String) -> String ! [NetworkError]
+fn fetch_page(url: String) -> String ! NetworkError
 uses [NetConnect]
 cost <= 5000
 {
@@ -142,6 +142,8 @@ fn process(x: Int) -> Int {
 ```
 
 ### 3.3 Struct and enum types
+
+> **Note (N7):** Product types use the `struct` keyword: `struct Point { x: Float, y: Float }`. The `type` keyword is reserved for sum types/ADTs. The examples below use `type` with record syntax for historical reasons; canonical Spore uses `struct` for product types.
 
 Structs are nominal product types:
 
@@ -287,9 +289,9 @@ format_temp(temp: 98.6) // ERROR: expected Celsius, got Float
 Newtypes may have refinements:
 
 ```spore
-type Port = Int if 1 <= self <= 65535
-type NonEmptyString = String if self.len() > 0
-type Latitude = Float if -90.0 <= self <= 90.0
+type Port = Int when 1 <= self <= 65535
+type NonEmptyString = String when self.len() > 0
+type Latitude = Float when -90.0 <= self <= 90.0
 ```
 
 **Type aliases** are transparent — interchangeable with their definition:
@@ -297,7 +299,7 @@ type Latitude = Float if -90.0 <= self <= 90.0
 ```spore
 alias StringList = List[String]
 alias Callback[T] = Fn(event: T) -> Unit
-alias Result[T] = T ! [GenericError]
+alias Result[T] = T ! GenericError
 
 type UserId = String       // newtype: UserId ≠ String (nominal)
 alias UserName = String    // alias: UserName == String (transparent)
@@ -323,7 +325,7 @@ trait Display {
 }
 
 trait Serialize {
-    fn serialize(self) -> Bytes ! [SerializeError]
+    fn serialize(self) -> Bytes ! SerializeError
     cost serialize <= 100
 }
 ```
@@ -381,7 +383,7 @@ cost <= 500
     // implementation
 }
 
-fn serialize_all[T](items: List[T]) -> List[Bytes] ! [SerializeError]
+fn serialize_all[T](items: List[T]) -> List[Bytes] ! SerializeError
 where T: Serialize + Display
 {
     items |> map(|item| item.serialize())
@@ -412,12 +414,12 @@ Concrete surface syntax for `trait`, `effect`, `handler`, and `handle ... with` 
 
 ```spore
 trait Serialize {
-    fn serialize(self) -> Bytes ! [SerializeError]
+    fn serialize(self) -> Bytes ! SerializeError
 }
 
 effect HttpClient = NetConnect | Clock
 
-fn fetch_page(url: Url) -> Response ! [NetworkError]
+fn fetch_page(url: Url) -> Response ! NetworkError
 uses [HttpClient]
 {
     ...
@@ -759,7 +761,7 @@ fn get_name(person: Person) -> String {
 Pattern matching integrates with Spore's row-typed error sets for exhaustive error handling:
 
 ```spore
-fn handle_result(result: Invoice ! [TaxError, ValidationError]) -> String {
+fn handle_result(result: Invoice ! TaxError | ValidationError) -> String {
     match result {
         Ok(invoice) => "Invoice #" ++ show(invoice.id),
         Err(TaxError { region, reason }) => "Tax error in " ++ show(region) ++ ": " ++ reason,
@@ -773,7 +775,7 @@ fn handle_result(result: Invoice ! [TaxError, ValidationError]) -> String {
 `@allows` is a hole-level constraint that limits which functions an Agent may use to fill a specific hole. It provides fine-grained control over Agent behavior without affecting the type system's soundness.
 
 ```spore
-fn process_payment(amount: Money, card: Card) -> Receipt ! [PaymentFailed]
+fn process_payment(amount: Money, card: Card) -> Receipt ! PaymentFailed
 uses [PaymentGateway, AuditLog]
 cost <= 2000
 {
@@ -793,7 +795,7 @@ cost <= 2000
 **Use case — architectural intent**:
 
 ```spore
-fn build_dashboard(org: Org) -> Dashboard ! [DataError]
+fn build_dashboard(org: Org) -> Dashboard ! DataError
 uses [Database, Cache, Analytics]
 cost <= 20000
 {
@@ -854,14 +856,14 @@ fn safe_unwrap[T](opt: Option[T]) -> T {
 
 ### 3.14 Row-type error sets
 
-Spore's `! [Err1, Err2]` is a **closed, row-typed error union**. Error types are themselves enum variants (ADTs), and the `!` syntax computes unions automatically across call chains:
+Spore's `! Err1 | Err2` is a **closed, row-typed error union**. Error types are themselves enum variants (ADTs), and the `!` syntax computes unions automatically across call chains:
 
 ```spore
-fn parse(input: String) -> Ast ! [SyntaxError, EncodingError]
-fn validate(ast: Ast) -> ValidAst ! [TypeError, RangeError]
+fn parse(input: String) -> Ast ! SyntaxError | EncodingError
+fn validate(ast: Ast) -> ValidAst ! TypeError | RangeError
 
 // Error sets union automatically via `?` propagation:
-fn compile(input: String) -> ValidAst ! [SyntaxError, EncodingError, TypeError, RangeError] {
+fn compile(input: String) -> ValidAst ! SyntaxError | EncodingError | TypeError | RangeError {
     let ast = parse(input)?
     validate(ast)?
 }
@@ -878,9 +880,9 @@ type SyntaxError = {
 }
 ```
 
-**Error set subtyping**: A function with error set `! [A]` can be called where `! [A, B]` is expected — the caller's error set is a superset.
+**Error set subtyping**: A function with error set `! A` can be called where `! A | B` is expected — the caller's error set is a superset.
 
-**`?` operator**: Propagates errors, automatically widening the error set. If `f()` returns `T ! [E1]` and `g()` returns `T ! [E2]`, calling both with `?` in the same function requires the enclosing function to declare `! [E1, E2]` (or a superset).
+**`?` operator**: Propagates errors, automatically widening the error set. If `f()` returns `T ! E1` and `g()` returns `T ! E2`, calling both with `?` in the same function requires the enclosing function to declare `! E1 | E2` (or a superset).
 
 ### 3.15 Recursive types
 
@@ -935,7 +937,7 @@ type Tree[T] = {
 |---|---|---|
 | Function parameter types | **Yes** | Gravity center — the signature IS the API |
 | Function return type | **Yes** | Agent reads signatures for synthesis; human reads for understanding |
-| Error sets (`! [...]`) | **Yes** | Error contract — must be visible |
+| Error sets (`! ...`) | **Yes** | Error contract — must be visible |
 | Effect sets (`uses [...]`) | **Yes** | Security boundary — must be visible |
 | Cost bounds (`cost <=`) | **Yes** | Performance contract — must be visible |
 | Struct/type field types | **Yes** | Data definition — must be explicit |
@@ -1505,9 +1507,9 @@ Refinement types are not yet implemented but are a planned extension organized i
 L0 refinements are predicates the compiler can fully evaluate at compile time:
 
 ```spore
-type Port = Int if 1 <= self <= 65535
-type Percentage = Float if 0.0 <= self <= 100.0
-type NonEmptyString = String if self.len() > 0
+type Port = Int when 1 <= self <= 65535
+type Percentage = Float when 0.0 <= self <= 100.0
+type NonEmptyString = String when self.len() > 0
 ```
 
 The decidable predicate language includes:
@@ -1524,7 +1526,7 @@ The decidable predicate language includes:
 Γ ⊢ e ⇒ base_type
 eval(predicate[self ↦ e]) = true
 ────────────────────────────────
-Γ ⊢ e ⇐ base_type if predicate
+Γ ⊢ e ⇐ base_type when predicate
 ```
 
 When the compiler cannot statically evaluate the predicate (e.g., value comes from runtime input), it requires an explicit runtime check via control flow.
@@ -1534,7 +1536,7 @@ When the compiler cannot statically evaluate the predicate (e.g., value comes fr
 L1 uses flow-sensitive abstract interpretation to propagate refinement information:
 
 ```spore
-fn process_port(raw: Int) -> Port ! [InvalidPort] {
+fn process_port(raw: Int) -> Port ! InvalidPort {
     if raw < 1 || raw > 65535 {
         raise InvalidPort { value: raw }
     }
@@ -1901,7 +1903,7 @@ Spore's type system is most directly influenced by Rust:
 ### Liquid Haskell
 
 - Refinement types attached to base types.
-- Spore adopts the refinement syntax (`type Port = Int if ...`) but replaces the SMT backend with decidable predicates (L0) and abstract interpretation (L1).
+- Spore adopts the refinement syntax (`type Port = Int when ...`) but replaces the SMT backend with decidable predicates (L0) and abstract interpretation (L1).
 
 ### TypeScript
 

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -65,7 +65,7 @@ Modern programs interleave pure computation with diverse side effects — file I
 Every Spore function may carry a `uses` clause listing the atomic effects it requires:
 
 ```spore
-fn read_config(path: String) -> Config ! [IoError, ParseError]
+fn read_config(path: String) -> Config ! IoError | ParseError
 uses [FileRead]
 {
     let content = read_file(path)
@@ -158,7 +158,7 @@ Aliases are purely syntactic sugar. After expansion, only atomic effects remain.
 ```spore
 effect HttpClient = NetConnect | Clock
 
-fn query_api(url: Url) -> Data ! [NetworkError]
+fn query_api(url: Url) -> Data ! NetworkError
 uses [HttpClient]
 {
     let response = http.get(url)
@@ -196,7 +196,7 @@ uses [FileWrite]
 When you need side effects during iteration, use the structured concurrency pattern:
 
 ```spore
-fn fetch_all(urls: List[Url]) -> List[Response] ! [NetworkError]
+fn fetch_all(urls: List[Url]) -> List[Response] ! NetworkError
 uses [NetConnect, Spawn]
 {
     parallel_scope {
@@ -280,7 +280,7 @@ The module-level `uses` clause is **optional**. When omitted the compiler auto-i
 The `@allows` annotation constrains which functions an AI agent (or developer) may use to fill a Hole. It acts as a filter on `candidate_functions` in the `HoleReport`:
 
 ```spore
-fn process_input(raw: String) -> SafeInput ! [ValidationError] {
+fn process_input(raw: String) -> SafeInput ! ValidationError {
     @allows[validate, sanitize]
     ?clean_input
 }
@@ -294,8 +294,8 @@ The generated `HoleReport` includes the restriction:
   "expected_type": "SafeInput",
   "allows": ["validate", "sanitize"],
   "candidate_functions": [
-    "validate(raw: String) -> SafeInput ! [ValidationError]",
-    "sanitize(raw: String) -> SafeInput ! [ValidationError]"
+    "validate(raw: String) -> SafeInput ! ValidationError",
+    "sanitize(raw: String) -> SafeInput ! ValidationError"
   ]
 }
 ```
@@ -378,7 +378,7 @@ Expansion is **recursive**: if any $A_i$ is itself an alias, it is expanded unti
 #### 4.1 Complete function type
 
 ```text
-(T₁, T₂, …, Tₙ) -> R  uses S  ! [E₁, E₂, …]
+(T₁, T₂, …, Tₙ) -> R  uses S  ! E₁ | E₂ | …
 ```
 
 where:
@@ -441,7 +441,7 @@ A pure function (`uses {}`) trivially satisfies the deterministic condition beca
 
 ```spore
 /// @idempotent
-fn sync_user(user_id: UserId) -> SyncResult ! [NetworkError]
+fn sync_user(user_id: UserId) -> SyncResult ! NetworkError
 uses [NetConnect, FileRead]
 { ... }
 ```
@@ -600,7 +600,7 @@ When the compiler encounters a Hole (`?name`), the generated `HoleReport` includ
   "available_capabilities": ["NetConnect"],
   "cost_budget": 5000,
   "candidate_functions": [
-    "http.get(url: Url) -> Data ! [NetworkError] uses [NetConnect]"
+    "http.get(url: Url) -> Data ! NetworkError uses [NetConnect]"
   ]
 }
 ```
@@ -660,18 +660,18 @@ Effects are not merely string tags — each effect is a **typed construct** whos
 effect Console {
     fn println(msg: String) -> Unit
     fn eprintln(msg: String) -> Unit
-    fn read_line() -> String ! [IoError]
+    fn read_line() -> String ! IoError
 }
 
 effect FileRead {
-    fn read_file(path: String) -> Bytes ! [IoError]
-    fn list_dir(path: String) -> List[String] ! [IoError]
+    fn read_file(path: String) -> Bytes ! IoError
+    fn list_dir(path: String) -> List[String] ! IoError
 }
 
 effect FileWrite {
-    fn write_file(path: String, data: Bytes) -> Unit ! [IoError]
-    fn create_dir(path: String) -> Unit ! [IoError]
-    fn delete(path: String) -> Unit ! [IoError]
+    fn write_file(path: String, data: Bytes) -> Unit ! IoError
+    fn create_dir(path: String) -> Unit ! IoError
+    fn delete(path: String) -> Unit ! IoError
 }
 
 effect Env {
@@ -703,10 +703,10 @@ handler MockConsole for Console {
 }
 
 handler RealFileRead for FileRead {
-    fn read_file(path: String) -> Bytes ! [IoError] {
+    fn read_file(path: String) -> Bytes ! IoError {
         platform.fs.read(path)
     }
-    fn list_dir(path: String) -> List[String] ! [IoError] {
+    fn list_dir(path: String) -> List[String] ! IoError {
         platform.fs.list(path)
     }
 }

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -114,7 +114,7 @@ fn tree_sum(tree: Tree<Int>) -> Int {
 When the compiler cannot automatically detect structural recursion but you know the cost is bounded, declare it:
 
 ```spore
-fn merge_sort<T>(list: List<T>) -> List<T>
+fn merge_sort[T](list: List[T]) -> List[T]
     where T: Ord
     decreases len(list)
     cost ≤ len(list) * log(len(list)) * 5 + len(list)
@@ -150,7 +150,7 @@ fn collatz_steps(n: Int) -> Int {
 `@unbounded` functions cannot be called directly from `cost ≤ K` functions. To bridge the boundary, use a runtime cost limiter:
 
 ```spore
-fn safe_collatz(n: Int) -> Int ! [CostExceeded]
+fn safe_collatz(n: Int) -> Int ! CostExceeded
     cost ≤ 10000
 {
     with_cost_limit(10000) {
@@ -759,7 +759,7 @@ These fallback steps only convert FAIL → PASS, never the reverse.
 Four-dimensional cost declarations are verified **independently per dimension**:
 
 ```spore
-fn sort<T>(items: List<T, max: n>) -> List<T, max: n>
+fn sort[T](items: List[T, max: n]) -> List[T, max: n]
     where T: Ord
     cost ≤ {compute: n * log(n) * 3, alloc: n, io: 0, parallel: 1}
 ```
@@ -773,7 +773,7 @@ When using scalar `cost ≤ K`, the compiler first computes symbolic cost per di
 Partially-defined functions participate in cost analysis:
 
 ```spore
-fn process(data: Data) -> Result ! [ProcessError]
+fn process(data: Data) -> Result ! ProcessError
     cost ≤ 1000
 {
     parsed = parser.parse(data)     // cost: 600
@@ -826,7 +826,7 @@ Source Code
 Bounded types provide compile-time size information for cost verification:
 
 ```spore
-fn process_batch(items: List[Order, max: 500]) -> BatchResult ! [TooLarge]
+fn process_batch(items: List[Order, max: 500]) -> BatchResult ! TooLarge
     cost ≤ 25000
     uses [Compute]
 {
@@ -838,7 +838,7 @@ fn process_batch(items: List[Order, max: 500]) -> BatchResult ! [TooLarge]
 
 1. **Compile-time**: the compiler uses 500 as the upper bound for `len(items)` in cost verification. It substitutes `n = 500` into the symbolic cost expression to verify `cost ≤ 25000`.
 2. **Runtime**: if a list exceeding 500 elements is passed, the call produces a `TooLarge` error at the call site. The function body itself never sees more than 500 elements.
-3. **Error propagation**: the `TooLarge` error must appear in the function's error set (`! [TooLarge]`) or in the caller's error handling.
+3. **Error propagation**: the `TooLarge` error must appear in the function's error set (`! TooLarge`) or in the caller's error handling.
 
 When no `max` constraint is present, the cost remains a symbolic expression in terms of `len(items)`.
 
@@ -853,7 +853,7 @@ extern fn c_sort[T](data: List[T]) -> List[T]
 ```
 
 ```spore
-extern fn openssl_encrypt(data: Bytes, key: Key) -> Bytes ! [CryptoError]
+extern fn openssl_encrypt(data: Bytes, key: Key) -> Bytes ! CryptoError
     uses [Compute]
     cost ≤ len(data) * 3 + 500
 ```
@@ -930,7 +930,7 @@ When an AI agent fills a Hole (see SEP-0003), it receives not just the type sign
 ```json
 {
   "hole": "combine_results",
-  "expected_type": "Result<T>",
+  "expected_type": "Result[T]",
   "cost_budget_remaining": 34,
   "recursion_context": {
     "pattern": "structural_binary_tree",
@@ -1159,7 +1159,7 @@ Spore's cost inference uses abstract interpretation — executing the program on
 
 ### Sized types: Hughes, Pareto, Sabry
 
-Sized types annotate data types with size information (e.g., `List<T, max: n>`) to enable termination checking and complexity analysis. Spore's bounded types are directly inspired by this line of work.
+Sized types annotate data types with size information (e.g., `List[T, max: n]`) to enable termination checking and complexity analysis. Spore's bounded types are directly inspired by this line of work.
 
 ---
 
@@ -1188,7 +1188,7 @@ Cost analysis is introduced as a new compiler capability. No existing Spore code
 
 ### Interaction with existing SEPs
 
-- **SEP-0002 (Type System):** CostExpr types integrate with the type checker. Bounded types (`List<T, max: n>`) provide size information for cost analysis.
+- **SEP-0002 (Type System):** CostExpr types integrate with the type checker. Bounded types (`List[T, max: n]`) provide size information for cost analysis.
 - **SEP-0003 (Hole System):** Cost budgets are propagated to HoleReports, enriching the constraint environment for hole-filling.
 
 ---

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -78,7 +78,7 @@ Without a formal protocol, every Agent tool would invent its own ad-hoc interact
 A hole is written with a `?` prefix followed by an identifier. Holes can appear anywhere an expression is expected:
 
 ```spore
-fn calculate_tax(income: Money, region: Region) -> Money ! [InvalidRegion]
+fn calculate_tax(income: Money, region: Region) -> Money ! InvalidRegion
     uses [TaxTable]
     cost ≤ 500
 {
@@ -101,7 +101,7 @@ If the annotation conflicts with the inferred type, the compiler emits a `hole-t
 A function may contain any number of independently named holes:
 
 ```spore
-fn reconcile(ledger: Ledger, txns: Vec<Tx>) -> Ledger ! [Mismatch]
+fn reconcile(ledger: Ledger, txns: Vec[Tx]) -> Ledger ! Mismatch
     cost ≤ 5000
 {
     let grouped     = group_by_account(txns)
@@ -114,7 +114,7 @@ fn reconcile(ledger: Ledger, txns: Vec<Tx>) -> Ledger ! [Mismatch]
 Holes can also appear nested inside expressions, function arguments, and match arms:
 
 ```spore
-fn render(page: Page) -> Html ! [TemplateError]
+fn render(page: Page) -> Html ! TemplateError
     uses [Templates]
     cost ≤ 800
 {
@@ -153,9 +153,9 @@ A complete Human → Agent → Compiler interaction:
 ```spore
 fn generate_invoice(
     customer: Customer,
-    items: Vec<LineItem>,
+    items: Vec[LineItem],
     tax_region: TaxRegion,
-) -> Invoice ! [TaxCalculationError, InvalidLineItem]
+) -> Invoice ! TaxCalculationError | InvalidLineItem
     uses [TaxTable]
     cost ≤ 5000
 {
@@ -173,7 +173,7 @@ fn generate_invoice(
 $ sporec --query-hole ?validate_items --json
 ```
 
-The compiler returns a HoleReport (see §4 for the full structure) containing: expected type `Vec<LineItem>`, available bindings, candidate function `validate_line_items` with an exact type match, cost 300 within budget 5000.
+The compiler returns a HoleReport (see §4 for the full structure) containing: expected type `Vec[LineItem]`, available bindings, candidate function `validate_line_items` with an exact type match, cost 300 within budget 5000.
 
 **Step 3 — Agent proposes a fill:**
 
@@ -195,7 +195,7 @@ $ sporec check src/billing/invoice.spore
 **Step 5 — Agent fills the next hole, compiler confirms completion:**
 
 ```text
-[ok] generate_invoice : (...) -> Invoice ! [TaxCalculationError, InvalidLineItem]
+[ok] generate_invoice : (...) -> Invoice ! TaxCalculationError | InvalidLineItem
   cost: 520 (within budget of 5000)
   all holes filled ✓
 ```
@@ -231,7 +231,7 @@ pub struct HoleInfo {
     pub expected_type: Ty,         // inferred/expected type
     pub function: String,          // enclosing function
     pub bindings: BTreeMap<String, Ty>,  // local bindings at hole site
-    pub suggestions: Vec<String>,  // candidate functions
+    pub suggestions: Vec[String],  // candidate functions
 }
 ```
 
@@ -281,7 +281,7 @@ When context provides **no constraints**, the hole is *unconstrained* — report
 When the scrutinee of a `match` is a hole, the compiler infers the hole's type from the **pattern types** in the match arms:
 
 ```spore
-fn classify(data: RawData) -> Category ! [ParseError]
+fn classify(data: RawData) -> Category ! ParseError
 {
     match ?parsed_data {         // hole as scrutinee
         Valid(v)   => categorize(v),
@@ -290,7 +290,7 @@ fn classify(data: RawData) -> Category ! [ParseError]
 }
 ```
 
-The compiler infers: `?parsed_data` must have a type with at least variants `Valid(_)` and `Invalid(_)`. If a type in scope matches (e.g., `Result<ValidData, ErrorInfo>`), it is reported as the inferred type. All branches are reported as **blocked** (since the scrutinee is unknown, no branch can execute during simulation).
+The compiler infers: `?parsed_data` must have a type with at least variants `Valid(_)` and `Invalid(_)`. If a type in scope matches (e.g., `Result[ValidData, ErrorInfo]`), it is reported as the inferred type. All branches are reported as **blocked** (since the scrutinee is unknown, no branch can execute during simulation).
 
 #### Extension A: Candidate Scoring Vector
 
@@ -331,7 +331,7 @@ overall = 0.40 × type_match + 0.20 × cost_fit + 0.25 × capability_fit + 0.15 
 
 Weights are hard-coded in the compiler. Candidates are sorted by `overall` descending, with `type_match` as tiebreaker, then `cost_fit`, then lexicographic name for stability.
 
-Each candidate also includes an `adjustments` array of human-readable notes (e.g., `"needs type conversion: Option<Card> → Card"`, `"cost near budget limit"`).
+Each candidate also includes an `adjustments` array of human-readable notes (e.g., `"needs type conversion: Option[Card] → Card"`, `"cost near budget limit"`).
 
 #### Extension B: Binding Dependency Graph
 
@@ -395,7 +395,7 @@ Suggestion generation rules:
 
 #### Error System Integration (Three-Field Model)
 
-The enclosing function's declared error list (`! [Err1, Err2, Err3]`) is partitioned into three categories at each hole site:
+The enclosing function's declared error list (`! Err1 | Err2 | Err3`) is partitioned into three categories at each hole site:
 
 | Field | Meaning |
 |---|---|
@@ -406,7 +406,7 @@ The enclosing function's declared error list (`! [Err1, Err2, Err3]`) is partiti
 Example:
 
 ```spore
-fn fetch_and_parse(url: Url) -> Document ! [NetworkError, ParseError, Timeout]
+fn fetch_and_parse(url: Url) -> Document ! NetworkError | ParseError | Timeout
     uses [Http]
     cost ≤ 3000
 {
@@ -543,7 +543,7 @@ When a circular dependency is detected, the compiler suggests three strategies:
 #### Layered Topological Sort
 
 ```pseudocode
-function compute_fill_order(G: Graph) -> Result<List<Set<Hole>>, CycleError>:
+function compute_fill_order(G: Graph) -> Result[List[Set[Hole]], CycleError]:
     if has_cycle(G): return Err(CycleError(find_cycle(G)))
 
     layers = []
@@ -634,7 +634,7 @@ When a hole is filled, the graph updates incrementally in O(|neighbors|):
 #### Agent Allocation Strategy
 
 ```pseudocode
-function assign_agents(ready: Set<Hole>, agents: List<Agent>) -> Assignment:
+function assign_agents(ready: Set[Hole], agents: List[Agent]) -> Assignment:
     ranked = rank_within_layer(ready, G)  // sort by transitive dependents
     assignment = {}
     ranked.iter().enumerate().for_each(|(i, hole)|
@@ -747,14 +747,14 @@ The Agent protocol defines a five-state machine with no explicit RETRY state:
     "errors": [
       {
         "code": "E0301",
-        "message": "type mismatch: expected Vec<ValidItem>, found Vec<RawItem>",
+        "message": "type mismatch: expected Vec[ValidItem], found Vec[RawItem]",
         "location": { "file": "src/orders.spore", "line": 18, "column": 5 },
         "suggestion": "consider using validate_items(raw_input).map(|i| i.into())"
       }
     ],
     "root_cause": "type_mismatch",
     "fix_hints": [
-      "candidate validate_items returns Vec<RawItem>, not Vec<ValidItem>",
+      "candidate validate_items returns Vec[RawItem], not Vec[ValidItem]",
       "try: validate_items(raw_input).map(|i| i.into())"
     ]
   }
@@ -777,7 +777,7 @@ The Agent reads diagnostics, understands the failure, and autonomously decides t
 A hole in a recursive function is valid — `?name` is just an expression of some type. It does not call itself. The compiler detects recursive calls to partial functions and terminates simulation at depth 1:
 
 ```spore
-fn factorial(n: Int) -> Int ! []
+fn factorial(n: Int) -> Int
     cost ≤ 1000
 {
     if n <= 1 { 1 }
@@ -788,7 +788,7 @@ fn factorial(n: Int) -> Int ! []
 Here `?factorial_step` has type `Int`. The function is partial. If a recursive call to `factorial` occurs:
 
 ```spore
-fn bad(n: Int) -> Int ! []
+fn bad(n: Int) -> Int
 {
     ?self_ref + bad(n - 1)   // bad is partial; recursive call also partial
 }
@@ -797,7 +797,7 @@ fn bad(n: Int) -> Int ! []
 The compiler reports:
 
 ```text
-[partial] bad: (Int) -> Int ! []
+[partial] bad: (Int) -> Int
   holes: ?self_ref
   note: recursive call to partial function bad — simulation terminates at depth 1
 ```
@@ -809,7 +809,7 @@ Simulation does not recurse into partial functions; it stops and emits a HoleRep
 Type holes are syntactically distinct from value holes. They use `?T_name` (uppercase convention) in **type positions** and represent unknown types:
 
 ```spore
-fn convert(input: ?InputType) -> ?OutputType ! []
+fn convert(input: ?InputType) -> ?OutputType
 {
     ?conversion_logic
 }
@@ -844,7 +844,7 @@ Value holes:
 When a hole has contradictory type constraints from its context, the compiler reports the conflict without failing:
 
 ```spore
-fn conflicted(flag: Bool) -> Int ! []
+fn conflicted(flag: Bool) -> Int
 {
     let x: String = ?ambiguous   // constraint 1: String (from let binding)
     let y: Int = x               // constraint 2: Int (from assignment)
@@ -870,9 +870,9 @@ The hole still appears in `--holes` output and still receives a HoleReport. The 
 Closures can contain holes. The hole's context captures both the closure's own parameters and any outer bindings captured by the closure:
 
 ```spore
-fn make_processor(config: Config) -> Fn(Data) -> Result ! [ProcessError]
+fn make_processor(config: Config) -> Fn(Data) -> Result ! ProcessError
 {
-    |data: Data| -> Result ! [ProcessError] {
+    |data: Data| -> Result ! ProcessError {
         ?process_with_config
     }
 }
@@ -898,7 +898,7 @@ A hole in a function inferred as `pure` (i.e., `uses []`) is itself pure by defi
 **Formal rule:** If function `f` has `uses []` (and is therefore inferred as `pure`), any expression that replaces a hole `?h` in `f`'s body must also be pure — it may not call functions requiring IO or State capabilities.
 
 ```spore
-fn pure_fn(x: Int) -> Int ! []
+fn pure_fn(x: Int) -> Int
 {
     ?must_be_pure   // ok: hole is inert
 }
@@ -1122,7 +1122,7 @@ All hole-related commands support `--json` for machine consumption.
       "name": "charge_payment",
       "location": { "file": "src/orders.spore", "line": 18, "column": 5 },
       "enclosing_function": "process_order",
-      "expected_type": "Response ! [PaymentFailed]",
+      "expected_type": "Response ! PaymentFailed",
       "capabilities": ["Inventory", "PaymentGateway"],
       "dependencies": []
     }
@@ -1196,7 +1196,7 @@ The hole system integrates with Language Server Protocol:
 ### Cost diagnostics for partial functions
 
 ```text
-[partial] pipeline: (Vec<Int>) -> Vec<Int> ! []
+[partial] pipeline: (Vec[Int]) -> Vec[Int]
   known cost: 200 (before hole) + ≤150 (after hole) = ≤350
   budget for ?middle_step: ≤650 (1000 - 350)
   note: ?middle_step filling must have cost ≤ 650

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -193,7 +193,7 @@ Source Text (.spore files)
 │  ─ Associated types + GAT instantiation                                 │
 │  ─ Const generics evaluation                                            │
 │  ─ Exhaustiveness checking (match expressions)                          │
-│  ─ Error set propagation and consistency (! [Errors])                   │
+│  ─ Error set propagation and consistency (! Errors)                   │
 │  ─ Refinement types: L0 decidable predicates + L1 abstract propagation  │
 │  ─ Capability check: body uses ⊆ declared uses, module ceiling check    │
 │  ─ Cost check: abstract interpretation of 4D cost vector                 │
@@ -294,7 +294,7 @@ The unified TypeCheck pass performs:
 | **Trait resolution** | Trait/Capability resolution, associated types, GAT instantiation |
 | **Const generics** | Evaluation of compile-time constant generic parameters |
 | **Exhaustiveness** | Verify match expressions cover all variants |
-| **Error sets** | Propagation and consistency of `! [ErrorType]` declarations |
+| **Error sets** | Propagation and consistency of `! ErrorType` declarations |
 | **Refinement types** | L0 decidable predicates + L1 abstract interpretation propagation |
 | **CapCheck** | Function body capability usage ⊆ declared `uses` set; module ceiling check |
 | **CostCheck** | Abstract interpretation of 4D cost vector: `compute(op) + alloc(cell) + io(call) + parallel(lane)`; verify ≤ declared bound |

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -79,7 +79,7 @@ Bob Nystrom's *"What Color is Your Function?"* (2015) identified how `async` spl
 
 ```spore
 // No async annotation needed—concurrency declared via the Spawn effect
-fn fetch_all(urls: List[Url]) -> List[Response] ! [NetError]
+fn fetch_all(urls: List[Url]) -> List[Response] ! NetError
 cost ≤ urls.len * per_fetch
 uses [Spawn, NetConnect]
 {
@@ -125,7 +125,7 @@ The block is an expression; its value is the last expression in the body. When t
 Because `parallel_scope` is an expression, it can return structured results assembled from spawned tasks:
 
 ```spore
-fn load_dashboard(user_id: UserId) -> Dashboard ! [DbError, NetError]
+fn load_dashboard(user_id: UserId) -> Dashboard ! DbError | NetError
 uses [Spawn, NetConnect, DbRead]
 {
     // parallel_scope returns the Dashboard struct directly
@@ -176,7 +176,7 @@ let task = spawn uses [NetConnect] { fetch(url) }
 
 | Method/Property | Type | Description |
 |-----------------|------|-------------|
-| `task.await` | `T ! [child errors]` | Block until the task completes and return its result |
+| `task.await` | `T ! child errors` | Block until the task completes and return its result |
 | `task.cancel()` | `Unit` | Request cooperative cancellation of the task |
 | `task.is_done` | `Bool` | `true` if the task has completed (successfully or with error) |
 | `task.is_cancelled` | `Bool` | `true` if the task was cancelled |
@@ -184,7 +184,7 @@ let task = spawn uses [NetConnect] { fetch(url) }
 Usage examples:
 
 ```spore
-fn selective_fetch(urls: List[Url]) -> Response ! [NetError]
+fn selective_fetch(urls: List[Url]) -> Response ! NetError
 uses [Spawn, NetConnect]
 {
     parallel_scope {
@@ -293,7 +293,7 @@ fn event_loop(
     commands: Receiver[Command],
     events: Receiver[Event],
     shutdown: Receiver[Unit],
-) -> Unit ! [ChannelClosed]
+) -> Unit ! ChannelClosed
 uses [ChanRecv[Command], ChanRecv[Event], ChanRecv[Unit], Spawn]
 {
     select {
@@ -323,7 +323,7 @@ Server entrypoints that accept inbound connections declare `NetListen`; the inne
 ```spore
 effect HttpHandler = Spawn | NetConnect | DbRead | Clock
 
-fn handle_request(req: Request) -> Response ! [DbError, Timeout]
+fn handle_request(req: Request) -> Response ! DbError | Timeout
 cost ≤ 5000
 uses [HttpHandler]
 {
@@ -353,7 +353,7 @@ fn etl_pipeline(
     source: DataSource,
     sink: DataSink,
     batch_size: Int,
-) -> EtlReport ! [ExtractError, TransformError, LoadError]
+) -> EtlReport ! ExtractError | TransformError | LoadError
 cost ≤ batch_size * 200
 uses [Spawn, NetConnect, DbRead, DbWrite]
 {
@@ -467,7 +467,7 @@ Two modes are supported:
 
 | Mode | On child failure | Return type | Use case |
 |------|-----------------|-------------|----------|
-| `fail_fast` (default) | Cancel siblings, propagate error | `T ! [E]` | All child results are required |
+| `fail_fast` (default) | Cancel siblings, propagate error | `T ! E` | All child results are required |
 | `collect` | Do not cancel siblings; collect results | `Result[T, E]` per task | Partial results are meaningful |
 
 ```spore
@@ -531,12 +531,12 @@ Users may define their own concurrency-related effects:
 
 ```spore
 effect RateLimit {
-    fn acquire_permit() -> Unit ! [RateLimitExceeded]
+    fn acquire_permit() -> Unit ! RateLimitExceeded
     fn release_permit() -> Unit
 }
 
 handler token_bucket_handler(rate: Int, per: Duration) for RateLimit {
-    fn acquire_permit() -> Unit ! [RateLimitExceeded] {
+    fn acquire_permit() -> Unit ! RateLimitExceeded {
         if tokens > 0 { tokens -= 1; resume(()) }
         else { raise(RateLimitExceeded) }
     }
@@ -574,24 +574,24 @@ let (tx, rx) = Channel.new[Message](buffer: 0)
 
 ```spore
 effect ChanSend[T] {
-    fn send(value: T) -> Unit ! [ChannelClosed]
+    fn send(value: T) -> Unit ! ChannelClosed
 }
 
 effect ChanRecv[T] {
-    fn recv() -> T ! [ChannelClosed]
+    fn recv() -> T ! ChannelClosed
 }
 ```
 
 Functions using channels must declare the corresponding capabilities:
 
 ```spore
-fn producer(tx: Sender[Int]) -> Unit ! [ChannelClosed]
+fn producer(tx: Sender[Int]) -> Unit ! ChannelClosed
 uses [ChanSend[Int]]
 {
     (0..100).each(|i| tx.send(i))
 }
 
-fn consumer(rx: Receiver[Int]) -> List[Int] ! [ChannelClosed]
+fn consumer(rx: Receiver[Int]) -> List[Int] ! ChannelClosed
 uses [ChanRecv[Int]]
 {
     rx.collect()
@@ -713,7 +713,7 @@ uses [Spawn, FileRead, NetConnect]
 When the number of spawned tasks depends on runtime values, the compiler uses **symbolic cost expressions**:
 
 ```spore
-fn fetch_all(urls: List[Url]) -> List[Response] ! [NetError]
+fn fetch_all(urls: List[Url]) -> List[Response] ! NetError
 cost ≤ urls.len * per_fetch
 uses [Spawn, NetConnect]
 {
@@ -737,7 +737,7 @@ $ sporec --query-cost fetch_all
 To make the cost statically verifiable, use a **refinement type** to limit the input size:
 
 ```spore
-fn bounded_fetch(urls: List[Url, max: 100]) -> List[Response] ! [NetError]
+fn bounded_fetch(urls: List[Url, max: 100]) -> List[Response] ! NetError
 cost ≤ 100 * per_fetch + 500
 uses [Spawn, NetConnect]
 {
@@ -900,7 +900,7 @@ The compiler may emit a warning when it detects a long iterative computation wit
 `defer` blocks execute even during cancellation, guaranteeing resource cleanup:
 
 ```spore
-fn with_temp_file() -> Data ! [IoError, Cancelled]
+fn with_temp_file() -> Data ! IoError | Cancelled
 uses [Spawn, FileRead, FileWrite]
 {
     let file = create_temp_file()
@@ -916,7 +916,7 @@ uses [Spawn, FileRead, FileWrite]
 `with_timeout` is syntactic sugar over cancellation:
 
 ```spore
-fn fetch_with_timeout(url: Url, limit: Duration) -> Response ! [NetError, Timeout]
+fn fetch_with_timeout(url: Url, limit: Duration) -> Response ! NetError | Timeout
 uses [Spawn, NetConnect, Clock]
 {
     with_timeout(limit) {
@@ -1261,8 +1261,8 @@ task.is_cancelled                // Bool: was the task cancelled?
 let (tx, rx) = Channel.new[T](buffer: N)
 
 // Send / receive
-tx.send(value)          // ! [ChannelClosed]
-let value = rx.recv()   // ! [ChannelClosed]
+tx.send(value)          // ! ChannelClosed
+let value = rx.recv()   // ! ChannelClosed
 
 // Close and clone
 tx.close()
@@ -1302,7 +1302,7 @@ Concrete syntax for `effect`, `handler`, and `handle ... with` is defined in SEP
 ### A.8 Function signature with concurrency
 
 ```spore
-fn name(params) -> ReturnType ! [Errors]
+fn name(params) -> ReturnType ! Errors
 where T: Constraints
 cost ≤ <N>
 uses [Spawn, Channel, ...]
@@ -1316,7 +1316,7 @@ uses [Spawn, Channel, ...]
 ```spore
 effect HttpHandler = Spawn | NetConnect | DbRead | Clock
 
-fn handle_request(req: Request) -> Response ! [DbError, Timeout]
+fn handle_request(req: Request) -> Response ! DbError | Timeout
 cost ≤ 5000
 uses [HttpHandler]
 {
@@ -1344,7 +1344,7 @@ fn etl_pipeline(
     source: DataSource,
     sink: DataSink,
     batch_size: Int,
-) -> EtlReport ! [ExtractError, TransformError, LoadError]
+) -> EtlReport ! ExtractError | TransformError | LoadError
 cost ≤ batch_size * 200
 uses [Spawn, NetConnect, DbRead, DbWrite]
 {

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -85,7 +85,7 @@ There is no `module` keyword — the filesystem **is** the declaration. A file-l
 import billing.types
 import billing.tax
 
-pub fn generate_invoice(order: Order) -> Invoice ! [TaxError, ValidationError]
+pub fn generate_invoice(order: Order) -> Invoice ! TaxError | ValidationError
     cost ≤ 3000
     uses [PaymentGateway, AuditLog]
 {
@@ -114,18 +114,16 @@ import billing.invoice
 // Module import with rename
 import billing.invoice as inv
 
-// Selective import: bring specific items into scope
-import billing.invoice.{calculate, Invoice}
-
 // Item alias: binds a specific function or type to a local name
 alias gen = billing.invoice.generate_invoice
 alias Inv = billing.types.Invoice
 ```
 
+> **Note (D12):** Selective imports (`import billing.invoice.{calculate, Invoice}`) are not supported in v0.1. Use `import billing.invoice` and qualify names, or use `alias` for specific items.
+
 Key rules:
 
 - `import` operates on **modules** only. Dot (`.`) separates path segments.
-- Selective imports use dot (`.`) then braces (`{...}`) to bring specific items into scope.
 - `alias` operates on **items** only. You cannot alias a module (use `import ... as` instead).
 - No wildcard imports (`import billing.*` is not supported).
 - No implicit nested imports (`import billing` does not import `billing.invoice`).
@@ -140,10 +138,10 @@ Key rules:
 
 ```spore
 // Public: any importer can call this
-pub fn generate_invoice(order: Order) -> Invoice ! [TaxError] { ... }
+pub fn generate_invoice(order: Order) -> Invoice ! TaxError { ... }
 
 // Package-internal: accessible within this package only
-pub(pkg) fn validate(order: Order) -> ValidatedOrder ! [ValidationError] { ... }
+pub(pkg) fn validate(order: Order) -> ValidatedOrder ! ValidationError { ... }
 
 // Private (default): only this module can call this
 fn compute_totals(order: ValidatedOrder) -> Invoice { ... }
@@ -210,7 +208,7 @@ A Platform is the **only** code in a Spore application that can perform real IO.
 
 ```spore
 // Application code: pure function, emits effects
-fn read_config() -> Config ! [FileRead] {
+fn read_config() -> Config ! FileRead {
     let content = File.read("config.toml")  // emits FileRead effect
     parse_toml(content)
 }
@@ -289,7 +287,8 @@ Within a single module, functions may reference each other regardless of declara
 
 ```text
 import_decl    ::= 'import' module_path ('as' IDENT)?
-                  | 'import' module_path '.' '{' IDENT (',' IDENT)* '}'
+                   // NOTE (D12): selective imports ('import' module_path '.' '{' IDENT (',' IDENT)* '}')
+                   // are not supported in v0.1
 alias_decl     ::= visibility? 'alias' IDENT '=' qualified_item
 module_path    ::= IDENT ('.' IDENT)*
 qualified_item ::= module_path '.' IDENT
@@ -536,7 +535,7 @@ Application code is pure—it declares capability requirements but never perform
 
 ```spore
 // Application code: pure
-fn fetch_and_save(url: Url, dest: Path) -> Unit ! [NetRead, FileWrite] {
+fn fetch_and_save(url: Url, dest: Path) -> Unit ! NetRead | FileWrite {
     let data = Http.get(url)
     File.write(dest, data)
 }
@@ -556,7 +555,7 @@ A Platform declares three things:
 platform CliPlatform {
     version: "1.0.0"
     handles [FileRead, FileWrite, StdOut, StdErr, NetRead, NetWrite, Clock, Spawn, Exit]
-    entry: fn(args: List[Str]) -> I32 ! [Exit]
+    entry: fn(args: List[Str]) -> I32 ! Exit
 
     handler FileReadHandler {
         File.read(path: Path) -> Result[Bytes, IoError] {
@@ -697,7 +696,7 @@ Individual files can narrow the project ceiling to declare the maximum capabilit
 import billing.types
 import billing.tax
 
-pub fn generate_invoice(order: Order) -> Invoice ! [TaxError]
+pub fn generate_invoice(order: Order) -> Invoice ! TaxError
     uses [PaymentGateway, AuditLog]
 { ... }
 ```
@@ -727,7 +726,7 @@ Private functions are **also** bound by the module's capability ceiling (if decl
 // src/billing/invoice.spore
 #![uses(PaymentGateway, AuditLog)]
 
-pub fn generate_invoice(order: Order) -> Invoice ! [TaxError]
+pub fn generate_invoice(order: Order) -> Invoice ! TaxError
     uses [PaymentGateway, AuditLog]
 { ... }
 
@@ -737,7 +736,7 @@ fn log_audit(action: String, id: InvoiceId) -> Unit
 { ... }
 
 // Private function: ERROR — exceeds module ceiling
-fn send_email(to: Email, body: String) -> Unit ! [SmtpError]
+fn send_email(to: Email, body: String) -> Unit ! SmtpError
     uses [EmailService]    // not in module ceiling
 { ... }
 ```
@@ -1128,7 +1127,7 @@ GC algorithm: (1) scan all `.spore-lock` files in known project directories, (2)
 For v0.1, Spore uses **coarse-grained** capability names in the language-level type system:
 
 ```spore
-fn read_config() -> Config ! [IoError]
+fn read_config() -> Config ! IoError
     uses [FileRead]
 { ... }
 ```
@@ -1205,7 +1204,7 @@ Holes by module:
 
   billing.invoice (partial)
     ?invoice_logic at line 12
-      type: Invoice ! [TaxError]
+      type: Invoice ! TaxError
       capabilities: [PaymentGateway, AuditLog]
       budget remaining: 2400 ops
 
@@ -1244,14 +1243,14 @@ Snapshots use `sig` hashes only at the module and package level (impl changes do
 
 #### Interaction with the Error System
 
-Error types follow the same visibility rules as all other types. A function's error list (`! [TaxError]`) must reference only error types visible from the function's module:
+Error types follow the same visibility rules as all other types. A function's error list (`! TaxError`) must reference only error types visible from the function's module:
 
 ```spore
 // src/api/handler.spore
 import billing.invoice
 import billing.errors
 
-pub fn handle_create(req: Request) -> Response ! [errors.BillingError, ParseError]
+pub fn handle_create(req: Request) -> Response ! errors.BillingError | ParseError
     uses [PaymentGateway, AuditLog]
 {
     let order = parse_request(req)
@@ -1314,7 +1313,7 @@ Partial modules can be imported and their types used. Only function calls at run
 
 ```spore
 // src/billing/invoice.spore (has holes)
-pub fn generate_invoice(order: Order) -> Invoice ! [TaxError] {
+pub fn generate_invoice(order: Order) -> Invoice ! TaxError {
     ?invoice_logic
 }
 
@@ -1322,7 +1321,7 @@ pub fn generate_invoice(order: Order) -> Invoice ! [TaxError] {
 import billing.invoice
 
 // Compiles fine — handler is transitively partial
-pub fn handle(req: Request) -> Response ! [ApiError] {
+pub fn handle(req: Request) -> Response ! ApiError {
     let inv = invoice.generate_invoice(parse_order(req))
     Response.ok(inv)
 }
@@ -1369,7 +1368,7 @@ Spore and Roc share the same design philosophy: no built-in Platform; all Platfo
 platform WebPlatform {
     version: "1.0.0"
     handles [HttpServer, NetRead, NetWrite, Clock, Spawn, DbQuery]
-    entry: fn(req: Request) -> Response ! [HttpServer, DbQuery]
+    entry: fn(req: Request) -> Response ! HttpServer | DbQuery
 
     handler HttpServerHandler {
         Server.listen(port: U16, handler: fn(Request) -> Response) {
@@ -1385,7 +1384,7 @@ platform WebPlatform {
 platform LambdaPlatform {
     version: "1.0.0"
     handles [NetRead, NetWrite, S3Read, S3Write, DynamoRead, DynamoWrite]
-    entry: fn(event: JsonValue) -> JsonValue ! [S3Read, DynamoWrite]
+    entry: fn(event: JsonValue) -> JsonValue ! S3Read | DynamoWrite
 
     handler S3Handler {
         S3.get(bucket: Str, key: Str) -> Result[Bytes, S3Error] {
@@ -1515,7 +1514,7 @@ spore init my-platform --type platform
 platform EmbeddedPlatform {
     version: "0.1.0"
     handles [GpioRead, GpioWrite, Timer, SerialRead, SerialWrite]
-    entry: fn() -> Never ! [GpioRead, GpioWrite, Timer]
+    entry: fn() -> Never ! GpioRead | GpioWrite | Timer
 
     config: {
         cpu_freq: U32,
@@ -2050,7 +2049,7 @@ capability     ::= UPPER_IDENT
 
 // Imports and aliases
 import_decl    ::= 'import' module_path ('as' IDENT)?
-                  | 'import' module_path '.' '{' IDENT (',' IDENT)* '}'
+                   // NOTE (D12): selective imports not supported in v0.1
 alias_decl     ::= visibility? 'alias' IDENT '=' qualified_item
 module_path    ::= IDENT ('.' IDENT)*
 qualified_item ::= module_path '.' IDENT

--- a/seps/SEP-0009-standard-library.md
+++ b/seps/SEP-0009-standard-library.md
@@ -135,7 +135,7 @@ type Ordering { Less, Equal, Greater }
 
 ```spore
 fn unwrap[T](opt: Option[T]) -> T
-    ! [PanicError]
+    ! PanicError
     cost O(1)
 
 fn unwrap_or[T](opt: Option[T], default: T) -> T
@@ -158,7 +158,7 @@ fn is_none[T](opt: Option[T]) -> Bool
 
 ```spore
 fn unwrap[T, E](res: Result[T, E]) -> T
-    ! [PanicError]
+    ! PanicError
     cost O(1)
 
 fn unwrap_or[T, E](res: Result[T, E], default: T) -> T
@@ -597,10 +597,10 @@ fn sample[A](list: List[A]) -> Option[A]
 
 ### 4.4 Error type hierarchy
 
-All stdlib errors conform to a base capability trait:
+All stdlib errors conform to a base trait:
 
 ```spore
-capability Error[T] {
+trait Error[T] {
     fn message(self: T) -> String
 }
 ```


### PR DESCRIPTION
## Summary

Apply the finalized syntax-unification decisions across all active SEPs and rebase the stack onto the latest `main`.

## Canonical discussion thread

- Syntax unification decisions are tracked in the canonical design table in `spore-lang/spore/docs/DESIGN.md` and the coordinated syntax re-audit across implementation/docs/SEPs.

## Checklist

- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Changes by SEP

| SEP | Fixes applied |
|-----|---------------|
| **0001** | Remove `ModuleDecl` from EBNF (D7); fix `ErrorClause` to pipe syntax (D11); align `spec` semantics with the settled implementation |
| **0002** | Refinement `if` → `when` (D6); add `struct` vs `type` note (N7); error-clause fixes |
| **0003** | Error-clause bracket → pipe fixes |
| **0004** | Generic angle brackets `<T>` → `[T]` (D8); error-clause fixes |
| **0005** | Generic angle brackets (D8); remove empty `! []` clauses; error-clause fixes |
| **0006** | Error-clause reference fixes |
| **0007** | Error-clause fixes |
| **0008** | Mark selective imports as out of scope for v0.1 (D12); error-clause fixes |
| **0009** | `capability` → `trait` (D2); error-clause fixes |

## Decisions applied

- **D2**: `capability` → `trait`
- **D6**: Refinement `if` → `when`
- **D7**: No `module` keyword (file path = module)
- **D8**: `[T]` square brackets for generics
- **D11**: `! E1 | E2` pipe syntax (no brackets)
- **D12**: No selective imports in v0.1
- **N7**: `struct` = product, `type` = sum