### PR TITLE
📝 docs: sync effect core and concurrency seps

### DIFF
--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -398,8 +398,8 @@ trait Serialize {
 
 // effect: external world operations
 effect Console {
-    fn println(msg: Str) -> Unit
-    fn read_line() -> Str ! IOError
+    fn println(msg: Str) -> ()
+    fn read_line() -> Str ! IoError
 }
 
 // effect alias (uses | for union)
@@ -407,7 +407,7 @@ effect HttpClient = NetConnect | Clock
 effect CLI = Console | FileRead | FileWrite | Env | Spawn | Exit
 ```
 
-Effect operations and handler binding are also centralized here. `perform` is a reserved keyword for effect-operation expressions. `handle` accepts one or more `with` clauses. SEP-0003 defines the effect algebra and handler semantics; this SEP only fixes the settled outer syntax. The grammar intentionally leaves each handler operand as an expression because the richer handler/`handle` model is still pending the item-3 decision.
+Effect operations and handler binding are also centralized here. `perform` is a reserved keyword for effect-operation expressions. The settled outer handler grammar is `handle { ... } with { ... }`: the body is always a block, and the `with` block may contain inline effect arms and/or named handler installations via `use HandlerExpr`. SEP-0003 defines the effect algebra and handler semantics; this SEP fixes the corresponding surface syntax.
 
 The `uses` clause declares what effects a function requires. The compiler **auto-infers** effect properties from this set:
 
@@ -422,13 +422,13 @@ The `idempotent` property cannot be inferred and is annotated via doc comment: `
 The `uses` clause can mix atomic effect names with named effect aliases:
 
 ```spore
-fn query_database(sql: String) -> Data ! DbError | Timeout
+fn query_database(sql: Str) -> Data ! DbError | Timeout
 uses [NetConnect]
 {
     ...
 }
 
-fn run_cli(config_path: String) -> Unit ! Error
+fn run_cli(config_path: Str) -> () ! Error
 uses [CLI]
 {
     ...
@@ -653,13 +653,12 @@ fn event_loop(rx1: Channel.Receiver[Int], rx2: Channel.Receiver[String]) {
 ### Modules and imports
 
 ```spore
-module math uses [] {
-    pub fn add(a: Int, b: Int) -> Int { a + b }
-    fn helper() -> Int { 42 }  // private by default
-}
+// src/math.sp
+pub fn add(a: Int, b: Int) -> Int { a + b }
+fn helper() -> Int { 42 }  // private by default
 
 import std.collections as collections;
-import std.math.{sin, cos, tan};
+import std.math as math;
 ```
 
 ## Reference-level explanation
@@ -835,7 +834,7 @@ t"Dear {customer}, order {id}"    // template string
 
 ### EBNF Grammar
 
-For effect handling, the settled outer grammar is `perform <expr>` and `handle <expr>` followed by one or more `with <handler-expr>` clauses. The handler side remains expression-shaped here until the richer handler model is finalized.
+For effect handling, the settled outer grammar is `perform <expr>` together with `handle { ... } with { ... }`. Inline handler arms live inside the `with` block, and reusable named handlers are installed there with `use HandlerExpr`.
 
 ```ebnf
 (* ═══════════════════════════════════════════════════ *)
@@ -920,8 +919,10 @@ HandlerDecl     = "handler" Ident [ "(" ParamList ")" ] "for" Ident
 
 PerformExpr     = "perform" Expr ;
 
-HandleExpr      = "handle" Expr HandlerClause { HandlerClause } ;
-HandlerClause   = "with" Expr ;
+HandleExpr      = "handle" Block "with" HandlerBlock ;
+HandlerBlock    = "{" { HandlerEntry } "}" ;
+HandlerEntry    = EffectArm | HandlerUse ;
+HandlerUse      = "use" Expr ;
 
 (* ─── Impl (Trait Implementation) ─────────────────── *)
 
@@ -957,13 +958,13 @@ Param           = Ident ":" TypeExpr ;
 
 ErrorClause     = "!" TypeExpr { "|" TypeExpr } ;
 
-WhereClause     = { "where" Ident ":" BoundList } ;
-BoundList       = Ident { "+" Ident } ;
+WhereClause     = "where" WhereConstraint { "," WhereConstraint } ;
+WhereConstraint = Ident ":" Ident ;
 
 UsesClause      = "uses" "[" [ EffectList ] "]" ;
 EffectList      = Ident { "," Ident } ;
 
-CostClause      = "cost" "≤" CostExpr ;
+CostClause      = "cost" "[" CostExpr "," CostExpr "," CostExpr "," CostExpr "]" ;
 CostExpr        = IntLiteral
                 | Ident                        (* parameter reference *)
                 | CostExpr "*" CostExpr
@@ -1186,7 +1187,7 @@ fn <name>[<generics>](<params>) -> <ReturnType> [! <ErrorTypes>]
 
 2. **`! ErrorTypes`** — The error set. A function with `! E1 | E2` may produce errors of type `E1` or `E2`. Absence of `!` means the function cannot fail.
 
-3. **`where T: Bound`** — Generic constraints. Multiple bounds use `+` syntax: `where T: Eq + Hash`. Each `where` clause is on its own line.
+3. **`where T: Bound, U: Bound`** — Generic constraints. The canonical form is a single `where` clause with comma-separated constraints. Spore does not use `+` multi-bound syntax.
 
 4. **`uses [Effects]`** — The effect set required by this function. The compiler auto-infers effect properties:
    - `uses []` → `pure`, `deterministic`, `total`
@@ -1196,7 +1197,7 @@ fn <name>[<generics>](<params>) -> <ReturnType> [! <ErrorTypes>]
 
    **Implication chain:** `pure` ⊃ `deterministic` — a pure function is necessarily deterministic (same inputs always produce same outputs). A deterministic function is not necessarily pure (it may perform IO that doesn't introduce non-determinism). `total` is orthogonal: a function can be total without being pure.
 
-5. **`cost ≤ N`** — An upper bound on the function's resource cost. Can reference parameters (e.g., `cost ≤ n * 10`).
+5. **`cost [c, a, i, p]`** — A four-slot cost vector (`compute`, `alloc`, `io`, `parallel`). Each slot may reference parameters or use the currently supported linear `O(n)` forms.
 
 6. **`spec { ... }`** — Behavioral specification block. Contains `example` and `property` items that express the function's intended behavior as typechecked test metadata. When the enclosing function body is executable, `spore test` evaluates the `spec` block by calling the function by name. If the body still contains an unfilled hole, the `spec` block remains available to the compiler and HoleReport output, but executing it still reaches the hole and errors.
 

--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -407,7 +407,7 @@ effect HttpClient = NetConnect | Clock
 effect CLI = Console | FileRead | FileWrite | Env | Spawn | Exit
 ```
 
-Effect operations and handler binding are also centralized here. `perform` is a reserved keyword for effect-operation expressions. The settled outer handler grammar is `handle { ... } with { ... }`: the body is always a block, and the `with` block may contain inline effect arms and/or named handler installations via `use HandlerExpr`. SEP-0003 defines the effect algebra and handler semantics; this SEP fixes the corresponding surface syntax.
+Effect operations and handler binding are also centralized here. `perform` is a reserved keyword for effect-operation expressions. The settled handler grammar is `handler <Effect> as <HandlerName>(...) { ... }` for declarations and `handle { ... } with { ... }` for installation: the `with` block may contain inline effect arms via `on Effect.op(...) => ...` and/or named handler installations via `use HandlerName { ... }`. SEP-0003 defines the effect algebra and handler semantics; this SEP fixes the corresponding surface syntax.
 
 The `uses` clause declares what effects a function requires. The compiler **auto-infers** effect properties from this set:
 
@@ -834,7 +834,7 @@ t"Dear {customer}, order {id}"    // template string
 
 ### EBNF Grammar
 
-For effect handling, the settled outer grammar is `perform <expr>` together with `handle { ... } with { ... }`. Inline handler arms live inside the `with` block, and reusable named handlers are installed there with `use HandlerExpr`.
+For effect handling, the settled grammar is `perform <expr>`, top-level `handler <Effect> as <HandlerName>(...) { ... }`, and `handle { ... } with { ... }` where each item is either `use HandlerName { ... }` or `on Effect.op(...) => ...`.
 
 ```ebnf
 (* ═══════════════════════════════════════════════════ *)
@@ -914,15 +914,19 @@ EffectAlias     = Ident { "|" Ident } ;
 
 (* ─── Handler ─────────────────────────────────────── *)
 
-HandlerDecl     = "handler" Ident [ "(" ParamList ")" ] "for" Ident
+HandlerDecl     = "handler" Ident "as" Ident [ "(" ParamList ")" ]
                   "{" { FunctionDecl } "}" ;
 
 PerformExpr     = "perform" Expr ;
 
 HandleExpr      = "handle" Block "with" HandlerBlock ;
-HandlerBlock    = "{" { HandlerEntry } "}" ;
-HandlerEntry    = EffectArm | HandlerUse ;
-HandlerUse      = "use" Expr ;
+HandlerBlock    = "{" [ HandlerEntry { "," HandlerEntry } [ "," ] ] "}" ;
+HandlerEntry    = InlineHandlerBinding | NamedHandlerBinding ;
+NamedHandlerBinding
+                = "use" Ident "{" [ HandlerPayload { "," HandlerPayload } [ "," ] ] "}" ;
+HandlerPayload  = Ident ":" Expr ;
+InlineHandlerBinding
+                = "on" Ident "." Ident "(" [ Ident { "," Ident } ] ")" "=>" Expr ;
 
 (* ─── Impl (Trait Implementation) ─────────────────── *)
 

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -15,7 +15,7 @@ superseded_by: null
 
 # SEP-0003: Effect System
 
-> **Executive Summary**: Defines Spore's effect system as a flat capability-set model with 10 built-in intent-oriented atomic effects (Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit) plus user-defined effects. The surface syntax uses `effect`, `handler`, and `handle ... with`, while semantic checking remains a subset test over capability sets. Concrete grammar is centralized in SEP-0001; this SEP specifies effect algebra, handler semantics, narrowing rules, and diagnostics.
+> **Executive Summary**: Defines Spore's effect system as a flat capability-set model with 10 built-in intent-oriented atomic effects (Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit) plus user-defined effects. The canonical surface syntax uses explicit `effect` declarations, `perform Effect.op(...)`, top-level `handler`, and `handle { ... } with { ... }`, while semantic checking remains a subset test over capability sets. Concrete grammar is centralized in SEP-0001; this SEP specifies effect algebra, handler semantics, narrowing rules, and diagnostics.
 
 ## Summary
 
@@ -65,10 +65,14 @@ Modern programs interleave pure computation with diverse side effects — file I
 Every Spore function may carry a `uses` clause listing the atomic effects it requires:
 
 ```spore
-fn read_config(path: String) -> Config ! IoError | ParseError
+effect FileRead {
+    fn read_file(path: Str) -> Str ! IoError
+}
+
+fn read_config(path: Str) -> Config ! IoError | ParseError
 uses [FileRead]
 {
-    let content = read_file(path)
+    let content = perform FileRead.read_file(path)
     parse_toml(content)
 }
 ```
@@ -76,8 +80,12 @@ uses [FileRead]
 A function that interacts with the terminal declares `Console`:
 
 ```spore
-fn greet(name: String) uses [Console] {
-    println("Hello, " + name)
+effect Console {
+    fn println(msg: Str) -> ()
+}
+
+fn greet(name: Str) uses [Console] {
+    perform Console.println("Hello, " + name)
 }
 ```
 
@@ -263,17 +271,14 @@ error[cap-violation]: function body uses undeclared effect
 
 Running `sporec --fixes` auto-inserts the missing `uses` clause.
 
-### Module-level `uses` declarations
+### No module-level `uses` declarations
 
-A module may declare its effect ceiling with `module X uses [...]`:
+Spore does **not** have module-level `uses` ceilings or carriers. Source files declare no ambient effect budget. Effect checking happens at:
 
-```spore
-module billing uses [NetConnect, FileRead, Clock]
-```
+1. function signatures (`uses [...]`)
+2. project / Platform boundaries
 
-All functions within the module are constrained: their `uses` sets must be subsets of the module-level set. If a function exceeds the module ceiling the compiler emits a `cap-narrowing-violation` error.
-
-The module-level `uses` clause is **optional**. When omitted the compiler auto-infers the module's effect ceiling as the union of all its functions' effect sets. Running `sporec --fixes` inserts the inferred declaration.
+Diagnostics and tooling should therefore not synthesize or rely on `module X uses [...]` declarations.
 
 ### `@allows` — restricting Hole candidates
 
@@ -678,37 +683,37 @@ Effects are not merely string tags — each effect is a **typed construct** whos
 
 ```spore
 effect Console {
-    fn println(msg: String) -> Unit
-    fn eprintln(msg: String) -> Unit
-    fn read_line() -> String ! IoError
+    fn println(msg: Str) -> ()
+    fn eprintln(msg: Str) -> ()
+    fn read_line() -> Str ! IoError
 }
 
 effect FileRead {
-    fn read_file(path: String) -> Bytes ! IoError
-    fn list_dir(path: String) -> List[String] ! IoError
+    fn read_file(path: Str) -> Str ! IoError
+    fn list_dir(path: Str) -> List[Str] ! IoError
 }
 
 effect FileWrite {
-    fn write_file(path: String, data: Bytes) -> Unit ! IoError
-    fn create_dir(path: String) -> Unit ! IoError
-    fn delete(path: String) -> Unit ! IoError
+    fn write_file(path: Str, data: Str) -> () ! IoError
+    fn create_dir(path: Str) -> () ! IoError
+    fn delete(path: Str) -> () ! IoError
 }
 
 effect Env {
-    fn get(name: String) -> Option[String]
-    fn vars() -> List[(String, String)]
+    fn get(name: Str) -> Option[Str]
+    fn vars() -> List[(Str, Str)]
 }
 ```
 
-When a function declares `uses [FileRead]`, the compiler makes the `FileRead` effect's operations available. This design unifies effect tracking with method dispatch: calling `read_file(path)` dispatches to the bound handler for the `FileRead` effect.
+Declaring `uses [FileRead]` authorizes the effect, but operations remain explicit: `perform FileRead.read_file(path)` dispatches to the active `FileRead` handler. Canonical v0.1 semantics require the corresponding `effect` interface to be declared explicitly; undeclared pseudo-effect paths are compatibility-only.
 
-Effect aliases remain purely syntactic:
+Effect aliases are part of the committed v0.1 surface:
 
 ```spore
 effect FileIO = FileRead | FileWrite
 ```
 
-This expands to the union of the two effects and does not define a new effect.
+This expands semantically to the union of the two effects and does not define a new operation surface of its own.
 
 ### 14. Effect handlers
 
@@ -718,15 +723,15 @@ Effect handlers provide concrete implementations for effect operations, enabling
 
 ```spore
 handler MockConsole for Console {
-    fn println(msg: Str) -> Unit { self.output.push(msg) }
-    fn read_line() -> Str ! IOError { "mock input" }
+    fn println(msg: Str) -> () { self.output.push(msg) }
+    fn read_line() -> Str ! IoError { "mock input" }
 }
 
 handler RealFileRead for FileRead {
-    fn read_file(path: String) -> Bytes ! IoError {
+    fn read_file(path: Str) -> Str ! IoError {
         platform.fs.read(path)
     }
-    fn list_dir(path: String) -> List[String] ! IoError {
+    fn list_dir(path: Str) -> List[Str] ! IoError {
         platform.fs.list(path)
     }
 }
@@ -734,16 +739,30 @@ handler RealFileRead for FileRead {
 
 #### Handler binding
 
-The `handle ... with` expression binds one or more handler expressions to a computation. SEP-0001 fixes the settled outer grammar as `handle <expr>` followed by one or more `with <handler-expr>` clauses; the richer handler model remains under item-3 discussion.
+The canonical handler form is `handle { ... } with { ... }`. The `with` block may contain inline effect arms and/or named handler installations via `use HandlerExpr`.
 
 ```spore
-// Bind a single handler
-handle greet("world") with MockConsole { output: [] }
+// Bind a single named handler
+handle {
+    greet("world")
+} with {
+    use MockConsole { output: [] }
+}
 
-// Bind multiple handlers
-handle app.run()
-    with RealFileRead {}
-    with MockConsole { output: [] }
+// Bind multiple named handlers
+handle {
+    app.run()
+} with {
+    use RealFileRead {}
+    use MockConsole { output: [] }
+}
+
+// Inline handler arms remain available
+handle {
+    perform Console.println("hello")
+} with {
+    Console.println(msg) => ()
+}
 ```
 
 #### User-defined effects (allowed from v1)
@@ -955,7 +974,7 @@ Algebraic effect handlers (as in Koka or OCaml 5) allow effects to be intercepte
 3. **Platform abstraction** — The same user code runs on different platforms by swapping handlers (e.g., browser vs. server filesystem).
 4. **Colorless functions** — Unlike async/await, effect handlers do not bifurcate the function space.
 
-Spore's handler model is intentionally simpler than full algebraic effects: handlers do not support continuations or resumptions beyond simple `resume()`. This keeps the runtime overhead minimal and compilation straightforward while capturing the most valuable use cases.
+Spore's handler model is intentionally simpler than full algebraic effects: handlers are lexical, non-resumable, and one-shot. A matching handler arm computes the value of the corresponding `perform` expression directly; there is no continuation capture or `resume()` path in canonical v0.1 semantics.
 
 Syntax: `effect` defines operations, `handler` provides implementations, `handle ... with` binds handlers at call sites. See §13-14 for full details.
 

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -722,24 +722,24 @@ Effect handlers provide concrete implementations for effect operations, enabling
 #### Handler definition
 
 ```spore
-handler MockConsole for Console {
+handler Console as MockConsole(output: List[Str]) {
     fn println(msg: Str) -> () { self.output.push(msg) }
     fn read_line() -> Str ! IoError { "mock input" }
 }
 
-handler RealFileRead for FileRead {
+handler FileRead as RealFileRead(root: Str) {
     fn read_file(path: Str) -> Str ! IoError {
-        platform.fs.read(path)
+        platform.fs.read(self.root + "/" + path)
     }
     fn list_dir(path: Str) -> List[Str] ! IoError {
-        platform.fs.list(path)
+        platform.fs.list(self.root + "/" + path)
     }
 }
 ```
 
 #### Handler binding
 
-The canonical handler form is `handle { ... } with { ... }`. The `with` block may contain inline effect arms and/or named handler installations via `use HandlerExpr`.
+The canonical handler form is `handle { ... } with { ... }`. The `with` block may contain inline effect arms via `on Effect.op(...) => ...` and/or named handler installations via `use HandlerName { ... }`. The `use` payload initializes the handler instance fields declared in `handler <Effect> as <HandlerName>(...)`, and duplicate matches for the same `Effect.op` inside one `with` block are errors.
 
 ```spore
 // Bind a single named handler
@@ -753,7 +753,7 @@ handle {
 handle {
     app.run()
 } with {
-    use RealFileRead {}
+    use RealFileRead { root: "/srv/app" }
     use MockConsole { output: [] }
 }
 
@@ -761,7 +761,7 @@ handle {
 handle {
     perform Console.println("hello")
 } with {
-    Console.println(msg) => ()
+    on Console.println(msg) => {}
 }
 ```
 
@@ -774,10 +774,9 @@ effect RateLimit {
     fn check_limit(key: Str) -> Bool
 }
 
-handler TokenBucketLimiter(rate: Int, per: Duration) for RateLimit {
+handler RateLimit as FixedDecisionRateLimit(allowed: Bool) {
     fn check_limit(key: Str) -> Bool {
-        if self.tokens > 0 { self.tokens -= 1; true }
-        else { false }
+        self.allowed
     }
 }
 ```

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -550,7 +550,7 @@ effect RateLimit {
     fn release_permit() -> ()
 }
 
-handler token_bucket_handler(rate: Int, per: Duration) for RateLimit {
+handler RateLimit as token_bucket_handler(rate: Int, per: Duration) {
     fn acquire_permit() -> () ! RateLimitExceeded {
         if self.tokens > 0 {
             self.tokens -= 1;
@@ -1221,7 +1221,7 @@ The concurrency model is introduced as a new language feature. There is no exist
 
 5. **Dynamic lane adjustment.** The current model uses static lane counts (`lanes: K`). Should the runtime be able to dynamically adjust the actual parallelism based on system load, and if so, how does this interact with compile-time cost verification?
 
-6. **Effect handler composition order.** When multiple handlers are stacked (`with handler_a with handler_b`), the composition order matters. The precise semantics of handler ordering for concurrency effects (especially when `Spawn` interacts with IO effects) need formal specification.
+6. **Effect handler composition order.** When multiple handlers appear in one binding block (for example `with { use handler_a {}, use handler_b {} }`), the composition order matters. The precise semantics of handler ordering for concurrency effects (especially when `Spawn` interacts with IO effects) need formal specification.
 
 7. **Distributed concurrency.** This SEP covers single-machine concurrency. Extending the model to distributed settings (multi-node `parallel_scope`, remote channels) is a future concern but should not be foreclosed by current design decisions.
 

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -238,16 +238,25 @@ Because `Spawn` is an effect, different handlers give the same code different ru
 
 ```spore
 // Production: real parallel execution on a thread pool
-handle concurrent_work()
-    with platform.spawn_handler(thread_pool)
+handle {
+    concurrent_work()
+} with {
+    use ParallelHandler { pool: thread_pool }
+}
 
 // Testing: deterministic sequential execution
-handle concurrent_work()
-    with sequential_handler()
+handle {
+    concurrent_work()
+} with {
+    use SequentialHandler {}
+}
 
 // Compile-time simulation: abstract interpretation for cost analysis
-handle concurrent_work()
-    with cost_analysis_handler()
+handle {
+    concurrent_work()
+} with {
+    use CostAnalysisHandler {}
+}
 ```
 
 A test can replace the `Spawn` handler with `SequentialHandler` and a `NetConnect` handler with a mock—**no async test framework needed**:
@@ -261,9 +270,12 @@ test "fetch_and_merge produces correct results" {
         ])
     }
 
-    let result = handle fetch_and_merge([url1, url2])
-        with sequential_handler()
-        with mock_net
+    let result = handle {
+        fetch_and_merge([url1, url2])
+    } with {
+        use SequentialHandler {}
+        use mock_net
+    }
 
     assert_eq(result, expected_merged)
 }
@@ -509,8 +521,11 @@ Functions declare the effect via `uses [Spawn]`. Without this declaration, the c
 An effect handler is a concrete interpretation of an effect's operations:
 
 ```spore
-handle concurrent_work()
-    with platform.spawn_handler(thread_pool)
+handle {
+    concurrent_work()
+} with {
+    use ParallelHandler { pool: thread_pool }
+}
 ```
 
 #### Built-in handlers
@@ -531,18 +546,22 @@ Users may define their own concurrency-related effects:
 
 ```spore
 effect RateLimit {
-    fn acquire_permit() -> Unit ! RateLimitExceeded
-    fn release_permit() -> Unit
+    fn acquire_permit() -> () ! RateLimitExceeded
+    fn release_permit() -> ()
 }
 
 handler token_bucket_handler(rate: Int, per: Duration) for RateLimit {
-    fn acquire_permit() -> Unit ! RateLimitExceeded {
-        if tokens > 0 { tokens -= 1; resume(()) }
-        else { raise(RateLimitExceeded) }
+    fn acquire_permit() -> () ! RateLimitExceeded {
+        if self.tokens > 0 {
+            self.tokens -= 1;
+            ()
+        } else {
+            throw RateLimitExceeded
+        }
     }
-    fn release_permit() -> Unit {
-        tokens += 1
-        resume(())
+    fn release_permit() -> () {
+        self.tokens += 1;
+        ()
     }
 }
 ```


### PR DESCRIPTION
## Proposal summary

- sync `SEP-0001`, `SEP-0003`, and `SEP-0007` to the locked handler/effect/core decisions from the latest unification pass
- replace the stale `handle <expr> with ...`, `resume()`, and module-level `uses` stories with the current `handle { ... } with { ... }`, explicit `perform Effect.op(...)`, and function/project/Platform-only checking boundaries
- align concurrency examples around named handler installation via `use ...` and the current non-resumable / one-shot handler contract

## Linked discussion

- `SEP-0001`: https://github.com/spore-lang/spore-evolution/discussions/1
- `SEP-0003`: https://github.com/spore-lang/spore-evolution/discussions/3
- `SEP-0007`: https://github.com/spore-lang/spore-evolution/discussions/7

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

- this slice intentionally focuses on the effect/core/concurrency mainline in `SEP-0001/0003/0007`; `SEP-0008/0009` and the broader primitive/cost surface sweep will follow separately
- no implementation changes are mixed here; the follow-up implementation slices remain in the `spore` / `basic-cli` repos