### PR TITLE
📝 docs: clarify entries and startup contracts in core SEPs

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -62,6 +62,10 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 ## E
 
+**Entry** (SEP-0008): A manifest-selected executable target within a project. An entry resolves to an entry module.
+
+**Entry module** (SEP-0008): The source file and derived module selected by an entry, such as `src/main.sp` → `main`.
+
 **`Eq`** (SEP-0002): Compiler-known trait for structural equality comparison.
 
 **Effect** (SEP-0003): An observable interaction with the outside world (I/O, mutation, randomness), tracked via the capability system.
@@ -122,7 +126,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 ## P
 
-**Platform** (SEP-0008): A package that provides effect handlers for a target environment (e.g., CLI, Web, Embedded), granting capabilities and defining the program entry point.
+**Platform** (SEP-0008): A package that provides effect handlers for a target environment (e.g., CLI, Web, Embedded), granting capabilities and defining the startup contract that the selected entry module must satisfy.
 
 **Prelude** (SEP-0009): The set of types and functions available in every Spore module without explicit import.
 
@@ -149,6 +153,10 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 **Struct** (SEP-0002): Product type with named fields, defined as `struct Name { field1: T1, field2: T2 }`.
 
 **Structured concurrency** (SEP-0007): Concurrency model where all spawned tasks are scoped to their parent block, ensuring no task outlives its creator.
+
+**Startup contract** (SEP-0008): The Platform-defined requirement on the startup function's parameters, return type, and effect boundary.
+
+**Startup function** (SEP-0008): The callable inside the selected entry module that satisfies the Platform's startup contract. Today this is usually `main`.
 
 ## T
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -60,6 +60,8 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **Diagnostic code** (SEP-0006): Structured error/warning identifier in the format `X0NNN`, where X is a category letter: E (type error), C (capability), K (cost), M (module), W (warning).
 
+**Default entry** (SEP-0008): The manifest-selected entry used when project commands omit an explicit entry name.
+
 ## E
 
 **Entry** (SEP-0008): A manifest-selected executable target within a project. An entry resolves to an entry module.
@@ -126,7 +128,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 ## P
 
-**Platform** (SEP-0008): A package that provides effect handlers for a target environment (e.g., CLI, Web, Embedded), granting capabilities and defining the startup contract that the selected entry module must satisfy.
+**Platform** (SEP-0008): A package that provides effect handlers for a target environment (e.g., CLI, Web, Embedded). Each manifest-backed project binds exactly one Platform, and each selected entry module must satisfy its startup contract.
 
 **Prelude** (SEP-0009): The set of types and functions available in every Spore module without explicit import.
 
@@ -151,6 +153,10 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 **`Sub`** (SEP-0002): Compiler-known trait for the `-` operator, enabling operator overloading on user-defined types.
 
 **Struct** (SEP-0002): Product type with named fields, defined as `struct Name { field1: T1, field2: T2 }`.
+
+**spore** (SEP-0006, SEP-0008): The project/package workflow CLI. It owns `build`, `check`, `test`, `run`, `fmt`, `update`, and `upgrade`.
+
+**sporec** (SEP-0006, SEP-0008): The low-level explicit-input compiler CLI. It owns `compile`, `holes`, `query-hole`, and `explain`.
 
 **Structured concurrency** (SEP-0007): Concurrency model where all spawned tasks are scoped to their parent block, ensuring no task outlives its creator.
 

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -74,14 +74,14 @@ models, holes, and content-addressed modules.
 
 ### Compiling a Spore program
 
-A developer interacts with the compiler through the `sporec` CLI:
+A developer interacts with the toolchain through both `spore` and `sporec`:
 
 ```bash
-# One-shot compilation
-sporec build src/main.spore
+# Project-aware build
+spore build src/main.spore
 
 # Check without codegen
-sporec check src/main.spore
+spore check src/main.spore
 
 # Watch mode — recompile on save, show diagnostics in real time
 spore watch
@@ -89,11 +89,14 @@ spore watch
 # Watch mode with JSON output for agents / IDEs
 spore watch --json
 
+# Explicit-input compiler invocation
+sporec compile src/main.spore
+
 # Explain an error code
-sporec --explain E0301
+sporec explain E0301
 
 # Query a specific hole
-sporec --query-hole tax_logic --json
+sporec query-hole tax_logic --json
 ```
 
 ### What the developer sees
@@ -101,7 +104,7 @@ sporec --query-hole tax_logic --json
 **On success:**
 
 ```text
-$ sporec build src/main.spore
+$ spore build src/main.spore
   Compiling main (src/main.spore)
   Compiling http (src/net/http.spore)
   Compiling auth (src/auth/login.spore)
@@ -928,13 +931,13 @@ All diagnostics carry categorized codes:
 | `H0xxx` | Hole diagnostics | hole report, partial function, type conflict |
 | `M0xxx` | Module errors | circular dependency, visibility violation |
 
-Every code is queryable: `sporec --explain E0301` prints a detailed explanation
+Every code is queryable: `sporec explain E0301` prints a detailed explanation
 with common causes, examples, and fix strategies.
 
-#### `sporec --explain` output format
+#### `sporec explain` output format
 
 ```text
-$ sporec --explain E0301
+$ sporec explain E0301
 
   E0301: type mismatch
 
@@ -982,10 +985,10 @@ Target latencies (aspirational, not hard guarantees):
 #### `spore check`
 
 `spore check` performs all static analyses without code generation. It is the
-primary command for verifying correctness during development.
+primary project-aware command for verifying correctness during development.
 
 ```bash
-spore check src/main.spore          # check a single entry point
+spore check src/main.spore          # check a single entry module path
 spore check src/**/*.sp             # check all source files
 spore check --deny-warnings .       # treat warnings as errors (for CI)
 ```
@@ -1404,7 +1407,7 @@ note[H0101]: hole `tax_logic` requires filling
    = note: available bindings: income: Money, region: Region
    = note: available capabilities: [TaxTable]
    = note: candidate: `tax_table.lookup(region, income) -> Money`
-help: run `sporec --query-hole tax_logic` for full HoleReport
+help: run `sporec query-hole tax_logic` for full HoleReport
 ```
 
 ### Recovery strategies
@@ -1427,7 +1430,7 @@ errors into `= note: N additional errors caused by this`.
 
 ### Complete Error Code Registry
 
-All diagnostics carry a categorized code. Every code is queryable: `sporec --explain CODE`.
+All diagnostics carry a categorized code. Every code is queryable: `sporec explain CODE`.
 
 #### E0xxx — Type Errors
 
@@ -1540,7 +1543,7 @@ Diagnostics do not exist in isolation — they connect to every major Spore subs
 #### Hole System integration
 
 - `H0101` (hole-report) is emitted as `note` severity for each unfilled hole during compilation
-- `sporec --query-hole <name>` returns a full `HoleReport` — a superset of H0101 with candidate ranking, binding types, cost budget
+- `sporec query-hole <name>` returns a full `HoleReport` — a superset of H0101 with candidate ranking, binding types, cost budget
 - Partial functions (`H0201`) compile successfully — they produce diagnostics but not errors
 - The HoleReport JSON extends the diagnostic schema with a `hole_report` field
 
@@ -1679,7 +1682,7 @@ Some `help:` lines are concrete (`try Money.from_string(...)`) and some are stra
 Codes like `E0301` are more useful than raw names:
 
 - **Filterable:** `sporec --json | jq '.diagnostics[] | select(.code | startswith("K"))'` gives all cost errors
-- **Discoverable:** `sporec --explain E0301` opens documentation
+- **Discoverable:** `sporec explain E0301` opens documentation
 - **Stable:** codes don't change when messages are reworded; CI can allowlist specific codes
 - **Cross-referencing:** docs, forums, and issue trackers reference `E0301` unambiguously
 
@@ -1832,7 +1835,7 @@ TypedHIR layer; a new "opt hash" could gate the MIR → Cranelift translation.
    overwhelm agents processing large rebuilds.
 
 7. **Internationalization of diagnostics.** Error codes are language-independent,
-   but message text is currently English-only. Should `sporec --explain` support
+   but message text is currently English-only. Should `sporec explain` support
    localized explanations in a future version? This would require a translation
    infrastructure.
 

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -986,8 +986,8 @@ primary project-aware command for verifying correctness during development.
 
 ```bash
 spore check src/main.sp             # check a single entry module path
-spore check src/**/*.sp             # check all source files
-spore check --deny-warnings src/**/*.sp
+spore check src/main.sp src/net/http.sp
+spore check --deny-warnings src/main.sp src/net/http.sp
 ```
 
 ##### Implementation strategy
@@ -1017,8 +1017,8 @@ is passed.
 `spore fmt` rewrites source files to conform to the canonical Spore style.
 
 ```bash
-spore fmt src/**/*.sp               # format files in place
-spore fmt --check src/**/*.sp       # exit 1 if any file would change (no writes)
+spore fmt src/main.sp src/net/http.sp
+spore fmt --check src/main.sp src/net/http.sp
 ```
 
 ##### Implementation strategy
@@ -1043,8 +1043,8 @@ analysis gate:
 
 ```yaml
 # Example CI step
-- run: spore fmt --check src/**/*.sp
-- run: spore check --deny-warnings src/**/*.sp
+- run: spore fmt --check src/main.sp src/net/http.sp
+- run: spore check --deny-warnings src/main.sp src/net/http.sp
 ```
 
 ---
@@ -1141,27 +1141,19 @@ When an Agent's fix introduces new errors, the diagnostic system supports iterat
 
 The `inference_chain` and `candidates` fields are specifically designed to give Agents enough context to reason about errors **without re-reading source files**. The original diagnostic for the first error is preserved in the Agent's context, enabling diff-based reasoning.
 
-### Machine-applicable fix metadata
+### Future machine-applicable fix metadata
 
-Agents can apply machine-applicable fixes from `spore check --json`
-diagnostics even though the current public CLI does not yet expose a dedicated
-`fix` subcommand:
-
-```bash
-# Inspect machine-readable fixes for one file
-spore check --json src/billing.sp
-
-# Example: extract proposed edits for an editor or agent workflow
-spore check --json src/billing.sp | jq '.diagnostics[]? | select(.fixes != null) | .fixes'
-```
+The current public CLI does **not** yet expose machine-applicable fixes, fix
+flags, or a stable fix-specific JSON payload. This section records the future
+design target for editor / agent integration once such a surface exists.
 
 Fix applicability categories:
 
-| Category | Flag | Meaning |
-|----------|------|---------|
-| `safe` | `--fix` | Preserves behavior and type safety |
-| `unsafe` | `--unsafe-fix` | May change behavior; apply with caution |
-| `informational` | *(manual)* | Requires judgment |
+| Category | Future mode | Meaning |
+|----------|-------------|---------|
+| `safe` | dedicated fix mode | Preserves behavior and type safety |
+| `unsafe` | dedicated unsafe-fix mode | May change behavior; apply with caution |
+| `informational` | manual only | Requires judgment |
 
 #### Fix suggestion types
 

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -81,13 +81,13 @@ A developer interacts with the toolchain through both `spore` and `sporec`:
 spore build
 
 # Check without codegen
-spore check
+spore check src/main.sp
 
 # Watch mode — recompile on save, show diagnostics in real time
-spore watch
+spore watch src/main.sp
 
 # Watch mode with JSON output for agents / IDEs
-spore watch --json
+spore watch --json src/main.sp
 
 # Explicit-input compiler invocation
 sporec compile src/main.sp
@@ -96,7 +96,7 @@ sporec compile src/main.sp
 sporec explain E0301
 
 # Query a specific hole
-sporec query-hole tax_logic --json
+sporec query-hole --json src/main.sp tax_logic
 ```
 
 ### What the developer sees
@@ -126,7 +126,7 @@ help: try `Money.from_string("fifty dollars")`
 **In watch mode:**
 
 ```text
-$ spore watch
+$ spore watch src/main.sp
 [watch] Watching project: ./my-project (42 modules)
 [watch] ✓ Initial compilation complete (1.2s), 0 errors, 2 warnings, 5 holes
 
@@ -471,11 +471,8 @@ fn on_file_changed(path: Path) -> ChangeResult:
 #### Command and flags
 
 ```bash
-spore watch                        # Watch current project
-spore watch --json                 # NDJSON output for IDEs / agents
-spore watch --project ./my-proj    # Specify project path
-spore watch --quiet                # Only show errors
-spore watch --jobs 4               # Specify parallelism
+spore watch src/main.sp             # Watch one entry file / project target
+spore watch --json src/main.sp      # NDJSON output for IDEs / agents
 ```
 
 #### Debounce strategy
@@ -566,7 +563,7 @@ Watch mode **never exits** (except on Ctrl+C). Recovery behavior:
 #### Complete watch terminal output
 
 ```text
-$ spore watch
+$ spore watch src/main.sp
 [watch] Watching project: ./my-project (42 modules)
 [watch] ✓ Initial compilation complete (1.2s), 0 errors, 2 warnings, 5 holes
 
@@ -587,7 +584,7 @@ $ spore watch
 #### Hole fill progressive watch session
 
 ```text
-$ spore watch
+$ spore watch src/main.sp
 [watch] ✓ Initial compilation complete, 0 errors, 3 holes
 
   Holes (3):
@@ -988,9 +985,9 @@ Target latencies (aspirational, not hard guarantees):
 primary project-aware command for verifying correctness during development.
 
 ```bash
-spore check                       # check the current project
+spore check src/main.sp             # check a single entry module path
 spore check src/**/*.sp             # check all source files
-spore check --deny-warnings .       # treat warnings as errors (for CI)
+spore check --deny-warnings src/**/*.sp
 ```
 
 ##### Implementation strategy
@@ -1108,7 +1105,7 @@ programmatic reasoning without parsing human-readable text. Key fields:
 ### Agent hole-filling workflow
 
 ```text
-1. Start  spore watch --json
+1. Start  spore watch --json src/main.sp
 2. Parse initial hole list from NDJSON stream
 3. Select a  ready_to_fill  hole → generate implementation → write to file
 4. Wait for watch to emit compilation result
@@ -1144,18 +1141,18 @@ When an Agent's fix introduces new errors, the diagnostic system supports iterat
 
 The `inference_chain` and `candidates` fields are specifically designed to give Agents enough context to reason about errors **without re-reading source files**. The original diagnostic for the first error is preserved in the Agent's context, enabling diff-based reasoning.
 
-### Auto-fix integration
+### Machine-applicable fix metadata
 
-Agents can apply machine-applicable fixes automatically:
-
-> **Note:** DESIGN.md uses `--fixes` in some places; the canonical CLI flag is `--fix` (consistent with `compiler-output-v0.1` spec).
+Agents can apply machine-applicable fixes from `spore check --json`
+diagnostics even though the current public CLI does not yet expose a dedicated
+`fix` subcommand:
 
 ```bash
-# Apply all safe fixes
-sporec --fix src/billing.sp
+# Inspect machine-readable fixes for one file
+spore check --json src/billing.sp
 
-# Preview fixes without applying
-sporec --fix --dry-run src/billing.sp
+# Example: extract proposed edits for an editor or agent workflow
+spore check --json src/billing.sp | jq '.diagnostics[]? | select(.fixes != null) | .fixes'
 ```
 
 Fix applicability categories:
@@ -1244,7 +1241,7 @@ Fix applicability categories:
 └──────────────┘                   └──────────────┘                └──────────────┘
 ```
 
-The LSP server launches `spore watch --json` as a subprocess and translates the
+The LSP server launches `spore watch --json <entry-file>` as a subprocess and translates the
 NDJSON event stream into LSP messages:
 
 | Watch event | LSP message |
@@ -1407,7 +1404,7 @@ note[H0101]: hole `tax_logic` requires filling
    = note: available bindings: income: Money, region: Region
    = note: available capabilities: [TaxTable]
    = note: candidate: `tax_table.lookup(region, income) -> Money`
-help: run `sporec query-hole tax_logic` for full HoleReport
+help: run `sporec query-hole <file> tax_logic` for full HoleReport
 ```
 
 ### Recovery strategies
@@ -1543,7 +1540,7 @@ Diagnostics do not exist in isolation — they connect to every major Spore subs
 #### Hole System integration
 
 - `H0101` (hole-report) is emitted as `note` severity for each unfilled hole during compilation
-- `sporec query-hole <name>` returns a full `HoleReport` — a superset of H0101 with candidate ranking, binding types, cost budget
+- `sporec query-hole <file> <name>` returns a full `HoleReport` — a superset of H0101 with candidate ranking, binding types, cost budget
 - Partial functions (`H0201`) compile successfully — they produce diagnostics but not errors
 - The HoleReport JSON extends the diagnostic schema with a `hole_report` field
 

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -78,10 +78,10 @@ A developer interacts with the toolchain through both `spore` and `sporec`:
 
 ```bash
 # Project-aware build
-spore build src/main.spore
+spore build
 
 # Check without codegen
-spore check src/main.spore
+spore check
 
 # Watch mode — recompile on save, show diagnostics in real time
 spore watch
@@ -90,7 +90,7 @@ spore watch
 spore watch --json
 
 # Explicit-input compiler invocation
-sporec compile src/main.spore
+sporec compile src/main.sp
 
 # Explain an error code
 sporec explain E0301
@@ -104,10 +104,10 @@ sporec query-hole tax_logic --json
 **On success:**
 
 ```text
-$ spore build src/main.spore
-  Compiling main (src/main.spore)
-  Compiling http (src/net/http.spore)
-  Compiling auth (src/auth/login.spore)
+$ spore build
+  Compiling main (src/main.sp)
+  Compiling http (src/net/http.sp)
+  Compiling auth (src/auth/login.sp)
     Finished build in 1.4s — 3 modules, 0 errors, 0 warnings
 ```
 
@@ -115,7 +115,7 @@ $ spore build src/main.spore
 
 ```text
 error[E0301]: type mismatch
-  --> src/billing.spore:42:22
+  --> src/billing.sp:42:22
    |
 42 |     charge(card, "fifty dollars")
    |                  ^^^^^^^^^^^^^^^ expected `Money`, found `String`
@@ -133,8 +133,8 @@ $ spore watch
 [watch] Waiting for file changes...
 
 [watch] ─── Change detected ─────────────────────
-[watch] File changed: src/auth/login.spore
-[watch] Recompiling: src/auth/login.spore ... OK (34ms)
+[watch] File changed: src/auth/login.sp
+[watch] Recompiling: src/auth/login.sp ... OK (34ms)
 [watch] sig hash unchanged → skipping downstream
   ✓ 0 errors, 2 warnings, 4 holes (was: 5)
 ```
@@ -157,7 +157,7 @@ verbose adds analysis detail to default; default is the minimal actionable view.
 ### Pipeline overview
 
 ```text
-Source Text (.spore files)
+Source Text (.sp files)
     │
     ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
@@ -504,17 +504,17 @@ t=100ms  Begin incremental compile {A, B, C}
   "type": "incremental_compile",
   "timestamp": "2026-01-15T10:30:45Z",
   "trigger": {
-    "file": "src/auth/login.spore",
+    "file": "src/auth/login.sp",
     "change_type": "impl_only"
   },
-  "recompiled": ["src/auth/login.spore"],
+  "recompiled": ["src/auth/login.sp"],
   "skipped_downstream": true,
   "duration_ms": 34,
   "diagnostics": [],
   "holes": {
     "total": 4,
-    "filled_this_cycle": ["src/auth/login.spore:30"],
-    "ready_to_fill": ["src/auth/login.spore:45"]
+    "filled_this_cycle": ["src/auth/login.sp:30"],
+    "ready_to_fill": ["src/auth/login.sp:45"]
   }
 }
 ```
@@ -524,7 +524,7 @@ t=100ms  Begin incremental compile {A, B, C}
 ```json
 {
   "type": "diagnostic",
-  "file": "src/net/http.spore",
+  "file": "src/net/http.sp",
   "line": 23, "column": 5,
   "severity": "warning",
   "code": "W001",
@@ -541,11 +541,11 @@ t=100ms  Begin incremental compile {A, B, C}
   "changes": [
     {
       "action": "filled",
-      "hole": { "file": "src/auth.spore", "line": 10, "name": "hash_password" }
+      "hole": { "file": "src/auth.sp", "line": 10, "name": "hash_password" }
     },
     {
       "action": "unblocked",
-      "hole": { "file": "src/auth.spore", "line": 20, "name": "verify_password" },
+      "hole": { "file": "src/auth.sp", "line": 20, "name": "verify_password" },
       "reason": "dependency hash_password is now filled"
     }
   ]
@@ -571,15 +571,15 @@ $ spore watch
 [watch] ✓ Initial compilation complete (1.2s), 0 errors, 2 warnings, 5 holes
 
   Warnings:
-    src/net/http.spore:23:5  unused import: `Timeout`        [W0102]
-    src/db/query.spore:45:12 unused capability: `FileSystem`  [W0105]
+    src/net/http.sp:23:5  unused import: `Timeout`        [W0102]
+    src/db/query.sp:45:12 unused capability: `FileSystem`  [W0105]
 
   Holes (5):
-    ◯ src/auth/login.spore:30   authenticate     : User -> Token
-    ◯ src/auth/login.spore:45   validate_token   : Token -> Bool
-    ◯ src/db/query.spore:12     execute_query    : Query -> Result
-    ◯ src/net/http.spore:67     handle_request   : Request -> Response
-    ◯ src/net/http.spore:89     parse_headers    : Bytes -> Headers
+    ◯ src/auth/login.sp:30   authenticate     : User -> Token
+    ◯ src/auth/login.sp:45   validate_token   : Token -> Bool
+    ◯ src/db/query.sp:12     execute_query    : Query -> Result
+    ◯ src/net/http.sp:67     handle_request   : Request -> Response
+    ◯ src/net/http.sp:89     parse_headers    : Bytes -> Headers
 
 [watch] Waiting for file changes...
 ```
@@ -591,17 +591,17 @@ $ spore watch
 [watch] ✓ Initial compilation complete, 0 errors, 3 holes
 
   Holes (3):
-    ◯ src/auth.spore:10  hash_password     : String -> HashedPassword
-    ◯ src/auth.spore:20  verify_password   : String -> HashedPassword -> Bool
-    ◯ src/app.spore:50   create_user       : UserInput -> Result User Error
+    ◯ src/auth.sp:10  hash_password     : String -> HashedPassword
+    ◯ src/auth.sp:20  verify_password   : String -> HashedPassword -> Bool
+    ◯ src/app.sp:50   create_user       : UserInput -> Result User Error
          ⚠ blocked: depends on hash_password, verify_password
   Ready to fill: hash_password, verify_password
 
 // --- Developer fills hash_password ---
 
 [watch] ─── Change detected ────────────────────────
-[watch] File changed: src/auth.spore
-[watch] Recompiling: src/auth.spore ... OK (28ms)
+[watch] File changed: src/auth.sp
+[watch] Recompiling: src/auth.sp ... OK (28ms)
 [watch] sig hash unchanged → skipping downstream
   ✓ 0 errors, 2 holes (was: 3)
     ● hash_password      [filled ✓]
@@ -612,10 +612,10 @@ $ spore watch
 // --- Developer fills verify_password ---
 
 [watch] ─── Change detected ────────────────────────
-[watch] File changed: src/auth.spore
-[watch] Recompiling: src/auth.spore ... OK (31ms)
+[watch] File changed: src/auth.sp
+[watch] Recompiling: src/auth.sp ... OK (31ms)
 [watch] sig hash changed → checking downstream:
-         └─ src/app.spore ... OK (22ms)
+         └─ src/app.sp ... OK (22ms)
   ✓ 0 errors, 1 hole
     ● verify_password    [filled ✓]
     ◯ create_user       → no longer blocked!
@@ -624,8 +624,8 @@ $ spore watch
 // --- Developer fills create_user ---
 
 [watch] ─── Change detected ────────────────────────
-[watch] File changed: src/app.spore
-[watch] Recompiling: src/app.spore ... OK (35ms)
+[watch] File changed: src/app.sp
+[watch] Recompiling: src/app.sp ... OK (35ms)
   ✓ 0 errors, 0 holes 🎉 All holes filled!
 ```
 
@@ -694,8 +694,8 @@ fn update_dep_graph(module_id: ModuleId, old_deps: Set<ModuleId>, new_deps: Set<
 [watch] Checking project capability ceiling...
          ceiling allows: {Network, FileSystem, Clock} → ✓ within bounds
 [watch] Downstream capability compatibility:
-         ├─ src/api/client.spore → OK
-         └─ src/app.spore → propagation stops
+         ├─ src/api/client.sp → OK
+         └─ src/app.sp → propagation stops
 [watch] ✓ 3 modules recompiled, 0 errors, 1 capability warning
 ```
 
@@ -712,9 +712,9 @@ When the ceiling is exceeded:
 ```text
 [watch] Cost change: sort: O(n·log n) → O(n²)
 [watch] Checking downstream cost budgets:
-         ├─ src/data/table.spore
+         ├─ src/data/table.sp
          │   sort_column budget: O(n·log n) → ✗ exceeded
-         └─ src/app.spore
+         └─ src/app.sp
              process_data budget: O(n²) → ✓ within bounds
 [watch] ✗ 1 error
 ```
@@ -727,7 +727,7 @@ Watch events are converted to LSP messages by the Spore LSP server:
 {
   "method": "textDocument/publishDiagnostics",
   "params": {
-    "uri": "file:///project/src/auth.spore",
+    "uri": "file:///project/src/auth.sp",
     "diagnostics": [{
       "range": {
         "start": { "line": 22, "character": 9 },
@@ -750,7 +750,7 @@ Watch events are converted to LSP messages by the Spore LSP server:
   "params": {
     "holes": [
       {
-        "uri": "file:///project/src/auth.spore",
+        "uri": "file:///project/src/auth.sp",
         "range": {
           "start": { "line": 29, "character": 4 },
           "end": { "line": 29, "character": 50 }
@@ -823,7 +823,7 @@ Example:
 
 ```text
 error[E0301]: type mismatch
-  --> src/billing.spore:42:22
+  --> src/billing.sp:42:22
    |
 42 |     charge(card, "fifty dollars")
    |                  ^^^^^^^^^^^^^^^ expected `Money`, found `String`
@@ -858,7 +858,7 @@ derived from a JSON field. Schema:
       "code": "E0301",
       "message": "type mismatch: expected `Money`, found `String`",
       "location": {
-        "file": "src/billing.spore",
+        "file": "src/billing.sp",
         "range": {
           "start": { "line": 42, "col": 22 },
           "end": { "line": 42, "col": 37 }
@@ -880,7 +880,7 @@ derived from a JSON field. Schema:
         "applicability": "safe | unsafe | informational",
         "edits": [
           {
-            "file": "src/billing.spore",
+            "file": "src/billing.sp",
             "range": { "start": { "line": 42, "col": 22 }, "end": { "line": 42, "col": 37 } },
             "new_text": "Money.from_string(\"fifty dollars\")"
           }
@@ -988,7 +988,7 @@ Target latencies (aspirational, not hard guarantees):
 primary project-aware command for verifying correctness during development.
 
 ```bash
-spore check src/main.spore          # check a single entry module path
+spore check                       # check the current project
 spore check src/**/*.sp             # check all source files
 spore check --deny-warnings .       # treat warnings as errors (for CI)
 ```
@@ -1015,13 +1015,13 @@ is passed.
 
 **Lint warnings** (severity = Warning, code prefix `W`) follow the same rule.
 
-#### `spore format`
+#### `spore fmt`
 
-`spore format` rewrites source files to conform to the canonical Spore style.
+`spore fmt` rewrites source files to conform to the canonical Spore style.
 
 ```bash
-spore format src/**/*.sp            # format files in place
-spore format --check src/**/*.sp    # exit 1 if any file would change (no writes)
+spore fmt src/**/*.sp               # format files in place
+spore fmt --check src/**/*.sp       # exit 1 if any file would change (no writes)
 ```
 
 ##### Implementation strategy
@@ -1039,14 +1039,14 @@ implementation attaches comments to adjacent AST nodes during parsing (stored as
 leading/trailing trivia on `Spanned<T>`). Future work may adopt a CST
 (Concrete Syntax Tree) approach for perfect fidelity.
 
-**CI integration**: `spore format --check` is designed for CI pipelines. It exits
+**CI integration**: `spore fmt --check` is designed for CI pipelines. It exits
 with code 1 if any file would change, without modifying files. Combined with
 `spore check --deny-warnings`, these two commands form a complete CI static
 analysis gate:
 
 ```yaml
 # Example CI step
-- run: spore format --check src/**/*.sp
+- run: spore fmt --check src/**/*.sp
 - run: spore check --deny-warnings src/**/*.sp
 ```
 
@@ -1094,7 +1094,7 @@ implementations, then fill them one by one with immediate feedback.
 
 ### Structured consumption via `--json`
 
-Agents consume `sporec --json` output directly. The structured format enables
+Agents consume `spore check --json` output directly. The structured format enables
 programmatic reasoning without parsing human-readable text. Key fields:
 
 - `diagnostics[]` — iterate over all diagnostics
@@ -1136,10 +1136,10 @@ When an Agent's fix introduces new errors, the diagnostic system supports iterat
 
 ```text
 1. Agent applies fix for E0301 (type mismatch)
-2. sporec --json → new E0303 (error type mismatch introduced by fix)
+2. spore check --json → new E0303 (error type mismatch introduced by fix)
 3. Agent reads inference_chain for E0303 → understands the cascading error
 4. Agent applies a second fix addressing E0303
-5. sporec --json → 0 errors
+5. spore check --json → 0 errors
 ```
 
 The `inference_chain` and `candidates` fields are specifically designed to give Agents enough context to reason about errors **without re-reading source files**. The original diagnostic for the first error is preserved in the Agent's context, enabling diff-based reasoning.
@@ -1152,10 +1152,10 @@ Agents can apply machine-applicable fixes automatically:
 
 ```bash
 # Apply all safe fixes
-sporec --fix src/billing.spore
+sporec --fix src/billing.sp
 
 # Preview fixes without applying
-sporec --fix --dry-run src/billing.spore
+sporec --fix --dry-run src/billing.sp
 ```
 
 Fix applicability categories:
@@ -1186,7 +1186,7 @@ Fix applicability categories:
   "applicability": "safe",
   "edits": [
     {
-      "file": "src/scheduler.spore",
+      "file": "src/scheduler.sp",
       "range": { "start": { "line": 2, "col": 1 }, "end": { "line": 2, "col": 1 } },
       "new_text": "import time.DateTime\n"
     }
@@ -1202,7 +1202,7 @@ Fix applicability categories:
   "applicability": "unsafe",
   "edits": [
     {
-      "file": "src/billing.spore",
+      "file": "src/billing.sp",
       "range": { "start": { "line": 38, "col": 5 }, "end": { "line": 38, "col": 45 } },
       "new_text": ""
     }
@@ -1218,12 +1218,12 @@ Fix applicability categories:
   "applicability": "unsafe",
   "edits": [
     {
-      "file": "src/utils.spore",
+      "file": "src/utils.sp",
       "range": { "start": { "line": 10, "col": 1 }, "end": { "line": 10, "col": 3 } },
       "new_text": "pub fn"
     },
     {
-      "file": "src/api.spore",
+      "file": "src/api.sp",
       "range": { "start": { "line": 3, "col": 1 }, "end": { "line": 3, "col": 1 } },
       "new_text": "import utils.helper_fn\n"
     }
@@ -1325,7 +1325,7 @@ When an error spans multiple lines, the gutter marks the full range:
 
 ```text
 error[E0102]: struct missing required field `currency`
-  --> src/billing.spore:15:5
+  --> src/billing.sp:15:5
    |
 15 | /   let invoice = Invoice {
 16 | |       amount: 100,
@@ -1359,7 +1359,7 @@ Colors are disabled when output is piped (not a TTY) or when `--no-color` is pas
 
 ```text
 error[E0301]: type mismatch
-  --> src/billing.spore:42:22
+  --> src/billing.sp:42:22
    |
 42 |     charge(card, "fifty dollars")
    |                  ^^^^^^^^^^^^^^^ expected `Money`, found `String`
@@ -1371,7 +1371,7 @@ help: try `Money.from_string("fifty dollars")`
 
 ```text
 error[C0101]: undeclared capability
-  --> src/report.spore:27:5
+  --> src/report.sp:27:5
    |
 27 |     http.get(endpoint)
    |     ^^^^^^^^^^^^^^^^^^ requires `NetRead`, not declared in `uses`
@@ -1385,7 +1385,7 @@ help: add a `uses [NetRead]` clause to `fetch_data`
 
 ```text
 error[K0101]: cost budget exceeded
-  --> src/analytics.spore:55:5
+  --> src/analytics.sp:55:5
    |
 55 |     full_table_scan(records)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ this call costs 8200 op
@@ -1399,7 +1399,7 @@ help: filter `records` before scanning, or increase budget to `cost ≤ 10000`
 
 ```text
 note[H0101]: hole `tax_logic` requires filling
-  --> src/tax.spore:12:5
+  --> src/tax.sp:12:5
    |
 12 |     ?tax_logic
    |     ^^^^^^^^^^ expected type: `Money`, remaining cost budget: 400 op
@@ -1681,7 +1681,7 @@ Some `help:` lines are concrete (`try Money.from_string(...)`) and some are stra
 
 Codes like `E0301` are more useful than raw names:
 
-- **Filterable:** `sporec --json | jq '.diagnostics[] | select(.code | startswith("K"))'` gives all cost errors
+- **Filterable:** `spore check --json | jq '.diagnostics[] | select(.code | startswith("K"))'` gives all cost errors
 - **Discoverable:** `sporec explain E0301` opens documentation
 - **Stable:** codes don't change when messages are reworded; CI can allowlist specific codes
 - **Cross-referencing:** docs, forums, and issue trackers reference `E0301` unambiguously

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -69,6 +69,9 @@ In traditional languages, IO operations are built into the standard library, mak
 
 Every `.sp` file is exactly one module. The module name is derived from the file's path relative to the package's `src/` root:
 
+The canonical source extension in docs and manifests is `.sp`. Compatibility-only
+`.spore` handling, where it exists, is secondary to this spelling.
+
 | File Path | Module Name |
 |---|---|
 | `src/billing/invoice.sp` | `billing.invoice` |
@@ -249,9 +252,7 @@ The compiler builds a directed acyclic graph (DAG) of module dependencies:
 3. Determine topological build order. Modules at the same level compile in parallel.
 
 ```text
-$ spore build --show-order
-
-Build order (topological):
+Illustrative topological build order:
   1. billing.types       (0 dependencies)
   2. billing.tax         (1 dependency: billing.types)
   3. billing.invoice     (2 dependencies: billing.types, billing.tax)
@@ -384,7 +385,7 @@ Compatibility checking uses only `sig`: if `sig` is unchanged, dependents need n
 When a signature changes, all downstream modules referencing the old `sig` are flagged:
 
 ```text
-$ spore check
+$ spore check src/main.sp
 
 [warning] signature changed: billing.tax.calculate
   old sig: d91e4b
@@ -599,10 +600,10 @@ handler MockClock {
 }
 ```
 
-Running `spore test` automatically uses the Test Platform:
+Running `spore test tests/**/*.sp` automatically uses the Test Platform:
 
 ```bash
-$ spore test
+$ spore test tests/**/*.sp
    Using test platform: spore-platform/test v1.0.0
    Running 3 tests
 
@@ -692,7 +693,7 @@ pub fn fetch(url: Url) -> Result[Bytes, NetError]
 { ... }
 ```
 
-If the `#![uses(...)]` pragma is omitted, the compiler **infers** the ceiling from the union of all `pub` functions' capabilities and emits an `[info]` diagnostic suggesting the explicit declaration. The `sporec --fix` flag auto-applies the inferred pragma.
+If the `#![uses(...)]` pragma is omitted, the compiler **infers** the ceiling from the union of all `pub` functions' capabilities and emits an `[info]` diagnostic suggesting the explicit declaration.
 
 #### Capability propagation
 
@@ -732,11 +733,11 @@ fn send_email(to: Email, body: String) -> Unit ! SmtpError
         or move this function to a module that allows EmailService
 ```
 
-#### Capability violation error examples and `--fix` flow
+#### Capability violation error examples and remediation flow
 
 **Ceiling violation**: The error shown above.
 
-**Auto-fix with `sporec --fix`**: When a module omits its capability pragma, the compiler infers it:
+**Diagnostic hint**: When a module omits its capability pragma, the compiler infers it:
 
 ```text
 $ spore check src/billing/invoice.sp
@@ -752,12 +753,13 @@ $ spore check src/billing/invoice.sp
 **Full workflow**:
 
 ```bash
-spore check src/               # see [info] diagnostics suggesting capabilities
-sporec --fix src/              # auto-apply all capability declarations
-spore check src/               # clean: no more [info] suggestions
+spore check src/**/*.sp        # see [info] diagnostics suggesting capabilities
+# add the suggested #![uses(...)] pragma manually or via editor tooling
+spore check src/**/*.sp        # clean: no more [info] suggestions
 ```
 
-The `--fix` flag writes the inferred capability pragma as the first line of the module file.
+The current public CLI reports the inferred capability pragma in diagnostics, but
+does not yet auto-apply it.
 
 ### Package management
 
@@ -887,7 +889,7 @@ grant = [
 At runtime, the capability ceiling is enforced:
 
 ```bash
-spore run --allow network:listen:8080 --allow filesystem:read:/data
+spore run src/main.sp
 ```
 
 The `spore audit` command reports the full capability graph, flagging any ungrantable or suspicious requirements.
@@ -1143,7 +1145,7 @@ network:          filesystem:        env:            process:
                                       monotonic       fast
 ```
 
-For v0.1, the language-level `uses [FileRead]` maps to coarse categories. Fine-grained path restrictions are enforced in `spore.toml` and at runtime (`spore run --allow ...`), not in the type system. Promoting fine-grained capabilities into the type system is reserved for a future SEP.
+For v0.1, the language-level `uses [FileRead]` maps to coarse categories. Fine-grained path restrictions are enforced in `spore.toml` and at runtime via platform policy / host configuration, not in the type system. Promoting fine-grained capabilities into the type system is reserved for a future SEP.
 
 ### Publish and discovery flow
 
@@ -1595,13 +1597,14 @@ effect Exit   { fn exit(code: I32) -> Never }
 #### Module and build commands
 
 ```text
-spore check [path]            Check modules for errors
-spore check --show-deps       Show dependency graph
-spore build                   Build project entries in topological order
-spore build --show-order      Show module build order
-sporec holes [path]           List all holes across modules
-sporec --fix [path]           Auto-apply inferred capability declarations
-spore fmt [path]              Format source, including import ordering
+spore check [path...]           Check one or more source / entry files
+spore build [path]             Build the current project or one explicit file
+spore test [path...]           Validate test / spec files
+spore fmt [path...]            Format source, including import ordering
+sporec compile [path...]       Compile explicit input files
+sporec holes [path]            List holes in a source file
+sporec query-hole [path] [id]  Inspect one named hole in a source file
+sporec explain [code]          Explain one diagnostic code
 ```
 
 #### Snapshot and lock commands
@@ -1669,13 +1672,13 @@ spore add https://github.com/spore-std/http --alias std-http
 spore add https://github.com/spore-std/json --sig-only
 
 # 3. Write code, then check
-spore check src/
+spore check src/main.sp
 
-# 4. Auto-apply capability declarations
-sporec --fix src/
+# 4. Format before review
+spore fmt src/**/*.sp
 
 # 5. Build and test
-spore build && spore test
+spore build && spore test tests/**/*.sp
 
 # 6. If a dependency's signature changed, review and accept
 spore --permit billing.tax.calculate
@@ -1693,9 +1696,9 @@ mkdir my-app && cd my-app
 spore init
 spore add https://github.com/spore-std/http --alias std-http
 spore add https://github.com/spore-std/json --sig-only
-spore check src/
+spore check src/main.sp
 spore build
-spore run --allow network:listen:8080
+spore run src/main.sp
 ```
 
 #### Scenario 2: Update a dependency
@@ -1703,7 +1706,7 @@ spore run --allow network:listen:8080
 ```bash
 spore deps                      # view current dependency tree
 spore update http               # update to latest commit
-spore test                      # verify tests still pass
+spore test tests/**/*.sp        # verify tests still pass
 spore audit                     # check for capability changes
 git add .spore-lock spore.toml
 git commit -m "Update http to latest"
@@ -1780,7 +1783,7 @@ git push origin main --tags
 
 ### Workflow ergonomics
 
-- **`sporec --fix`** auto-applies inferred capability declarations, lowering the barrier for new users.
+- **Structured diagnostics** surface inferred capability declarations for manual or editor-assisted application, lowering the barrier for new users.
 - **`spore --permit`** provides explicit acknowledgment of breaking changes, preventing accidental API breakage.
 - **No semver** means developers never debate whether a change is "major" or "minor". The compiler decides mechanically.
 
@@ -1998,7 +2001,7 @@ New fields added to `.spore-lock` are ignored by older tools (forward-compatible
 
 The module system does not require wholesale adoption:
 
-- Packages can start with inferred capabilities (no `#![uses(...)]` pragma) and add explicit declarations later via `sporec --fix`.
+- Packages can start with inferred capabilities (no `#![uses(...)]` pragma) and add explicit declarations later once diagnostics show the inferred set.
 - Dependencies can mix Git, local path, and registry sources.
 - The `version` field in `spore.toml` remains available for human communication during the transition from semver.
 
@@ -2095,11 +2098,14 @@ effect_fn      ::= 'fn' IDENT '(' params ')' '->' type
 
 | Command | Description |
 |---|---|
-| `spore check [path]` | Check modules for errors and warnings |
-| `spore build` | Build project entries in topological order |
-| `sporec holes [path]` | List all holes in modules |
-| `sporec --fix [path]` | Auto-apply inferred capability declarations |
-| `spore fmt [path]` | Format source code (including import ordering) |
+| `spore check [path...]` | Check one or more source / entry files |
+| `spore build [path]` | Build the current project or one explicit file |
+| `spore test [path...]` | Validate test / spec files |
+| `spore fmt [path...]` | Format source code (including import ordering) |
+| `sporec compile [path...]` | Compile explicit input files |
+| `sporec holes [path]` | List all holes in a source file |
+| `sporec query-hole [path] [id]` | Inspect one named hole in a source file |
+| `sporec explain [code]` | Explain one diagnostic code |
 
 ### Snapshot and hash commands
 

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -167,40 +167,20 @@ my-billing-lib/
         └── invoice_test.spore
 ```
 
-Four package types exist:
+Three package types exist:
 
 | Type | Has Platform? | Can do IO? | Use Case |
 |---|---|---|---|
 | `package` | No | No (declares capability requirements) | Libraries, reusable components |
 | `application` | Yes | Yes (via Platform) | Executables, services |
 | `platform` | Is the Platform | Yes (raw syscalls) | Runtime providers |
-| `script` | Implicit | Yes (via `--platform` flag) | Single-file programs, prototypes |
 
 ### Script Mode
 
-Spore supports a lightweight **script mode** for single-file programs that require no `spore.toml` manifest:
-
-```bash
-# Run a single file directly with an implicit platform
-spore run hello.sp --platform cli
-
-# Equivalent to an implicit application with:
-#   [package]
-#   type = "application"
-#   platform = { git = "https://github.com/spore-lang/basic-cli" }
-```
-
-Script mode is ideal for quick prototypes, teaching, and small utilities. The compiler infers:
-
-- **Platform**: From `--platform` flag (required for scripts using IO effects). `cli` is shorthand for `spore-lang/basic-cli`.
-- **Capabilities**: Inherited from the specified platform's defaults.
-- **Dependencies**: Scripts cannot declare external dependencies. For multi-file or dependency-heavy projects, use `spore.toml`.
-
-Constraints:
-
-- A script is a single `.sp` file with a `main` function.
-- No `spore.toml` or `spore.lock` is generated.
-- The file's module name is derived from its filename (e.g., `hello.sp` → module `hello`).
+Script mode is intentionally **out of scope** for SEP-0008. Manifest-free
+single-file execution, file-header metadata, and script-vs-project precedence
+rules are specified by a separate script-mode SEP. SEP-0008 covers
+manifest-backed packages and applications only.
 
 ### Platforms
 
@@ -236,7 +216,10 @@ module_name = path.relative_to("src/")
                   // path separators become '.' in the module name
 ```
 
-Module name segments must be lowercase `snake_case`. Reserved names (`main`, `platform`, `test`) carry special semantics.
+Module name segments must be lowercase `snake_case`. Reserved names (`platform`,
+`test`) may carry tooling conventions, but executable selection is
+manifest-level: a module named `main` is only the default entry module by
+convention, not by special module semantics.
 
 #### Empty modules
 
@@ -549,13 +532,14 @@ A Platform declares three things:
 
 1. **Capability set**: Which IO capabilities it handles.
 2. **Effect handler implementations**: Runtime logic for each capability.
-3. **Entry point type**: The type signature the application's `main` must satisfy.
+3. **Startup contract**: The function contract that the selected module's
+   startup function must satisfy.
 
 ```spore
 platform CliPlatform {
     version: "1.0.0"
     handles [FileRead, FileWrite, StdOut, StdErr, NetRead, NetWrite, Clock, Spawn, Exit]
-    entry: fn(args: List[Str]) -> I32 ! Exit
+    startup: fn(args: List[Str]) -> I32 ! Exit
 
     handler FileReadHandler {
         File.read(path: Path) -> Result[Bytes, IoError] {
@@ -566,31 +550,27 @@ platform CliPlatform {
 }
 ```
 
-Platform declaration in `spore.toml`:
+Platform selection in `spore.toml`:
 
 ```toml
-[platforms]
-main = { git = "https://github.com/spore-platform/cli", version = "1.0.0" }
+[platform]
+git = "https://github.com/spore-platform/cli"
+version = "1.0.0"
 ```
 
 The compiler verifies:
 
-- Every capability used by application code is handled by some Platform.
-- The entry point type matches the Platform's requirement.
-- No two Platforms handle the same capability (unless priorities are explicit).
+- Every capability used by application code is handled by the selected Platform.
+- The startup function in the selected entry module matches the Platform's startup contract.
+- Test and mock Platforms may be substituted during testing, but a project binds to one Platform at a time.
 
-#### Multi-Platform support
+#### One Platform per project
 
-Applications may use multiple Platforms for different capability domains (e.g., CLI + GPU + S3):
-
-```toml
-[platforms]
-cli = { git = "https://github.com/spore-platform/cli", priority = 1 }
-gpu = { git = "https://github.com/spore-platform/cuda", priority = 2 }
-s3  = { git = "https://github.com/spore-platform/aws", priority = 3 }
-```
-
-Each effect is routed to the highest-priority Platform that handles it. The compiler ensures every effect has exactly one handler.
+A manifest-backed project selects exactly one Platform. Different deployment
+targets use different manifests, overrides, or future higher-level workspace
+flows; they are not modeled as multiple concurrent Platform bindings within one
+project. Multiple executable targets are modeled as project entries, not as
+multiple Platforms.
 
 #### Test Platforms for deterministic testing
 
@@ -599,7 +579,7 @@ Since application code is decoupled from IO implementations, a Test Platform can
 ```spore
 platform TestPlatform {
     handles [FileRead, FileWrite, NetRead, Clock]
-    entry: fn() -> TestResult
+    startup: fn() -> TestResult
 }
 
 handler MockFileSystem {
@@ -817,30 +797,37 @@ Dependencies are declared **per-project** in `spore.toml`, not per-file. The `[c
 
 Package names are `kebab-case` and globally unique within a registry. Module paths within a package use `snake_case` segments.
 
-### Application Entry Points
+### Application Entries
 
-An application's default entry point is `src/main.sp`, and the resulting binary name defaults to the package name from `spore.toml`:
+An application declares one or more named **entries** in `spore.toml`. Each
+entry selects an **entry module**, and the selected Platform then validates the
+module's **startup function** against its **startup contract**.
+
+The default emitted executable or run target name is the selected entry name:
 
 ```toml
 [package]
 name = "my-tool"
 type = "application"
-# Binary name: "my-tool", entry: src/main.sp
+default-entry = "my-tool"
+
+[entries.my-tool]
+path = "src/main.sp"
 ```
 
-To override the default or define additional binaries, use `[[bin]]`:
+Additional entries use the same table form:
 
 ```toml
-[[bin]]
-name = "my-tool"
-path = "src/main.sp"      # default, can be omitted
+[entries.my-tool]
+path = "src/main.sp"
 
-[[bin]]
-name = "my-tool-migrate"
-path = "src/migrate.sp"   # additional binary
+[entries.my-tool-migrate]
+path = "src/migrate.sp"
 ```
 
-Each `[[bin]]` entry must point to a `.sp` file containing a `main` function with the platform-required signature.
+Each entry path must point to a `.sp` file containing a startup function that
+satisfies the selected Platform's startup contract. Today that function is
+usually `main`.
 
 #### Content-addressed dependencies (BLAKE3, no semver)
 
@@ -1368,7 +1355,7 @@ Spore and Roc share the same design philosophy: no built-in Platform; all Platfo
 platform WebPlatform {
     version: "1.0.0"
     handles [HttpServer, NetRead, NetWrite, Clock, Spawn, DbQuery]
-    entry: fn(req: Request) -> Response ! HttpServer | DbQuery
+    startup: fn(req: Request) -> Response ! HttpServer | DbQuery
 
     handler HttpServerHandler {
         Server.listen(port: U16, handler: fn(Request) -> Response) {
@@ -1384,7 +1371,7 @@ platform WebPlatform {
 platform LambdaPlatform {
     version: "1.0.0"
     handles [NetRead, NetWrite, S3Read, S3Write, DynamoRead, DynamoWrite]
-    entry: fn(event: JsonValue) -> JsonValue ! S3Read | DynamoWrite
+    startup: fn(event: JsonValue) -> JsonValue ! S3Read | DynamoWrite
 
     handler S3Handler {
         S3.get(bucket: Str, key: Str) -> Result[Bytes, S3Error] {
@@ -1514,7 +1501,7 @@ spore init my-platform --type platform
 platform EmbeddedPlatform {
     version: "0.1.0"
     handles [GpioRead, GpioWrite, Timer, SerialRead, SerialWrite]
-    entry: fn() -> Never ! GpioRead | GpioWrite | Timer
+    startup: fn() -> Never ! GpioRead | GpioWrite | Timer
 
     config: {
         cpu_freq: U32,
@@ -1598,9 +1585,9 @@ effect Exit   { fn exit(code: I32) -> Never }
 |---|---|---|---|---|
 | Platform concept | ✓ | Partial (runtime) | ✗ | ✓ |
 | Effect system | ✗ (tag unions) | ✗ (Cmd/Sub) | ✓ | ✓ |
-| Multi-Platform | ✗ | ✗ | N/A | ✓ |
+| One Platform / project | ✗ | ✗ | N/A | ✓ |
 | Test Platform | Mock Platform | Mock Cmd | Manual mock | Test Platform |
-| Entry point | Platform-defined | Fixed (main) | Fixed (main) | Platform-defined |
+| Startup contract | Platform-defined | Fixed (main) | Fixed (main) | Platform-defined |
 | Concurrency | Platform-provided | Built-in runtime | Effect handler | Effect handler |
 
 ### CLI command reference
@@ -1877,7 +1864,7 @@ The compiler generates a capability routing table mapping each effect to its han
 | `E3006` | Shadowing conflict | Import alias conflicts with module name |
 | `E4201` | Effect handler conflict | Multiple Platforms handle the same effect |
 | `E4202` | Missing effect handler | No Platform handles a required effect |
-| `E4203` | Entry point type mismatch | `main` signature doesn't match Platform requirement |
+| `E4203` | Startup contract mismatch | Startup function signature doesn't match Platform requirement |
 
 ### Diagnostic structure
 
@@ -2078,7 +2065,7 @@ field          ::= IDENT ':' type
 platform_decl  ::= 'platform' IDENT '{' platform_body '}'
 platform_body  ::= ('version:' STRING)?
                    ('handles' cap_list)
-                   ('entry:' type)
+                   ('startup:' type)
                    handler_decl*
 
 // Handler declarations
@@ -2090,12 +2077,13 @@ effect_decl    ::= 'effect' IDENT '{' effect_fn* '}'
 effect_fn      ::= 'fn' IDENT '(' params ')' '->' type
 
 // spore.toml (TOML subset)
-// [package]       name, version, type, description, license, authors, spore-version
+// [package]       name, version, type, description, license, authors, spore-version, default-entry
 // [capabilities]  allowed
 // [dependencies]  <name> = { git|path|alias, sig, impl?, optional?, branch?, tag?, rev? }
 // [dev-dependencies]
 // [features]      <name> = [deps/features]
-// [platforms]     <name> = { git, version?, priority?, handles? }
+// [entries.<name>] path = STRING
+// [platform]      git|path, version?, handles?
 // [overrides]     <name> = { sig, impl }
 // [build]         script
 // [metadata]      arbitrary key-value

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -600,10 +600,10 @@ handler MockClock {
 }
 ```
 
-Running `spore test tests/**/*.sp` automatically uses the Test Platform:
+Running `spore test tests/fetch_weather_test.sp` automatically uses the Test Platform:
 
 ```bash
-$ spore test tests/**/*.sp
+$ spore test tests/fetch_weather_test.sp
    Using test platform: spore-platform/test v1.0.0
    Running 3 tests
 
@@ -753,9 +753,9 @@ $ spore check src/billing/invoice.sp
 **Full workflow**:
 
 ```bash
-spore check src/**/*.sp        # see [info] diagnostics suggesting capabilities
+spore check src/billing/invoice.sp
 # add the suggested #![uses(...)] pragma manually or via editor tooling
-spore check src/**/*.sp        # clean: no more [info] suggestions
+spore check src/billing/invoice.sp
 ```
 
 The current public CLI reports the inferred capability pragma in diagnostics, but
@@ -1597,14 +1597,14 @@ effect Exit   { fn exit(code: I32) -> Never }
 #### Module and build commands
 
 ```text
-spore check [path...]           Check one or more source / entry files
-spore build [path]             Build the current project or one explicit file
-spore test [path...]           Validate test / spec files
-spore fmt [path...]            Format source, including import ordering
-sporec compile [path...]       Compile explicit input files
-sporec holes [path]            List holes in a source file
-sporec query-hole [path] [id]  Inspect one named hole in a source file
-sporec explain [code]          Explain one diagnostic code
+spore check [path...]            Check one or more source / entry files
+spore build [path]               Build the current project or one explicit file
+spore test [path...]             Validate test / spec files
+spore fmt [path...]              Format source, including import ordering
+sporec compile [path...]         Compile explicit input files
+sporec holes [path]              List holes in a source file
+sporec query-hole [path] [id]    Inspect one named hole in a source file
+sporec explain [code]            Explain one diagnostic code
 ```
 
 #### Snapshot and lock commands
@@ -1675,10 +1675,10 @@ spore add https://github.com/spore-std/json --sig-only
 spore check src/main.sp
 
 # 4. Format before review
-spore fmt src/**/*.sp
+spore fmt src/main.sp src/cli.sp
 
 # 5. Build and test
-spore build && spore test tests/**/*.sp
+spore build && spore test tests/main_test.sp
 
 # 6. If a dependency's signature changed, review and accept
 spore --permit billing.tax.calculate
@@ -1706,7 +1706,7 @@ spore run src/main.sp
 ```bash
 spore deps                      # view current dependency tree
 spore update http               # update to latest commit
-spore test tests/**/*.sp        # verify tests still pass
+spore test tests/http_test.sp   # verify tests still pass
 spore audit                     # check for capability changes
 git add .spore-lock spore.toml
 git commit -m "Update http to latest"

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -20,7 +20,7 @@ superseded_by: null
 
 ## Summary
 
-This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via dot-separated paths (`import billing.invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `spore.lock` for reproducible builds, how dependencies are resolved without semantic versioning, how IO is abstracted through the Platform system using effect handlers, and how a two-layer capability ceiling (project-wide in `spore.toml` + file-level `#![uses(...)]` pragma) secures the supply chain.
+This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via dot-separated paths (`import billing.invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `.spore-lock` for reproducible builds, how dependencies are resolved without semantic versioning, how IO is abstracted through the Platform system using effect handlers, and how a two-layer capability ceiling (project-wide in `spore.toml` + file-level `#![uses(...)]` pragma) secures the supply chain.
 
 The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Elixir/Python (dot-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the two-layer capability ceiling, the import/alias separation, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
 
@@ -67,19 +67,19 @@ In traditional languages, IO operations are built into the standard library, mak
 
 ### Module declaration
 
-Every `.spore` file is exactly one module. The module name is derived from the file's path relative to the package's `src/` root:
+Every `.sp` file is exactly one module. The module name is derived from the file's path relative to the package's `src/` root:
 
 | File Path | Module Name |
 |---|---|
-| `src/billing/invoice.spore` | `billing.invoice` |
-| `src/auth/token.spore` | `auth.token` |
-| `src/utils.spore` | `utils` |
-| `src/main.spore` | `main` |
+| `src/billing/invoice.sp` | `billing.invoice` |
+| `src/auth/token.sp` | `auth.token` |
+| `src/utils.sp` | `utils` |
+| `src/main.sp` | `main` |
 
 There is no `module` keyword — the filesystem **is** the declaration. A file-level pragma may narrow the module's capability ceiling (see [Two-layer capability ceiling](#two-layer-capability-ceiling)):
 
 ```spore
-// src/billing/invoice.spore
+// src/billing/invoice.sp
 #![uses(PaymentGateway, AuditLog)]
 
 import billing.types
@@ -158,13 +158,13 @@ my-billing-lib/
 ├── spore.toml              // package manifest
 ├── src/
 │   ├── billing/
-│   │   ├── invoice.spore   -- module: billing.invoice
-│   │   ├── tax.spore       -- module: billing.tax
-│   │   └── types.spore     -- module: billing.types
-│   └── utils.spore         -- module: utils
+│   │   ├── invoice.sp   -- module: billing.invoice
+│   │   ├── tax.sp       -- module: billing.tax
+│   │   └── types.sp     -- module: billing.types
+│   └── utils.sp         -- module: utils
 └── test/
     └── billing/
-        └── invoice_test.spore
+        └── invoice_test.sp
 ```
 
 Three package types exist:
@@ -208,11 +208,11 @@ The same application code can run on different Platforms—CLI, Web, WASM, Embed
 
 #### File-to-module mapping
 
-The compiler maps `.spore` files to modules using the path relative to `src/`:
+The compiler maps `.sp` files to modules using the path relative to `src/`:
 
 ```text
 module_name = path.relative_to("src/")
-                  .strip_extension(".spore")
+                  .strip_extension(".sp")
                   // path separators become '.' in the module name
 ```
 
@@ -223,15 +223,15 @@ convention, not by special module semantics.
 
 #### Empty modules
 
-An empty `.spore` file is a valid module. It compiles successfully, exports nothing, and has no capabilities:
+An empty `.sp` file is a valid module. It compiles successfully, exports nothing, and has no capabilities:
 
 ```spore
-// src/billing/future.spore
+// src/billing/future.sp
 // This module is a placeholder for future billing features.
 ```
 
 ```text
-$ sporec check src/billing/future.spore
+$ spore check src/billing/future.sp
 
 [ok] billing.future
   exports: (none)
@@ -249,7 +249,7 @@ The compiler builds a directed acyclic graph (DAG) of module dependencies:
 3. Determine topological build order. Modules at the same level compile in parallel.
 
 ```text
-$ sporec build --show-order
+$ spore build --show-order
 
 Build order (topological):
   1. billing.types       (0 dependencies)
@@ -279,7 +279,7 @@ qualified_item ::= module_path '.' IDENT
 
 #### Import ordering convention
 
-The compiler does not enforce import order, but `sporec fmt` auto-sorts imports into four groups separated by blank lines:
+The compiler does not enforce import order, but `spore fmt` auto-sorts imports into four groups separated by blank lines:
 
 ```spore
 // 1. Platform / standard library imports
@@ -384,7 +384,7 @@ Compatibility checking uses only `sig`: if `sig` is unchanged, dependents need n
 When a signature changes, all downstream modules referencing the old `sig` are flagged:
 
 ```text
-$ sporec check
+$ spore check
 
 [warning] signature changed: billing.tax.calculate
   old sig: d91e4b
@@ -436,17 +436,17 @@ alias Compute = billing.invoice.compute_totals          // private alias
 Attempting to access a private item from another module:
 
 ```text
-[error] visibility violation at src/api/handler.spore:15
+[error] visibility violation at src/api/handler.sp:15
   billing.invoice.compute_totals is private
   ─── it is only visible within module billing.invoice
 
-  help: add `pub` or `pub(pkg)` to its definition in src/billing/invoice.spore
+  help: add `pub` or `pub(pkg)` to its definition in src/billing/invoice.sp
 ```
 
 Attempting to access a `pub(pkg)` item from an external package:
 
 ```text
-[error] visibility violation at src/handler.spore:8
+[error] visibility violation at src/handler.sp:8
   billing.invoice.validate is pub(pkg)
   ─── it is only visible within the 'my-billing-lib' package
   ─── your module 'handler' is in the 'my-api' package
@@ -460,7 +460,7 @@ Holes inherit the visibility context of their enclosing function. A HoleReport i
 
 ```json
 {
-  "hole": { "name": "payment_logic", "location": "src/api/handler.spore:15" },
+  "hole": { "name": "payment_logic", "location": "src/api/handler.sp:15" },
   "candidates": [
     {
       "function": "billing.invoice.generate_invoice",
@@ -491,7 +491,7 @@ This ensures agents filling holes never suggest inaccessible functions.
 The only re-export mechanism is `pub alias`:
 
 ```spore
-// src/billing/shortcuts.spore
+// src/billing/shortcuts.sp
 import billing.invoice
 import billing.types
 
@@ -656,7 +656,7 @@ This defines the maximum set of capabilities available to **any** file in the pr
 Individual files can narrow the project ceiling to declare the maximum capabilities their functions may use:
 
 ```spore
-// src/billing/invoice.spore
+// src/billing/invoice.sp
 #![uses(PaymentGateway, AuditLog)]
 ```
 
@@ -667,10 +667,10 @@ Individual files can narrow the project ceiling to declare the maximum capabilit
 
 **Example — two layers in action:**
 
-`spore.toml` allows `IO`, `FileRead`, `FileWrite`, `Net`, `PaymentGateway`, `AuditLog`. But `src/billing/invoice.spore` only needs payment and audit:
+`spore.toml` allows `IO`, `FileRead`, `FileWrite`, `Net`, `PaymentGateway`, `AuditLog`. But `src/billing/invoice.sp` only needs payment and audit:
 
 ```spore
-// src/billing/invoice.spore
+// src/billing/invoice.sp
 #![uses(PaymentGateway, AuditLog)]
 
 import billing.types
@@ -681,10 +681,10 @@ pub fn generate_invoice(order: Order) -> Invoice ! TaxError
 { ... }
 ```
 
-Meanwhile, `src/net/client.spore` needs only network capabilities:
+Meanwhile, `src/net/client.sp` needs only network capabilities:
 
 ```spore
-// src/net/client.spore
+// src/net/client.sp
 #![uses(Net)]
 
 pub fn fetch(url: Url) -> Result[Bytes, NetError]
@@ -692,7 +692,7 @@ pub fn fetch(url: Url) -> Result[Bytes, NetError]
 { ... }
 ```
 
-If the `#![uses(...)]` pragma is omitted, the compiler **infers** the ceiling from the union of all `pub` functions' capabilities and emits an `[info]` diagnostic suggesting the explicit declaration. The `sporec --fixes` flag auto-applies the inferred pragma.
+If the `#![uses(...)]` pragma is omitted, the compiler **infers** the ceiling from the union of all `pub` functions' capabilities and emits an `[info]` diagnostic suggesting the explicit declaration. The `sporec --fix` flag auto-applies the inferred pragma.
 
 #### Capability propagation
 
@@ -703,7 +703,7 @@ Importing a module does **not** grant its capabilities. If you call a function t
 Private functions are **also** bound by the module's capability ceiling (if declared). However, they do **not** contribute to the inferred capability set:
 
 ```spore
-// src/billing/invoice.spore
+// src/billing/invoice.sp
 #![uses(PaymentGateway, AuditLog)]
 
 pub fn generate_invoice(order: Order) -> Invoice ! TaxError
@@ -722,7 +722,7 @@ fn send_email(to: Email, body: String) -> Unit ! SmtpError
 ```
 
 ```text
-[error] capability ceiling violation at src/billing/invoice.spore:12
+[error] capability ceiling violation at src/billing/invoice.sp:12
   function send_email uses [EmailService]
   module billing.invoice allows [PaymentGateway, AuditLog]
   ─── EmailService is not in the module's capability set
@@ -732,14 +732,14 @@ fn send_email(to: Email, body: String) -> Unit ! SmtpError
         or move this function to a module that allows EmailService
 ```
 
-#### Capability violation error examples and `--fixes` flow
+#### Capability violation error examples and `--fix` flow
 
 **Ceiling violation**: The error shown above.
 
-**Auto-fix with `sporec --fixes`**: When a module omits its capability pragma, the compiler infers it:
+**Auto-fix with `sporec --fix`**: When a module omits its capability pragma, the compiler infers it:
 
 ```text
-$ sporec check src/billing/invoice.spore
+$ spore check src/billing/invoice.sp
 
 [ok] billing.invoice
   exports: generate_invoice, void_invoice
@@ -752,12 +752,12 @@ $ sporec check src/billing/invoice.spore
 **Full workflow**:
 
 ```bash
-sporec check src/              # see [info] diagnostics suggesting capabilities
-sporec --fixes src/            # auto-apply all capability declarations
-sporec check src/              # clean: no more [info] suggestions
+spore check src/               # see [info] diagnostics suggesting capabilities
+sporec --fix src/              # auto-apply all capability declarations
+spore check src/               # clean: no more [info] suggestions
 ```
 
-The `--fixes` flag writes the inferred capability pragma as the first line of the module file.
+The `--fix` flag writes the inferred capability pragma as the first line of the module file.
 
 ### Package management
 
@@ -1059,9 +1059,9 @@ All fetched dependencies are cached in `.spore-store/`:
 │       └── interface.spore-sig
 ├── impls/                   # Implementation cache
 │   ├── 7b8d4f2a.../
-│   │   └── module.spore
+│   │   └── module.sp
 │   └── 2f3e4d5c.../
-│       └── module.spore
+│       └── module.sp
 ├── git/                     # Git source cache
 │   └── github.com/
 │       └── user/
@@ -1097,7 +1097,7 @@ pub trait StorageBackend {
 **Cache strategy**:
 
 - **Content-addressed**: Identical hashes share storage. Two packages using the same dependency version store it once.
-- **Global shared**: By default `~/.spore-store` is shared across all projects. Configurable via `~/.spore/config.toml`.
+- **Global shared**: By default `~/.spore-store` is shared across all projects. Configurable via `~/.sp/config.toml`.
 - **Offline-capable**: Once cached, dependencies are available without network access.
 
 **Garbage collection**:
@@ -1185,7 +1185,7 @@ Holes respect module boundaries:
 - A module calling a partial function becomes **transitively partial**.
 
 ```text
-$ sporec --holes
+$ sporec holes
 
 Holes by module:
 
@@ -1233,7 +1233,7 @@ Snapshots use `sig` hashes only at the module and package level (impl changes do
 Error types follow the same visibility rules as all other types. A function's error list (`! TaxError`) must reference only error types visible from the function's module:
 
 ```spore
-// src/api/handler.spore
+// src/api/handler.sp
 import billing.invoice
 import billing.errors
 
@@ -1253,14 +1253,14 @@ pub fn handle_create(req: Request) -> Response ! errors.BillingError | ParseErro
 A module containing only type definitions is valid and pure:
 
 ```spore
-// src/billing/types.spore
+// src/billing/types.sp
 pub type Invoice { id: InvoiceId, total: Money, status: InvoiceStatus }
 pub type InvoiceStatus { Draft, Sent, Paid, Void }
 pub type LineItem { description: String, quantity: Int, unit_price: Money }
 ```
 
 ```text
-$ sporec check src/billing/types.spore
+$ spore check src/billing/types.sp
 
 [ok] billing.types
   exports: Invoice, InvoiceStatus, LineItem
@@ -1299,12 +1299,12 @@ impl = "e9f3d2"
 Partial modules can be imported and their types used. Only function calls at runtime are blocked:
 
 ```spore
-// src/billing/invoice.spore (has holes)
+// src/billing/invoice.sp (has holes)
 pub fn generate_invoice(order: Order) -> Invoice ! TaxError {
     ?invoice_logic
 }
 
-// src/api/handler.spore
+// src/api/handler.sp
 import billing.invoice
 
 // Compiles fine — handler is transitively partial
@@ -1315,7 +1315,7 @@ pub fn handle(req: Request) -> Response ! ApiError {
 ```
 
 ```text
-$ sporec check
+$ spore check
 
 [partial] billing.invoice.generate_invoice
   holes: ?invoice_logic
@@ -1329,7 +1329,7 @@ Build: success (2 partial functions)
 #### Alias chains are forbidden
 
 ```text
-[error] alias chain detected at src/api/shortcuts.spore:3
+[error] alias chain detected at src/api/shortcuts.sp:3
   api_gen → billing.shortcuts.gen → billing.invoice.generate_invoice
   ─── aliases must point directly to original definitions
 
@@ -1495,7 +1495,7 @@ Creating a new Platform follows six steps:
 spore init my-platform --type platform
 ```
 
-**Step 2**: Define the Platform contract in `platform.spore`:
+**Step 2**: Define the Platform contract in `platform.sp`:
 
 ```spore
 platform EmbeddedPlatform {
@@ -1513,7 +1513,7 @@ platform EmbeddedPlatform {
 **Step 3**: Implement effect handlers:
 
 ```spore
-// handlers/gpio.spore
+// handlers/gpio.sp
 handler GpioHandler {
     Gpio.read(pin: U8) -> Bool {
         resume(ffi_gpio_read(pin))
@@ -1595,13 +1595,13 @@ effect Exit   { fn exit(code: I32) -> Never }
 #### Module and build commands
 
 ```text
-sporec check [path]           Check modules for errors
-sporec check --show-deps      Show dependency graph
-sporec build                  Build all modules in topological order
-sporec build --show-order     Show build order
-sporec --holes [path]         List all holes across modules
-sporec --fixes [path]         Auto-apply inferred capability declarations
-sporec fmt [path]             Format source, including import ordering
+spore check [path]            Check modules for errors
+spore check --show-deps       Show dependency graph
+spore build                   Build project entries in topological order
+spore build --show-order      Show module build order
+sporec holes [path]           List all holes across modules
+sporec --fix [path]           Auto-apply inferred capability declarations
+spore fmt [path]              Format source, including import ordering
 ```
 
 #### Snapshot and lock commands
@@ -1669,13 +1669,13 @@ spore add https://github.com/spore-std/http --alias std-http
 spore add https://github.com/spore-std/json --sig-only
 
 # 3. Write code, then check
-sporec check src/
+spore check src/
 
 # 4. Auto-apply capability declarations
-sporec --fixes src/
+sporec --fix src/
 
 # 5. Build and test
-sporec build && spore test
+spore build && spore test
 
 # 6. If a dependency's signature changed, review and accept
 spore --permit billing.tax.calculate
@@ -1693,8 +1693,8 @@ mkdir my-app && cd my-app
 spore init
 spore add https://github.com/spore-std/http --alias std-http
 spore add https://github.com/spore-std/json --sig-only
-sporec check src/
-sporec build
+spore check src/
+spore build
 spore run --allow network:listen:8080
 ```
 
@@ -1736,7 +1736,7 @@ utils = { path = "../utils", sig = "...", impl = "..." }
 ```bash
 # After editing core or utils:
 spore update --recompute-hash   # update hashes for path deps
-sporec build
+spore build
 ```
 
 #### Scenario 5: Publish a package
@@ -1773,14 +1773,14 @@ git push origin main --tags
 
 ### Readability and navigation
 
-- **File = module** eliminates the confusion of Rust's `mod`/`use` distinction or OCaml's separate `.mli` files. Opening a `.spore` file immediately tells you the module name — no `module` keyword needed.
+- **File = module** eliminates the confusion of Rust's `mod`/`use` distinction or OCaml's separate `.mli` files. Opening a `.sp` file immediately tells you the module name — no `module` keyword needed.
 - **Dot-separated imports** (`import billing.invoice`) use a uniform separator for both path segments and item access, avoiding the confusion of mixing `/` and `.`. The import path mirrors the module name directly.
 - **Import/alias separation** removes ambiguity: `import` always means module, `alias` always means item.
 - **Three visibility levels** are intuitive. The default is private; opt-in to exposure via `pub` or `pub(pkg)`.
 
 ### Workflow ergonomics
 
-- **`sporec --fixes`** auto-applies inferred capability declarations, lowering the barrier for new users.
+- **`sporec --fix`** auto-applies inferred capability declarations, lowering the barrier for new users.
 - **`spore --permit`** provides explicit acknowledgment of breaking changes, preventing accidental API breakage.
 - **No semver** means developers never debate whether a change is "major" or "minor". The compiler decides mechanically.
 
@@ -1862,7 +1862,7 @@ The compiler generates a capability routing table mapping each effect to its han
 | `E3004` | Signature change detected | `sig` hash mismatch in `.spore-lock` |
 | `E3005` | Alias chain | `pub alias` pointing to another alias |
 | `E3006` | Shadowing conflict | Import alias conflicts with module name |
-| `E4201` | Effect handler conflict | Multiple Platforms handle the same effect |
+| `E4201` | Platform binding conflict | Project declares more than one Platform binding |
 | `E4202` | Missing effect handler | No Platform handles a required effect |
 | `E4203` | Startup contract mismatch | Startup function signature doesn't match Platform requirement |
 
@@ -1938,7 +1938,7 @@ Unison pioneered content-addressed functions where every definition is identifie
 
 ### Roc
 
-Roc's platform/package separation is the primary inspiration for Spore's Platform system. Roc demonstrated that packages can be pure by default, with IO delegated entirely to the Platform. Spore extends this with algebraic effect handlers (Roc uses tag unions) and multi-Platform support.
+Roc's platform/package separation is the primary inspiration for Spore's Platform system. Roc demonstrated that packages can be pure by default, with IO delegated entirely to the Platform. Spore extends this with algebraic effect handlers (Roc uses tag unions), named entries, and explicit startup contracts.
 
 ### Elm
 
@@ -1998,7 +1998,7 @@ New fields added to `.spore-lock` are ignored by older tools (forward-compatible
 
 The module system does not require wholesale adoption:
 
-- Packages can start with inferred capabilities (no `#![uses(...)]` pragma) and add explicit declarations later via `sporec --fixes`.
+- Packages can start with inferred capabilities (no `#![uses(...)]` pragma) and add explicit declarations later via `sporec --fix`.
 - Dependencies can mix Git, local path, and registry sources.
 - The `version` field in `spore.toml` remains available for human communication during the transition from semver.
 
@@ -2095,11 +2095,11 @@ effect_fn      ::= 'fn' IDENT '(' params ')' '->' type
 
 | Command | Description |
 |---|---|
-| `sporec check [path]` | Check modules for errors and warnings |
-| `sporec build` | Compile all modules in topological order |
-| `sporec --holes [path]` | List all holes in modules |
-| `sporec --fixes [path]` | Auto-apply inferred capability declarations |
-| `sporec fmt [path]` | Format source code (including import ordering) |
+| `spore check [path]` | Check modules for errors and warnings |
+| `spore build` | Build project entries in topological order |
+| `sporec holes [path]` | List all holes in modules |
+| `sporec --fix [path]` | Auto-apply inferred capability declarations |
+| `spore fmt [path]` | Format source code (including import ordering) |
 
 ### Snapshot and hash commands
 


### PR DESCRIPTION
## Proposal summary

- clarify project `entry` vs `entry module` vs Platform `startup contract`
- remove multi-Platform wording from SEP-0008 and align one-project-one-Platform
- align SEP-0006 command examples with the current `spore` / `sporec` split

## Linked discussion

- https://github.com/spore-lang/spore-evolution/discussions/6
- https://github.com/spore-lang/spore-evolution/discussions/8

## Pre-submission checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.

## Proposal checklist

- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

- This PR establishes terminology and scope boundaries only.
- It does not yet introduce the standalone script-mode SEP.
- It does not yet finish the full manifest follow-up beyond removing current ambiguity.