### PR TITLE
📝 docs(seps): safe canon sweep

### DIFF
--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -1342,41 +1342,21 @@ fn example() {
 }
 ```
 
-#### HoleReport JSON format
+#### Hole protocol reference
 
-When queried (`sporec query-hole <file> <name>`), the compiler emits a structured report:
+`sporec query-hole <file> <name> --json` returns one hole object from the shared typed-hole protocol, and `sporec holes <file> --json` returns the batch form with both `holes` and `dependency_graph`. SEP-0005 is the authoritative schema and workflow specification; SEP-0001 intentionally avoids freezing a second inline JSON shape here.
 
-```json
-{
-  "hole": "validate_logic",
-  "expected_type": "Receipt",
-  "bindings": {
-    "amount": "Money",
-    "method": "PaymentMethod"
-  },
-  "available_capabilities": ["NetConnect"],
-  "candidate_functions": [
-    "payment_gateway.charge(amount: Money, method: PaymentMethod) -> Receipt ! Declined | InsufficientFunds uses [NetConnect]"
-  ],
-  "error_types_to_handle": ["Declined", "InsufficientFunds"],
-  "spec": {
-    "examples": [
-      {
-        "label": "successful charge",
-        "expr": "validate(Money(100), CreditCard(\"4242...\")).is_ok()"
-      }
-    ],
-    "properties": [
-      {
-        "label": "idempotent",
-        "predicate": "|a: Money, m: PaymentMethod| validate(a, m) == validate(a, m)"
-      }
-    ]
-  }
-}
-```
+At minimum, the shared hole object includes:
 
-When a function has both a `spec` block and a hole body, the HoleReport includes the spec items as additional constraints. This gives hole-filling agents a self-contained behavioral contract alongside the existing type and capability context, even though the examples and properties are not yet runnable without hitting the hole.
+- `name` / `display_name`
+- `location`
+- `expected_type` / `type_inferred_from`
+- `function` / `enclosing_signature`
+- `bindings` / `binding_dependencies`
+- `capabilities`, `errors_to_handle`, `cost_budget`
+- `candidates`, `dependent_holes`, `confidence`, `error_clusters`
+
+When a function has both a `spec` block and a hole body, that shared hole object may surface the `spec` items as additional behavioral context for tooling. The authoritative transport and evolution rules remain in SEP-0005 so SEP-0001 does not accidentally freeze a stale field layout.
 
 ## Complete examples
 

--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -1344,7 +1344,7 @@ fn example() {
 
 #### HoleReport JSON format
 
-When queried (`sporec --query-hole ?name`), the compiler emits a structured report:
+When queried (`sporec query-hole <file> <name>`), the compiler emits a structured report:
 
 ```json
 {
@@ -1703,7 +1703,7 @@ Spore's explicit syntax enables highly specific error messages:
 
 ```text
 error[E0301]: function `fetch_data` uses effect `NetConnect` but does not declare it
-  --> src/api.spore:12:5
+  --> src/api.sp:12:5
    |
 12 | fn fetch_data(url: Url) -> Data ! NetworkError {
    |    ^^^^^^^^^^ missing `uses` clause
@@ -1716,7 +1716,7 @@ error[E0301]: function `fetch_data` uses effect `NetConnect` but does not declar
 
 ```text
 error[E0401]: non-exhaustive match expression
-  --> src/main.spore:25:5
+  --> src/main.sp:25:5
    |
 25 | match color {
    |       ^^^^^ missing variant `Blue`
@@ -1728,7 +1728,7 @@ error[E0401]: non-exhaustive match expression
 
 ```text
 error[E0101]: `for` loops are not supported in Spore
-  --> src/main.spore:10:5
+  --> src/main.sp:10:5
    |
 10 | for x in list {
    | ^^^ Spore uses recursion and higher-order functions instead of loops
@@ -1741,7 +1741,7 @@ error[E0101]: `for` loops are not supported in Spore
 
 ```text
 error[E0501]: `spec` must appear after all other signature clauses
-  --> src/lib.spore:5:1
+  --> src/lib.sp:5:1
    |
  5 | spec { ... }
  6 | cost ≤ 500
@@ -1753,7 +1753,7 @@ error[E0501]: `spec` must appear after all other signature clauses
 
 ```text
 spec failure: `parse_date` — example "ISO 8601"
-  --> src/dates.spore:5:5
+  --> src/dates.sp:5:5
    |
  5 |     example "ISO 8601": parse_date("2024-01-15") == Ok(Date(2024, 1, 15))
    |
@@ -1765,7 +1765,7 @@ spec failure: `parse_date` — example "ISO 8601"
 
 ```text
 spec counterexample: `parse_date` — property "round-trip"
-  --> src/dates.spore:9:5
+  --> src/dates.sp:9:5
    |
  9 |     property "round-trip": |d: Date| parse_date(d.to_iso_string()) == Ok(d)
    |
@@ -1778,7 +1778,7 @@ spec counterexample: `parse_date` — property "round-trip"
 
 ```text
 warning[W0501]: public function `parse_date` has no `spec` block
-  --> src/dates.spore:3:1
+  --> src/dates.sp:3:1
    |
  3 | pub fn parse_date(s: String) -> Result[Date, ParseError] ! ParseError {
    |        ^^^^^^^^^^ no behavioral contract declared

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -1732,7 +1732,7 @@ Agents can query this registry to discover available functions, match types, and
 
 ### Hole reporting
 
-The checker tracks `HoleReport` — a map from hole names to their inferred expected types, available variables in scope, and suggested fill functions. This structured output is the primary input for Agent hole-filling strategies.
+The checker feeds the shared typed-hole protocol defined in SEP-0005. In practice, `sporec holes FILE --json` returns a batch object with `holes` plus `dependency_graph`, and `sporec query-hole FILE ?name --json` returns one hole object with the same inferred type, scope, and candidate information. This structured output is the primary input for Agent hole-filling strategies.
 
 ## Structured representation / protocol impact
 
@@ -1767,12 +1767,21 @@ Function signatures (parameter types, return type, error set, CapSet, cost bound
 
 ### Machine-readable output
 
-Type errors are emitted as structured JSON for Agent consumption:
+Type diagnostics participate in the shared diagnostics protocol described in SEP-0006. This SEP relies on the canonical type rendering, stable codes, severities, and spans provided by that protocol rather than defining a competing JSON schema.
 
 ```json
-{"error": "type_mismatch", "context": "function `add`",
- "expected": "Int", "actual": "String",
- "location": "main.sp:5:12"}
+{
+  "code": "E0301",
+  "severity": "error",
+  "message": "type mismatch: expected `Int`, found `String`",
+  "primary_span": {
+    "file": "main.sp",
+    "range": {
+      "start": { "line": 5, "col": 12 },
+      "end": { "line": 5, "col": 18 }
+    }
+  }
+}
 ```
 
 ## Diagnostics impact
@@ -1792,7 +1801,7 @@ Type errors are emitted as structured JSON for Agent consumption:
 
 ### Dual-channel diagnostics
 
-Every diagnostic is emitted in both machine-readable (JSON v0) and human-readable (Elm-style v2) formats. The type system provides:
+Every diagnostic is emitted as human-readable and machine-readable projections over the shared diagnostic objects described in SEP-0006. For the type system, those projections must preserve:
 
 - The **expected type** (from check mode / declared return type).
 - The **actual type** (from synth mode / expression).
@@ -1801,7 +1810,7 @@ Every diagnostic is emitted in both machine-readable (JSON v0) and human-readabl
 
 ### Hole diagnostics
 
-For each hole, the checker reports:
+For each hole, the checker reports the type-system facts that feed the shared SEP-0005 hole object rather than inventing a second hole-specific schema in this SEP.
 
 ```text
 Hole ?h1 in function `example`:

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -1772,7 +1772,7 @@ Type errors are emitted as structured JSON for Agent consumption:
 ```json
 {"error": "type_mismatch", "context": "function `add`",
  "expected": "Int", "actual": "String",
- "location": "main.spore:5:12"}
+ "location": "main.sp:5:12"}
 ```
 
 ## Diagnostics impact

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -244,7 +244,7 @@ fn save_data(data: Data) -> Unit {
 
 ```text
 error[cap-violation]: function body uses undeclared effect
-  --> src/storage.spore:1:1
+  --> src/storage.sp:1:1
    |
  1 | fn save_data(data: Data) -> Unit {
    |    ^^^^^^^^^ no `uses` clause declared
@@ -617,7 +617,7 @@ When an agent or developer fills a Hole with code that exceeds the available set
 
 ```text
 ERROR [cap-violation] Hole ?fetch_logic filled code uses unauthorised effects:
-  --> src/service.spore:15:5
+  --> src/service.sp:15:5
    |
 15 |     ?fetch_logic    // filled with: fetch_and_save(url)
    |     ^^^^^^^^^^^^ hole fill exceeds available effects
@@ -865,7 +865,7 @@ Example diagnostic:
 
 ```text
 error[cap-violation]: function body uses undeclared effect
-  --> src/app.spore:12:5
+  --> src/app.sp:12:5
    |
 10 | fn process(data: Data) -> Result
 11 | uses [FileRead]

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -21,7 +21,7 @@ superseded_by: null
 
 This SEP introduces Spore's **effect system**: a compile-time mechanism that tracks how functions interact with the outside world. Every function declares — via a `uses [...]` clause — the set of *atomic effects* it requires. The compiler verifies that a function body never exercises an effect absent from its declared set, auto-infers semantic properties (pure, deterministic, total) from that set, and uses set-inclusion as the basis for subtyping and effect narrowing.
 
-The built-in effect vocabulary is **intent-oriented**: each built-in effect answers "What does this code intend to do with the outside world?" Pure computation is the default state — no effect declaration is needed for it. Mutable state is tracked by the language semantics, not by built-in external effect names. In compiler internals and tooling protocols, these effect names form the capability set used for subset checks, platform ceilings, and machine-readable fields such as `available_capabilities`.
+The built-in effect vocabulary is **intent-oriented**: each built-in effect answers "What does this code intend to do with the outside world?" Pure computation is the default state — no effect declaration is needed for it. Mutable state is tracked by the language semantics, not by built-in external effect names. In compiler internals and tooling protocols, these effect names form the capability set used for subset checks, platform ceilings, and machine-readable fields such as `capabilities`.
 
 The design is intentionally **flat and monomorphic**: effect sets are finite sets of atomic identifiers with no effect variables, no row types, and no effect polymorphism. Named aliases (`effect X = A | B`) provide ergonomics without adding expressiveness. Higher-order functions such as `map` accept only pure (`uses []`) closures; effectful iteration is expressed through `parallel_scope` + `spawn`.
 
@@ -277,7 +277,7 @@ The module-level `uses` clause is **optional**. When omitted the compiler auto-i
 
 ### `@allows` — restricting Hole candidates
 
-The `@allows` annotation constrains which functions an AI agent (or developer) may use to fill a Hole. It acts as a filter on `candidate_functions` in the `HoleReport`:
+The `@allows` annotation constrains which functions an AI agent (or developer) may use to fill a Hole. In the shared SEP-0005 hole protocol, this shows up as a filtered `candidates` list rather than as a separate bespoke schema.
 
 ```spore
 fn process_input(raw: String) -> SafeInput ! ValidationError {
@@ -286,21 +286,31 @@ fn process_input(raw: String) -> SafeInput ! ValidationError {
 }
 ```
 
-The generated `HoleReport` includes the restriction:
+A representative machine-readable view is:
 
 ```json
 {
-  "hole": "clean_input",
+  "name": "clean_input",
+  "display_name": "?clean_input",
   "expected_type": "SafeInput",
-  "allows": ["validate", "sanitize"],
-  "candidate_functions": [
-    "validate(raw: String) -> SafeInput ! ValidationError",
-    "sanitize(raw: String) -> SafeInput ! ValidationError"
+  "candidates": [
+    {
+      "name": "validate",
+      "type_match": 1.0,
+      "capability_fit": 1.0,
+      "overall": 1.0
+    },
+    {
+      "name": "sanitize",
+      "type_match": 1.0,
+      "capability_fit": 1.0,
+      "overall": 1.0
+    }
   ]
 }
 ```
 
-Without `@allows`, all functions matching the type and effect constraints appear. With `@allows`, the candidate list is further filtered to only the named functions.
+Without `@allows`, all functions matching the type and effect constraints may appear. With `@allows`, the candidate list is further filtered to only the named functions.
 
 ### Pure recursive function example — fibonacci
 
@@ -587,20 +597,30 @@ uses [FileRead, NetConnect]
 
 ### 11. Interaction with the Hole system
 
-When the compiler encounters a Hole (`?name`), the generated `HoleReport` includes the capability set available at that program point. The field is named `available_capabilities` for protocol compatibility, but its elements are the same intent-oriented effect names described in this SEP:
+When the compiler encounters a Hole (`?name`), the shared SEP-0005 hole object includes the capability set available at that program point under the field name `capabilities`:
 
 ```json
 {
-  "hole": "fetch_logic",
+  "name": "fetch_logic",
+  "display_name": "?fetch_logic",
   "expected_type": "Data",
   "bindings": {
     "url": "Url",
     "timeout": "Duration"
   },
-  "available_capabilities": ["NetConnect"],
-  "cost_budget": 5000,
-  "candidate_functions": [
-    "http.get(url: Url) -> Data ! NetworkError uses [NetConnect]"
+  "capabilities": ["NetConnect"],
+  "cost_budget": {
+    "budget_total": 5000,
+    "cost_before_hole": 0,
+    "budget_remaining": 5000
+  },
+  "candidates": [
+    {
+      "name": "http.get",
+      "type_match": 1.0,
+      "capability_fit": 1.0,
+      "overall": 1.0
+    }
   ]
 }
 ```
@@ -774,7 +794,7 @@ The `uses` clause makes a function's external interactions visible at a glance. 
 
 ### Structured effect information in HoleReport
 
-LLM-based agents filling Holes receive the `available_capabilities` field in the JSON `HoleReport`. This enables agents to:
+LLM-based agents filling Holes receive the `capabilities` field in the shared SEP-0005 hole object. This enables agents to:
 
 1. **Constrain code generation.** The agent knows which operations are permissible and avoids generating code that would fail effect checks.
 2. **Filter candidate functions.** Only functions whose `uses S` satisfies S ⊆ S_available are presented as candidates.
@@ -833,7 +853,7 @@ All effect alias definitions are collected into a structured registry available 
 
 ### LSP extensions
 
-The language server protocol integration should expose:
+The language server protocol integration should expose effect information through the shared hover and diagnostics pipeline described in SEP-0006:
 
 - Effect set in hover information for functions.
 - Inferred properties (`pure`, `deterministic`, `total`) in hover tooltips.

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -170,7 +170,7 @@ fn generate_invoice(
 **Step 2 — Agent queries holes:**
 
 ```text
-$ sporec --query-hole ?validate_items --json
+$ sporec query-hole src/billing/invoice.sp ?validate_items --json
 ```
 
 The compiler returns a HoleReport (see §4 for the full structure) containing: expected type `Vec[LineItem]`, available bindings, candidate function `validate_line_items` with an exact type match, cost 300 within budget 5000.
@@ -184,7 +184,7 @@ validate_line_items(items)
 **Step 4 — Compiler verifies:**
 
 ```text
-$ sporec check src/billing/invoice.spore
+$ spore check src/billing/invoice.sp
 
 [partial] generate_invoice
   ?validate_items: filled ✓ (cost 300)
@@ -510,7 +510,7 @@ Circular hole dependencies are **compile errors**. Detection uses standard DFS c
 
 ```text
 error[H0301]: circular hole dependency detected
-  --> src/order.spore
+  --> src/order.sp
   |
   | ?validate_order depends on ?check_inventory  (value dependency)
   | ?check_inventory depends on ?validate_order  (type dependency)
@@ -684,7 +684,7 @@ The Agent protocol defines a five-state machine with no explicit RETRY state:
                │ select a hole from ready_to_fill                │
                ▼                                                 │
           ┌──────────┐                                           │
-          │ ANALYZE  │── sporec --query-hole ?name --json        │
+          │ ANALYZE  │── sporec query-hole <file> <name> --json  │
           └────┬─────┘   receive full HoleReport v0.3            │
                │                                                 │
                │ generate fill code                              │
@@ -715,7 +715,7 @@ The Agent protocol defines a five-state machine with no explicit RETRY state:
 
 **DISCOVER**: The Agent starts `spore watch --json` and receives a `hole_graph_update` event containing the full dependency graph, `ready_to_fill` list, and `blocked` list. The Agent selects one or more holes from `ready_to_fill`.
 
-**ANALYZE**: For each selected hole, the Agent requests its HoleReport via `sporec --query-hole ?name --json`. It examines:
+**ANALYZE**: For each selected hole, the Agent requests its HoleReport via `sporec query-hole <file> <name> --json`. It examines:
 
 - `confidence.candidate_ranking`:
   - `"unique_best"` → use the top candidate directly
@@ -748,7 +748,7 @@ The Agent protocol defines a five-state machine with no explicit RETRY state:
       {
         "code": "E0301",
         "message": "type mismatch: expected Vec[ValidItem], found Vec[RawItem]",
-        "location": { "file": "src/orders.spore", "line": 18, "column": 5 },
+        "location": { "file": "src/orders.sp", "line": 18, "column": 5 },
         "suggestion": "consider using validate_items(raw_input).map(|i| i.into())"
       }
     ],
@@ -825,14 +825,14 @@ fn convert(input: ?InputType) -> ?OutputType
 **Reporting:**
 
 ```text
-$ sporec --holes --type-holes
+$ sporec holes --type-holes
 
 Type holes:
-  ?InputType   in convert (src/convert.spore:1)  — parameter type
-  ?OutputType  in convert (src/convert.spore:1)  — return type
+  ?InputType   in convert (src/convert.sp:1)  — parameter type
+  ?OutputType  in convert (src/convert.sp:1)  — return type
 
 Value holes:
-  ?conversion_logic  in convert (src/convert.spore:5)  — body
+  ?conversion_logic  in convert (src/convert.sp:5)  — body
 ```
 
 **Intended behavior:** When both type holes and value holes are present, the compiler first attempts to infer type holes from usage context (e.g., if `convert` is called with a known argument type). If inference succeeds, the value hole's expected type becomes determined. If inference fails, the value hole is reported with type `_` (unconstrained).
@@ -924,10 +924,10 @@ If the Agent fills with an impure expression:
 ### CLI interface
 
 ```text
-$ sporec --holes                         # list all holes
-$ sporec --holes --json                  # machine-readable
-$ sporec --query-hole ?name              # full HoleReport for one hole
-$ sporec --query-hole ?name --json       # JSON format
+$ sporec holes                           # list all holes
+$ sporec holes --json                    # machine-readable
+$ sporec query-hole <file> <name>        # full HoleReport for one hole
+$ sporec query-hole <file> <name> --json # JSON format
 $ sporec --simulate fn_name              # multi-path simulation
 $ spore holes --suggest-order            # topological ordering
 $ spore holes --graph                    # dependency graph visualization
@@ -1113,14 +1113,14 @@ t13        COMMIT ── all holes filled ────────────�
 
 All hole-related commands support `--json` for machine consumption.
 
-**`sporec --holes --json`:**
+**`sporec holes --json`:**
 
 ```json
 {
   "holes": [
     {
       "name": "charge_payment",
-      "location": { "file": "src/orders.spore", "line": 18, "column": 5 },
+      "location": { "file": "src/orders.sp", "line": 18, "column": 5 },
       "enclosing_function": "process_order",
       "expected_type": "Response ! PaymentFailed",
       "capabilities": ["Inventory", "PaymentGateway"],
@@ -1134,7 +1134,7 @@ All hole-related commands support `--json` for machine consumption.
 }
 ```
 
-**`sporec --query-hole ?name --json`:** Returns the full HoleReport v0.3 structure (see §4).
+**`sporec query-hole <file> <name> --json`:** Returns the full HoleReport v0.3 structure (see §4).
 
 **`spore watch --json`:** Emits an NDJSON event stream with `hole_graph_update`, `hole_update`, and `compile_result` events.
 
@@ -1149,8 +1149,8 @@ All hole-related commands support `--json` for machine consumption.
     "filled_holes": 3,
     "remaining_holes": 5,
     "ready_to_fill": [
-      { "name": "validate_input", "file": "src/order.spore", "line": 42 },
-      { "name": "check_auth", "file": "src/auth.spore", "line": 15 }
+      { "name": "validate_input", "file": "src/order.sp", "line": 42 },
+      { "name": "check_auth", "file": "src/auth.sp", "line": 15 }
     ],
     "blocked": [
       { "name": "process_order", "blocked_by": ["validate_input", "check_auth"] },
@@ -1229,7 +1229,7 @@ On failed fill: full diagnostic with `root_cause`, `fix_hints`, and `suggestion`
 
 ### Alternative 1: Anonymous Holes (`?`)
 
-Rejected. Anonymous holes create ambiguity in CLI queries (`sporec --query-hole ?` with multiple holes) and prevent clear communication between human and Agent. No mainstream language with typed holes (Agda, Idris, Lean) defaults to anonymous holes in practice — users always name them.
+Rejected. Anonymous holes create ambiguity in CLI queries (`sporec query-hole <file> ?` with multiple holes) and prevent clear communication between human and Agent. No mainstream language with typed holes (Agda, Idris, Lean) defaults to anonymous holes in practice — users always name them.
 
 ### Alternative 2: Holes Affect Signature Hashes
 

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -170,7 +170,7 @@ fn generate_invoice(
 **Step 2 — Agent queries holes:**
 
 ```text
-$ sporec query-hole src/billing/invoice.sp ?validate_items --json
+$ sporec --query-hole ?validate_items --json
 ```
 
 The compiler returns a HoleReport (see §4 for the full structure) containing: expected type `Vec[LineItem]`, available bindings, candidate function `validate_line_items` with an exact type match, cost 300 within budget 5000.
@@ -184,7 +184,7 @@ validate_line_items(items)
 **Step 4 — Compiler verifies:**
 
 ```text
-$ spore check src/billing/invoice.sp
+$ sporec check src/billing/invoice.spore
 
 [partial] generate_invoice
   ?validate_items: filled ✓ (cost 300)
@@ -510,7 +510,7 @@ Circular hole dependencies are **compile errors**. Detection uses standard DFS c
 
 ```text
 error[H0301]: circular hole dependency detected
-  --> src/order.sp
+  --> src/order.spore
   |
   | ?validate_order depends on ?check_inventory  (value dependency)
   | ?check_inventory depends on ?validate_order  (type dependency)
@@ -684,7 +684,7 @@ The Agent protocol defines a five-state machine with no explicit RETRY state:
                │ select a hole from ready_to_fill                │
                ▼                                                 │
           ┌──────────┐                                           │
-          │ ANALYZE  │── sporec query-hole <file> <name> --json  │
+          │ ANALYZE  │── sporec --query-hole ?name --json        │
           └────┬─────┘   receive full HoleReport v0.3            │
                │                                                 │
                │ generate fill code                              │
@@ -715,7 +715,7 @@ The Agent protocol defines a five-state machine with no explicit RETRY state:
 
 **DISCOVER**: The Agent starts `spore watch --json` and receives a `hole_graph_update` event containing the full dependency graph, `ready_to_fill` list, and `blocked` list. The Agent selects one or more holes from `ready_to_fill`.
 
-**ANALYZE**: For each selected hole, the Agent requests its HoleReport via `sporec query-hole <file> <name> --json`. It examines:
+**ANALYZE**: For each selected hole, the Agent requests its HoleReport via `sporec --query-hole ?name --json`. It examines:
 
 - `confidence.candidate_ranking`:
   - `"unique_best"` → use the top candidate directly
@@ -748,7 +748,7 @@ The Agent protocol defines a five-state machine with no explicit RETRY state:
       {
         "code": "E0301",
         "message": "type mismatch: expected Vec[ValidItem], found Vec[RawItem]",
-        "location": { "file": "src/orders.sp", "line": 18, "column": 5 },
+        "location": { "file": "src/orders.spore", "line": 18, "column": 5 },
         "suggestion": "consider using validate_items(raw_input).map(|i| i.into())"
       }
     ],
@@ -825,14 +825,14 @@ fn convert(input: ?InputType) -> ?OutputType
 **Reporting:**
 
 ```text
-$ sporec holes --type-holes
+$ sporec --holes --type-holes
 
 Type holes:
-  ?InputType   in convert (src/convert.sp:1)  — parameter type
-  ?OutputType  in convert (src/convert.sp:1)  — return type
+  ?InputType   in convert (src/convert.spore:1)  — parameter type
+  ?OutputType  in convert (src/convert.spore:1)  — return type
 
 Value holes:
-  ?conversion_logic  in convert (src/convert.sp:5)  — body
+  ?conversion_logic  in convert (src/convert.spore:5)  — body
 ```
 
 **Intended behavior:** When both type holes and value holes are present, the compiler first attempts to infer type holes from usage context (e.g., if `convert` is called with a known argument type). If inference succeeds, the value hole's expected type becomes determined. If inference fails, the value hole is reported with type `_` (unconstrained).
@@ -924,10 +924,10 @@ If the Agent fills with an impure expression:
 ### CLI interface
 
 ```text
-$ sporec holes                           # list all holes
-$ sporec holes --json                    # machine-readable
-$ sporec query-hole <file> <name>        # full HoleReport for one hole
-$ sporec query-hole <file> <name> --json # JSON format
+$ sporec --holes                         # list all holes
+$ sporec --holes --json                  # machine-readable
+$ sporec --query-hole ?name              # full HoleReport for one hole
+$ sporec --query-hole ?name --json       # JSON format
 $ sporec --simulate fn_name              # multi-path simulation
 $ spore holes --suggest-order            # topological ordering
 $ spore holes --graph                    # dependency graph visualization
@@ -1113,14 +1113,14 @@ t13        COMMIT ── all holes filled ────────────�
 
 All hole-related commands support `--json` for machine consumption.
 
-**`sporec holes --json`:**
+**`sporec --holes --json`:**
 
 ```json
 {
   "holes": [
     {
       "name": "charge_payment",
-      "location": { "file": "src/orders.sp", "line": 18, "column": 5 },
+      "location": { "file": "src/orders.spore", "line": 18, "column": 5 },
       "enclosing_function": "process_order",
       "expected_type": "Response ! PaymentFailed",
       "capabilities": ["Inventory", "PaymentGateway"],
@@ -1134,7 +1134,7 @@ All hole-related commands support `--json` for machine consumption.
 }
 ```
 
-**`sporec query-hole <file> <name> --json`:** Returns the full HoleReport v0.3 structure (see §4).
+**`sporec --query-hole ?name --json`:** Returns the full HoleReport v0.3 structure (see §4).
 
 **`spore watch --json`:** Emits an NDJSON event stream with `hole_graph_update`, `hole_update`, and `compile_result` events.
 
@@ -1149,8 +1149,8 @@ All hole-related commands support `--json` for machine consumption.
     "filled_holes": 3,
     "remaining_holes": 5,
     "ready_to_fill": [
-      { "name": "validate_input", "file": "src/order.sp", "line": 42 },
-      { "name": "check_auth", "file": "src/auth.sp", "line": 15 }
+      { "name": "validate_input", "file": "src/order.spore", "line": 42 },
+      { "name": "check_auth", "file": "src/auth.spore", "line": 15 }
     ],
     "blocked": [
       { "name": "process_order", "blocked_by": ["validate_input", "check_auth"] },
@@ -1229,7 +1229,7 @@ On failed fill: full diagnostic with `root_cause`, `fix_hints`, and `suggestion`
 
 ### Alternative 1: Anonymous Holes (`?`)
 
-Rejected. Anonymous holes create ambiguity in CLI queries (`sporec query-hole <file> ?` with multiple holes) and prevent clear communication between human and Agent. No mainstream language with typed holes (Agda, Idris, Lean) defaults to anonymous holes in practice — users always name them.
+Rejected. Anonymous holes create ambiguity in CLI queries (`sporec --query-hole ?` with multiple holes) and prevent clear communication between human and Agent. No mainstream language with typed holes (Agda, Idris, Lean) defaults to anonymous holes in practice — users always name them.
 
 ### Alternative 2: Holes Affect Signature Hashes
 


### PR DESCRIPTION
## Proposal summary

- Safe docs-only sweep after PR #20 in the remaining non-PR-20 SEP files.
- Convert legacy `.spore` example paths to canonical `.sp`.
- Align obvious hole/check CLI spellings to `sporec holes`, `sporec query-hole <file> <name>`, and `spore check`.
- Larger CLI/capability cleanup remains deferred (including `spore fill`, `simulate`, cost-query syntax, and capability-boundary semantics).

## Linked discussion

- Follow-up to PR #20: https://github.com/spore-lang/spore-evolution/pull/20

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

This is intentionally the safe sweep after PR #20. It leaves broader CLI and capability cleanup for a later PR.