### PR TITLE
📝 docs: align platform and script-mode runtime docs

### DIFF
--- a/drafts/script-mode.md
+++ b/drafts/script-mode.md
@@ -17,7 +17,7 @@ superseded_by: null
 
 # Draft SEP: Script Mode & Inline Script Metadata
 
-> **Executive Summary**: This proposal adds a first-class script workflow to `spore` without weakening the manifest-backed project model. Scripts use a dedicated file-header block comment with TOML-like metadata, and script mode is explicitly separated from project mode rather than borrowing nearby project configuration. The result is a reproducible single-file workflow that remains compatible with named project entries, one-project/one-Platform semantics, and future agent tooling.
+> **Executive Summary**: This proposal adds a first-class script workflow to `spore` without weakening the manifest-backed project model. Scripts use a dedicated file-header block comment with TOML-like metadata, and the target CLI shape separates script mode from project mode instead of borrowing nearby project configuration. Current shipped `spore run <file>` behavior still includes a compatibility path where files under a project's `src/` tree resolve as project-backed entries; this draft defines the stricter future split. The result is a reproducible single-file workflow that remains compatible with named project entries, one-project/one-Platform semantics, and future agent tooling.
 
 ## Summary
 
@@ -32,8 +32,8 @@ The proposal introduces:
   - `[platform]`
   - `[dependencies]`
 - a strict mode split:
-  - `spore run <file>` is script mode
-  - bare `spore run` and `spore run --entry <name>` are project mode
+  - **proposed**: `spore run <file>` is script mode
+  - **proposed**: bare `spore run` and `spore run --entry <name>` are project mode
 - explicit project-control flags:
   - `--project <path>`
   - `--no-project`
@@ -71,102 +71,109 @@ The goal is therefore **not** "just run any file somehow." The goal is:
 
 ### Two ways to run code
 
-After this SEP, `spore run` has two user-facing modes:
+Current implementations route **`spore run <file>`** through one of two runtime
+paths:
 
 1. **Project mode**
-   - `spore run`
-   - `spore run --entry api`
-   - `spore run --project ../apps/billing --entry api`
-   - Runs a named project entry from an attached project.
-2. **Script mode**
+   - `spore run src/main.sp` when that file lives under a manifest-backed
+     project's `src/` tree
+   - Attaches a project and derives the corresponding entry path from that file's
+     location under `src/`.
+2. **Standalone file mode**
    - `spore run tools/repro.sp`
-   - Runs one explicit source file as a script, independent of project config.
+   - Runs one explicit source file when it is **not** resolved as a project
+     entry under `src/`.
 
-An explicit `<file>` means script mode. `--entry <name>` means project mode.
-They are mutually exclusive.
+An explicit file path therefore does **not** always force standalone mode.
+Files inside a discovered project's `src/` tree are currently routed through
+project mode.
 
-### Example: standalone script
+### Example: standalone file
 
 ```spore
-/* spore-script
-requires-spore = ">=0.1.0"
-
-[platform]
-path = "../platforms/cli"
-
-[dependencies]
-json = { git = "https://github.com/spore-lang/json", sig = "sig:abcd1234" }
-*/
-
-fn main() -> () {
-    println("hello from script mode")
-    return
+fn main() -> I32 {
+    42
 }
 ```
 
-Running the file:
+Running the file today:
 
 ```bash
 spore run tools/hello.sp
+42
 ```
 
-The header makes the script self-describing: the tool can validate the required
-Spore version, choose the script's platform, and resolve its external
-dependencies even when no `spore.toml` exists nearby.
+Current standalone-file execution still permits `fn main() -> I32`. The
+returned value is printed by `spore run`; it does **not** become the host
+process exit status.
 
-### Example: script inside a project tree
+### Example: explicit file inside a project tree
 
 ```bash
 spore run tools/migrate.sp
 ```
 
 Even if `tools/migrate.sp` lives under a directory that also contains
-`spore.toml`, the command still stays in script mode. Nearby project manifests,
-entries, dependencies, and platforms are ignored. The script runs from its own
-header metadata plus script-mode defaults only.
+`spore.toml`, the command currently stays in standalone file mode because
+project auto-detection only maps files inside the project's `src/` tree to
+project entries.
 
-### Example: project mode with an explicit project root
+By contrast, `spore run src/main.sp` is currently resolved through project mode,
+because the file path can be mapped to a manifest-backed entry under `src/`.
+
+### Future example: project mode with an explicit project root
 
 ```bash
-spore run --project ../apps/billing
-spore run --project ../apps/billing --entry worker
+spore run .
+spore run ../apps/billing
 ```
 
-`--project <path>` belongs to project mode. It selects the project whose default
-entry or named entry should run.
+This is **proposed CLI surface**, not current shipped behavior. Today `spore run`
+expects a file path, not a project directory.
 
-### Example: run a project entry
+### Future example: run the discovered project entry
 
 ```bash
 spore run
-spore run --entry worker
-spore run --project ../apps/billing --entry worker
+spore run .
+spore run ../apps/billing
 ```
 
-Bare `spore run` is project mode: it finds a project from the current working
-directory and runs its default entry. `--entry <name>` selects a named manifest
-entry instead. `--project <path>` replaces cwd-based project discovery.
+This is also **proposed CLI surface**, not current shipped behavior. In the
+current implementation, project mode is only reached when the explicit file path
+passed to `spore run` resolves to a manifest-backed entry under `src/`. When
+that happens, the selected entry must satisfy both the Platform startup
+signature and the selected Platform package's `[platform].handles` capability
+contract.
 
-### Passing script or entry arguments
+### Future example: passing script or entry arguments
 
 ```bash
 spore run tools/repro.sp -- --verbose --limit 10
-spore run --entry worker -- --queue invoices
+spore run . -- --queue invoices
 ```
 
-`--` separates `spore run` flags from the arguments passed through to the script
-or selected entry.
+This argument-passthrough form is **proposed**, not current shipped behavior.
 
 ## Reference-level explanation
 
+The sections below include **future script-mode design space** (for example
+script headers and richer CLI flags) in addition to the current shipped mode
+resolution documented above.
+
 ### Terminology
 
-- **script mode**: `spore run <file>` with one explicit source file
-- **project mode**: `spore run` or `spore run --entry <name>`
-- **script header**: the dedicated file-header block comment recognized as
-  structured script metadata
+- **standalone file mode**: `spore run <file>` when the explicit file does not
+  resolve to a project entry under `src/`
+- **project-backed file resolution**: current shipped behavior where
+  `spore run <file>` attaches a manifest-backed project only when that explicit
+  file resolves to an entry under `src/`
+- **project mode**: proposed broader CLI surface such as `spore run`,
+  `spore run .`, or `spore run <project-dir>`
+- **script header**: a proposed dedicated file-header block comment recognized
+  as structured script metadata
 - **effective run configuration**: the final configuration after applying CLI
-  flags plus the metadata relevant to the active mode
+  inputs plus the metadata relevant to the active mode
 
 ### Script header format
 
@@ -201,7 +208,8 @@ error. It must not silently ignore malformed structured metadata.
 V1 script metadata contains:
 
 - `requires-spore = "<version-range>"`
-- `[platform]` using the same schema as manifest `[platform]`
+- `[platform]` carrying script-local platform selection metadata that parallels
+  manifest platform configuration, without requiring the exact same table shape
 - `[dependencies]` using the same dependency-entry shape as manifest
   `[dependencies]`
 
@@ -210,90 +218,86 @@ instead of inventing a parallel configuration language.
 
 ### CLI surface
 
-The intended `spore run` surface is:
+The current public `spore run` surface discussed in this draft is:
 
 ```text
-spore run [--project PATH] [--entry NAME] [-- ARGS...]
-spore run FILE [--no-project] [-- ARGS...]
+spore run FILE
 ```
 
-Rules:
+Rules today:
 
-- `FILE` and `--entry` are mutually exclusive
-- `FILE` and `--project` are mutually exclusive
-- bare `spore run` is valid only in project mode
-- `spore run <file>` is script mode
-- `--no-project` is allowed only in script mode; it is an explicit assertion,
-  not a request to detach from a project after project discovery
+- `FILE` may resolve as a project-backed entry only when it maps to a file under a
+  discovered project's `src/` tree
+- otherwise `spore run FILE` falls back to standalone file mode
+- bare `spore run`, `spore run .`, and `spore run <project-dir>` belong to the
+  proposed project-mode surface, not the shipped baseline described here
+- separate `--project`, `--entry`, and `--no-project` switches are future CLI
+  design, not the shipped surface described here
 
 ### Project discovery
 
-Project discovery exists only in project mode:
+Project discovery currently happens only when the explicit file path maps into a
+discovered project's `src/` tree:
 
-1. **If `--project <path>` is present**
-   - attach exactly that project
-2. **Else**
-   - discover a project by walking upward from the current working directory
+1. **`PATH` is a file under a discovered project's `src/` tree**
+   - walk upward from the file's directory
+   - attach that project and derive the entry path from the file's path under
+     `src/`
 
-Script mode performs no project discovery.
+If the explicit file path does not map into a discovered project's `src/` tree,
+the command falls back to standalone file mode.
 
 ### Project mode semantics
 
 In project mode:
 
-- the attached project is required
-- `--entry <name>` selects a named manifest entry
-- without `--entry`, the manifest's `default-entry` is used
+- the attached project is manifest-backed
+- a file path under `src/` maps to the corresponding project entry path
+- bare `spore run` or `spore run <dir>` remains proposed future CLI surface for
+  selecting the manifest's inferred/default entry
 - if no project can be found, the command fails with an explicit error
 
-Project mode is manifest-backed. It does not consult script headers because no
-explicit script file is being selected.
+Project mode is the path that uses Platform contracts such as `basic-cli`'s
+`main() -> ()` startup requirement.
 
 ### Script mode semantics
 
-In script mode:
+In standalone file mode:
 
-- the explicit `FILE` is the execution target
+- the explicit file is the execution target
 - the file does not need to be a named manifest entry
-- the file may live inside or outside a project tree
-- project manifests, project dependencies, project entries, project platforms,
-  and `default-entry` are ignored
-- the effective run configuration is derived only from:
-  - CLI script-mode flags
-  - the script header, if present
-  - script-mode defaults
+- files outside any project's `src/` tree run this way, even if they live
+  elsewhere under a project root (for example `tools/migrate.sp`)
+- standalone execution does **not** use a Platform contract module
+- `fn main() -> I32` is still accepted and its result is printed as a normal
+  value
+- standalone execution does **not** convert the return value into the host
+  process exit status
 
-If a file lives inside a project tree but is invoked as `spore run <file>`, it
-still remains script mode.
+The explicit `Exit` effect path is currently a project-mode Platform feature,
+not a standalone-file return convention.
 
 ### Effective configuration and precedence
 
-Project mode and script mode have different precedence rules.
+Current `spore run` precedence is simpler than the future CLI sketched earlier
+in this draft because it is still file-selected.
 
-#### Project mode
+#### Project-backed file resolution
 
-1. `--project <path>` if present
-2. cwd-based project discovery otherwise
-3. `--entry <name>` if present
-4. manifest `default-entry` otherwise
+1. start from the explicit file path
+2. walk upward from that file's directory looking for a manifest-backed project
+3. if the file lands under the discovered project's `src/` tree, derive the
+   entry path from that relative location
+4. otherwise stay in standalone file mode
 
-#### Script mode
+#### Standalone file mode
 
-1. script-mode CLI assertions such as `--no-project`
-2. script header metadata
-3. script-mode defaults
+1. the explicit file path
+2. no manifest-backed Platform contract
+3. no script-header metadata contract yet
 
-The resulting precedence is:
-
-| Concern | Highest precedence | Fallback |
-|---|---|---|
-| Entry selection | `--entry` | manifest `default-entry` |
-| Project root (project mode only) | `--project` | cwd discovery |
-| External dependencies (script mode) | script `[dependencies]` | script-mode defaults |
-| Platform (script mode) | script `[platform]` | script-mode defaults |
-| Spore version requirement (script mode) | script `requires-spore` | active tool defaults only |
-
-In particular, script mode never inherits project dependencies or platform.
+In particular, current standalone file mode does not inherit project Platform
+contracts just because the file lives somewhere under the same repository root.
 
 ### Relationship to named project entries
 
@@ -402,7 +406,9 @@ heavyweight.
 
 Rejected because script mode should stay independent from project mode. A file
 run as `spore run path/to/file.sp` should not silently inherit dependencies,
-entries, or platform choices from whichever project happens to contain it.
+entries, or platform choices from whichever project happens to contain it in the
+target CLI shape, even though the current shipped implementation still has a
+compatibility path for files discovered under a project's `src/` tree.
 
 ### Store script metadata in a sidecar file
 
@@ -411,9 +417,11 @@ and generate. The metadata should travel with the script.
 
 ### Treat explicit files as project-aware entry paths
 
-Rejected because explicit files are the script-mode surface in this design.
-Durable project execution should remain manifest-based through default entries
-and named entries.
+Rejected as the long-term default because explicit files are the script-mode
+surface in this design. Durable project execution should remain manifest-based
+through default entries and named entries, even though the current shipped
+implementation still accepts some explicit `src/...` file paths as
+project-backed entry resolution.
 
 ## Prior art
 

--- a/seps/SEP-0003-effect-capability-system.md
+++ b/seps/SEP-0003-effect-capability-system.md
@@ -115,6 +115,10 @@ Spore ships with the following intent-oriented atomic effects. Each one answers:
 | `Random` | Non-deterministic computation | `random()`, `uuid()` |
 | `Exit` | Process lifecycle control | `exit()`, `abort()` |
 
+`Exit` authorizes explicit process termination. Startup contracts, runtime exit
+propagation, and host exit-code conversion are Platform/runtime concerns
+specified in SEP-0008 rather than in this effect SEP.
+
 ### Design rationale: intent-oriented built-in effects
 
 The guiding principle is: **each built-in effect answers "What does this code intend to do with the outside world?"** This leads to several deliberate design choices:
@@ -131,16 +135,19 @@ The guiding principle is: **each built-in effect answers "What does this code in
 
 ### Platform mapping: basic-cli
 
-The `basic-cli` platform maps standard library operations to built-in effects as follows:
+The `basic-cli` Platform currently maps its package modules to built-in effects as follows:
 
 | Operation | Required effect |
 |---|---|
-| `Stdout.println`, `Stderr.println` | `Console` |
-| `Stdin.read_line` | `Console` |
-| `File.read`, `Dir.list` | `FileRead` |
-| `File.write`, `Dir.create` | `FileWrite` |
-| `Env.get`, `Env.vars` | `Env` |
-| `Cmd.exec` | `Spawn` |
+| `basic_cli.stdout.print`, `basic_cli.stdout.println`, `basic_cli.stdout.eprint`, `basic_cli.stdout.eprintln` | `Console` |
+| `basic_cli.stdin.read_line` | `Console` |
+| `basic_cli.file.file_read`, `basic_cli.file.file_exists`, `basic_cli.file.file_stat` | `FileRead` |
+| `basic_cli.file.file_write` | `FileWrite` |
+| `basic_cli.dir.dir_list` | `FileRead` |
+| `basic_cli.dir.dir_mkdir` | `FileWrite` |
+| `basic_cli.env.env_get`, `basic_cli.env.env_set` | `Env` |
+| `basic_cli.cmd.process_run`, `basic_cli.cmd.process_run_status` | `Spawn` |
+| `basic_cli.cmd.exit` | `Exit` |
 
 ### Defining effect aliases
 
@@ -159,7 +166,12 @@ Aliases expand recursively and flatten:
 CLI → {Console, FileRead, FileWrite, Env, Spawn, Exit}
 ```
 
-Aliases are purely syntactic sugar. After expansion, only atomic effects remain.
+Aliases are purely syntactic sugar in `uses [...]`: after expansion, only atomic
+effects remain. The current implementation also ships a small builtin alias
+hierarchy for `IO`, `FileIO`, and `NetIO`, but **same-module declarations
+shadow those builtin names**. In other words, a local `effect IO = Console` or
+`effect IO { ... }` is treated as that local declaration, not as the builtin
+filesystem/network bundle.
 
 ### Using effects in practice
 
@@ -175,6 +187,11 @@ uses [HttpClient]
 ```
 
 After alias expansion this is equivalent to `uses [NetConnect, Clock]`.
+
+`perform` and inline `on Effect.op(...)` arms are stricter: they target
+**declared effect interfaces**, not aliases or undeclared pseudo-effect paths.
+`uses [Alias]` may cover `perform Console.println(...)` after alias expansion,
+but `perform Alias.println(...)` is not the canonical surface.
 
 ### Pure closures in higher-order functions
 
@@ -273,7 +290,7 @@ Running `sporec --fixes` auto-inserts the missing `uses` clause.
 
 ### No module-level `uses` declarations
 
-Spore does **not** have module-level `uses` ceilings or carriers. Source files declare no ambient effect budget. Effect checking happens at:
+Spore does **not** currently standardize module-level `uses` ceilings or carriers. Source files declare no ambient effect budget. Effect checking happens at:
 
 1. function signatures (`uses [...]`)
 2. project / Platform boundaries
@@ -384,9 +401,32 @@ In any `uses` declaration:
 
 $$\texttt{uses } [C] \equiv \texttt{uses } [A_1, A_2, \ldots, A_n]$$
 
-Expansion is **recursive**: if any $A_i$ is itself an alias, it is expanded until every element is an atomic effect. The result is always a flat set.
+Expansion is **recursive**: if any $A_i$ is itself an alias, it is expanded
+until every element is an atomic effect. The result is always a flat set.
+
+The shipped implementation also reserves builtin aliases `IO`, `FileIO`, and
+`NetIO` for convenience expansion, but those names are **not global keywords**:
+same-module declared effects and effect aliases with the same names shadow the
+builtin hierarchy.
 
 **No effect variables exist.** All effect sets must be fully determined at compile time. There is no `uses E` generic parameter and no effect polymorphism.
+
+### 3.1 Declared effects, imports, and `perform`
+
+The canonical checked path for `perform` is:
+
+1. the current capability set must contain the named effect after alias
+   expansion, and
+2. the effect name must resolve to a declared effect/interface with a known
+   operation signature.
+
+That rule applies equally to inline handler arms such as
+`on Console.println(msg) => ...`.
+
+Imported `pub effect` interfaces preserve their operation signatures across
+module boundaries, so cross-module `perform Effect.op(...)` is typechecked
+against the imported signature rather than against an untyped name stub.
+Ambiguous imported same-name effects with different signatures are rejected.
 
 ### 4. Function types and CapSet encoding
 

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -16,13 +16,13 @@ superseded_by: null
 
 # SEP-0008: Module & Package System
 
-> **Executive Summary**: Defines a content-addressed package system (BLAKE3 dual-hash) with platform-as-package architecture, where platforms provide effect handlers via `foreign fn` declarations. Uses 1-file-=1-module mapping with dot-separated import paths (`import billing.invoice`), `spore.toml` for project configuration, and a two-layer capability ceiling (project + file level). Enforces visibility rules (pub/pub(pkg)/private) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through capability isolation — downloaded packages declaring `uses [Compute]` provably cannot access IO.
+> **Executive Summary**: Defines a content-addressed package system (BLAKE3 dual-hash) with platform-as-package architecture, where a selected Platform package declares its startup contract, host adapter, and handled effects via manifest metadata and package modules. Uses 1-file-=1-module mapping with dot-separated import paths (`import billing.invoice`) and `spore.toml` for project configuration. Enforces visibility rules (pub/pub(pkg)/private) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through explicit function-level effects plus Platform metadata. Broader project/file capability ceilings remain follow-up work rather than part of the current shipped contract.
 
 ## Summary
 
-This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via dot-separated paths (`import billing.invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `.spore-lock` for reproducible builds, how dependencies are resolved without semantic versioning, how IO is abstracted through the Platform system using effect handlers, and how a two-layer capability ceiling (project-wide in `spore.toml` + file-level `#![uses(...)]` pragma) secures the supply chain.
+This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via dot-separated paths (`import billing.invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `.spore-lock` for reproducible builds, how dependencies are resolved without semantic versioning, and how IO is abstracted through selected Platform packages and startup contracts. Additional project-wide or file-level capability ceilings remain reserved for later SEP work instead of being part of the current implementation-aligned contract.
 
-The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Elixir/Python (dot-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the two-layer capability ceiling, the import/alias separation, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
+The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Elixir/Python (dot-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the import/alias separation, reserved capability-ceiling design space, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
 
 ## Motivation
 
@@ -58,10 +58,10 @@ A human-readable `version` field remains available in `spore.toml` for documenta
 
 In traditional languages, IO operations are built into the standard library, making them impossible to substitute for testing, impossible to sandbox for security, and impossible to port across runtimes without rewriting application code. Spore's Platform system, inspired by Roc, makes IO a pluggable concern:
 
-- **Application code is pure**: Functions declare capability requirements (`uses [FileRead, NetWrite]`) but never perform IO directly.
-- **Platforms provide effect handlers**: A Platform maps abstract capabilities to concrete system calls.
-- **Test Platforms enable deterministic testing**: Mock handlers return predefined data, eliminating flaky tests.
-- **Supply-chain security**: A downloaded package declaring `uses [Compute]` is provably pure—it cannot access the filesystem, network, or any IO primitive.
+- **Application code declares capabilities explicitly**: Functions write `uses [...]` clauses and call platform-owned APIs; they do not issue raw host operations directly.
+- **Platform packages define the runtime boundary**: A Platform package publishes foreign-function modules, a startup contract, and a host adapter.
+- **Alternative Platforms can preserve the same application surface**: CLI, test, web, or embedded runtimes can supply different implementations for the same declared capabilities.
+- **Supply-chain security comes from explicit effects plus Platform metadata**: A package cannot manufacture filesystem, process, or network access unless the selected Platform exposes and handles those operations.
 
 ## Guide-level explanation
 
@@ -79,12 +79,10 @@ The canonical source extension in docs and manifests is `.sp`. Compatibility-onl
 | `src/utils.sp` | `utils` |
 | `src/main.sp` | `main` |
 
-There is no `module` keyword — the filesystem **is** the declaration. A file-level pragma may narrow the module's capability ceiling (see [Two-layer capability ceiling](#two-layer-capability-ceiling)):
+There is no `module` keyword — the filesystem **is** the declaration. Current implementations do not require or standardize an additional file-level `#![uses(...)]` ceiling; capability requirements remain attached to individual function signatures.
 
 ```spore
 // src/billing/invoice.sp
-#![uses(PaymentGateway, AuditLog)]
-
 import billing.types
 import billing.tax
 
@@ -111,7 +109,8 @@ Module names use **dot-separated** paths derived from the filesystem. There is n
 Spore uses **dot-separated** paths for module imports and for item selection:
 
 ```spore
-// Module import: makes all pub items accessible via qualified name
+// Module import: brings the module into scope; current implementations then
+// register its pub items as unqualified local names
 import billing.invoice
 
 // Module import with rename
@@ -122,7 +121,13 @@ alias gen = billing.invoice.generate_invoice
 alias Inv = billing.types.Invoice
 ```
 
-> **Note (D12):** Selective imports (`import billing.invoice.{calculate, Invoice}`) are not supported in v0.1. Use `import billing.invoice` and qualify names, or use `alias` for specific items.
+> **Note (D12):** Selective imports (`import billing.invoice.{calculate, Invoice}`) are not supported in v0.1. Use `import billing.invoice` and call the imported item by its current bare local name, or use `alias` for specific items.
+>
+> **Current implementation note:** `import mod as alias` is the locked surface
+> syntax, but imported items are still registered unqualified in the current
+> checker/runtime path. Alias-qualified member access (`inv.generate_invoice()`)
+> remains follow-up work; today the safe implementation-aligned path is to
+> import the module and call the imported item by its bare local name.
 
 Key rules:
 
@@ -130,6 +135,14 @@ Key rules:
 - `alias` operates on **items** only. You cannot alias a module (use `import ... as` instead).
 - No wildcard imports (`import billing.*` is not supported).
 - No implicit nested imports (`import billing` does not import `billing.invoice`).
+- Imported functions preserve the metadata needed for downstream checking:
+  parameter/return types, `uses [...]`, declared `!errors`, generic parameters,
+  and `where` bounds.
+- Imported `pub effect` / capability interfaces preserve operation signatures
+  across module boundaries, so `perform Effect.op(...)` keeps operation typing
+  after import.
+- Ambiguous imported same-name functions or effect interfaces with conflicting
+  signatures are rejected rather than silently overwritten.
 
 ### Visibility
 
@@ -150,7 +163,7 @@ pub(pkg) fn validate(order: Order) -> ValidatedOrder ! ValidationError { ... }
 fn compute_totals(order: ValidatedOrder) -> Invoice { ... }
 ```
 
-Visibility applies uniformly to functions, types, and aliases.
+Visibility applies uniformly to functions, types, effect interfaces, and aliases.
 
 ### Packages
 
@@ -187,23 +200,31 @@ manifest-backed packages and applications only.
 
 ### Platforms
 
-A Platform is the **only** code in a Spore application that can perform real IO. It provides effect handlers that interpret abstract capabilities at runtime:
+A Platform is the **only** package in a Spore application that bridges declared effects to the host runtime. In the current MVP it contributes:
+
+1. package modules that expose Platform-owned `foreign fn` surfaces,
+2. a contract module that defines the startup signature, and
+3. an adapter function that bridges application startup into the host runtime.
 
 ```spore
-// Application code: pure function, emits effects
-fn read_config() -> Config ! FileRead {
-    let content = File.read("config.toml")  // emits FileRead effect
-    parse_toml(content)
-}
+import basic_cli.stdout
+import basic_cli.cmd
 
-// Platform: provides the FileRead handler
-// Application code never sees this implementation
-handler FileReadHandler {
-    File.read(path) -> resume(os_read_file(path))
+fn main() -> () uses [Console, Exit] {
+    println("about to exit")
+    exit(7)
 }
 ```
 
-The same application code can run on different Platforms—CLI, Web, WASM, Embedded—without modification. For testing, a **Test Platform** replaces real IO with deterministic mock handlers.
+For `basic-cli`, project mode currently requires `main() -> ()`. Explicit process termination is modeled as a Platform API (`basic_cli.cmd.exit`) requiring `uses [Exit]`; the runtime carries that as a structured project outcome and the CLI converts that outcome to a host exit status at the process boundary.
+
+In the current implementation, project mode also validates the selected entry's
+startup capability requirements against the selected Platform package's
+`[platform].handles` manifest field. A manifest-backed application may only
+start if its entry function's required effects are listed in that Platform
+contract metadata.
+
+Standalone single-file execution is outside SEP-0008. Its legacy `main() -> I32` behavior is documented separately in `drafts/script-mode.md`.
 
 ## Reference-level explanation
 
@@ -513,19 +534,26 @@ alias invoice = billing.types.Invoice    // ERROR: 'invoice' conflicts with modu
 
 ### Platform abstraction
 
-#### IO via effect handlers
+#### IO via Platform boundary
 
-Application code is pure—it declares capability requirements but never performs IO directly. IO operations are expressed as effects that the Platform's handlers interpret at runtime:
+Application code declares capability requirements and crosses the runtime
+boundary through the selected Platform package. In the current MVP,
+manifest-backed project mode resolves those calls through Platform-owned modules
+plus the Platform's startup contract:
 
 ```spore
-// Application code: pure
-fn fetch_and_save(url: Url, dest: Path) -> Unit ! NetRead | FileWrite {
-    let data = Http.get(url)
-    File.write(dest, data)
+import basic_cli.file
+
+fn export_report(path: Str, content: Str) -> () ! IoError
+uses [FileWrite]
+{
+    file_write(path, content)
 }
 ```
 
-The type system tracks all effects. Effects propagate upward: if you call a function requiring capability `C`, your function must also declare `uses [C]`.
+The type system tracks all effects. Effects propagate upward: if you call an
+operation requiring capability `C`, your function must also declare
+`uses [C]`.
 
 #### Platform definition
 
@@ -550,7 +578,7 @@ type = "platform"
 contract-module = "platform_contract"
 startup-contract = "main"
 adapter-function = "main_for_host"
-handles = ["Console", "FileRead", "FileWrite", "Env", "Spawn"]
+handles = ["Console", "FileRead", "FileWrite", "Env", "Spawn", "Exit"]
 ```
 
 ```spore
@@ -567,9 +595,28 @@ pub fn main_for_host(app_main: () -> ()) -> () {
 
 The hole-backed startup function in the Platform contract module is the
 authoritative startup signature. Applications targeting that Platform must
-implement the same startup function name/signature in their entry module. Any
+implement the same startup function name plus the same parameter/return shape in
+their entry module. Current MVP capability requirements are checked separately:
+the selected startup entry's `uses [...]` set must fit within `[platform].handles`
+rather than being encoded into the adapter's callable Rust-facing shape. Any
 `spec` items attached to the Platform contract and the application
 implementation both apply.
+
+For `basic-cli` today, the startup contract remains `main() -> ()`. Applications
+do **not** return process exit codes from `main`; they call the Platform surface
+explicitly:
+
+```spore
+import basic_cli.cmd
+
+fn main() -> () uses [Exit] {
+    exit(7)
+}
+```
+
+The runtime propagates this as a structured project outcome. The current CLI
+boundary accepts exit codes in `0..=255`; unsupported values are reported as
+errors rather than silently truncated.
 
 Parser-level `platform { ... }` blocks remain future sugar over the same
 package-owned contract; the MVP does not require that syntax to land first.
@@ -590,7 +637,7 @@ path = "src/main.sp"
 
 The compiler verifies:
 
-- Every capability used by application code is handled by the selected Platform package's `[platform]` metadata.
+- The selected startup entry's required capabilities are listed in the selected Platform package's `[platform]` metadata.
 - The startup function in the selected entry module matches the Platform contract module's startup contract.
 - The selected Platform package exports the named adapter from its contract module.
 - Test and mock Platforms may be substituted during testing, but a project binds to one Platform at a time.
@@ -605,11 +652,13 @@ multiple Platforms.
 
 #### Test Platforms for deterministic testing
 
-Since application code is decoupled from IO implementations, a Test Platform can substitute mock handlers:
+Since application code is decoupled from IO implementations, a future Test
+Platform can substitute mock handlers. The syntax below is illustrative future
+sugar rather than the current package-backed MVP surface:
 
 ```spore
 platform TestPlatform {
-    handles [FileRead, FileWrite, NetRead, Clock]
+    handles [FileRead, FileWrite, NetConnect, Clock]
     startup: fn() -> TestResult
 }
 
@@ -646,10 +695,10 @@ Test result: ok. 3 passed; 0 failed
 
 #### Security model
 
-1. **Pure packages cannot perform IO**. They declare capability requirements but lack handlers.
-2. **Only Platforms hold `RawSyscall`**. No user package can access raw system calls.
+1. **Pure packages cannot perform IO**. They may declare capability requirements, but they do not carry Platform implementations.
+2. **Only Platform packages bridge to raw host operations**. No user package can invoke host operations without going through the selected Platform.
 3. **Capabilities are explicit**. An auditor can inspect any function's `uses` clause to know exactly what it can do.
-4. **Supply-chain safety**: A downloaded package declaring `uses [Compute]` is provably pure.
+4. **Supply-chain safety**: A downloaded package cannot gain hidden filesystem, process, or network access through an implicit stdlib shim; those surfaces must be provided by the selected Platform package.
 
 ```text
 $ spore audit billing-lib
@@ -664,132 +713,27 @@ Package: billing-lib
 
   ✓ No RawSyscall usage
   ✓ No undeclared capabilities
-  ✓ All capability requirements declared in spore.toml
+  ✓ Startup entry requirements fit the selected Platform metadata
 ```
 
 ### Module capabilities
 
-#### Two-layer capability ceiling
+#### Capability checking today
 
-Capabilities are constrained through a two-layer ceiling system:
+The current implementation-aligned model standardizes capability checking at two
+places:
 
-**Layer 1 — Project-wide ceiling (`spore.toml`):**
+1. function signatures (`uses [...]`)
+2. selected Platform boundaries and Platform metadata
 
-```toml
-[capabilities]
-allowed = ["IO", "FileRead", "FileWrite", "Net", "PaymentGateway", "AuditLog"]
-```
-
-This defines the maximum set of capabilities available to **any** file in the project. No module can exceed this ceiling.
-
-**Layer 2 — File-level narrowing (`#![uses(...)]` pragma):**
-
-Individual files can narrow the project ceiling to declare the maximum capabilities their functions may use:
-
-```spore
-// src/billing/invoice.sp
-#![uses(PaymentGateway, AuditLog)]
-```
-
-- Any function in the module can use a subset of these capabilities.
-- No function can use capabilities **not** in this set.
-- The file-level pragma must be a **subset** of `spore.toml`'s `[capabilities] allowed`.
-- Private functions are also bound by the ceiling.
-
-**Example — two layers in action:**
-
-`spore.toml` allows `IO`, `FileRead`, `FileWrite`, `Net`, `PaymentGateway`, `AuditLog`. But `src/billing/invoice.sp` only needs payment and audit:
-
-```spore
-// src/billing/invoice.sp
-#![uses(PaymentGateway, AuditLog)]
-
-import billing.types
-import billing.tax
-
-pub fn generate_invoice(order: Order) -> Invoice ! TaxError
-    uses [PaymentGateway, AuditLog]
-{ ... }
-```
-
-Meanwhile, `src/net/client.sp` needs only network capabilities:
-
-```spore
-// src/net/client.sp
-#![uses(Net)]
-
-pub fn fetch(url: Url) -> Result[Bytes, NetError]
-    uses [Net]
-{ ... }
-```
-
-If the `#![uses(...)]` pragma is omitted, the compiler **infers** the ceiling from the union of all `pub` functions' capabilities and emits an `[info]` diagnostic suggesting the explicit declaration.
+Additional project-wide or file-level ceilings such as `[capabilities] allowed`
+or `#![uses(...)]` remain reserved for follow-up design work. They are not part
+of the shipped MVP contract today, and tooling should not treat them as
+normative.
 
 #### Capability propagation
 
 Importing a module does **not** grant its capabilities. If you call a function that requires capability `C`, your function must also declare `uses [C]`. Capabilities propagate upward through the call graph.
-
-#### Private functions and the ceiling
-
-Private functions are **also** bound by the module's capability ceiling (if declared). However, they do **not** contribute to the inferred capability set:
-
-```spore
-// src/billing/invoice.sp
-#![uses(PaymentGateway, AuditLog)]
-
-pub fn generate_invoice(order: Order) -> Invoice ! TaxError
-    uses [PaymentGateway, AuditLog]
-{ ... }
-
-// Private function: OK — uses subset of module ceiling
-fn log_audit(action: String, id: InvoiceId) -> Unit
-    uses [AuditLog]
-{ ... }
-
-// Private function: ERROR — exceeds module ceiling
-fn send_email(to: Email, body: String) -> Unit ! SmtpError
-    uses [EmailService]    // not in module ceiling
-{ ... }
-```
-
-```text
-[error] capability ceiling violation at src/billing/invoice.sp:12
-  function send_email uses [EmailService]
-  module billing.invoice allows [PaymentGateway, AuditLog]
-  ─── EmailService is not in the module's capability set
-
-  help: either add EmailService to the file-level pragma:
-          #![uses(PaymentGateway, AuditLog, EmailService)]
-        or move this function to a module that allows EmailService
-```
-
-#### Capability violation error examples and remediation flow
-
-**Ceiling violation**: The error shown above.
-
-**Diagnostic hint**: When a module omits its capability pragma, the compiler infers it:
-
-```text
-$ spore check src/billing/invoice.sp
-
-[ok] billing.invoice
-  exports: generate_invoice, void_invoice
-
-  [info] inferred module capabilities: [PaymentGateway, AuditLog]
-    ─── derived from union of pub function capabilities
-    ─── consider adding: #![uses(PaymentGateway, AuditLog)]
-```
-
-**Full workflow**:
-
-```bash
-spore check src/billing/invoice.sp
-# add the suggested #![uses(...)] pragma manually or via editor tooling
-spore check src/billing/invoice.sp
-```
-
-The current public CLI reports the inferred capability pragma in diagnostics, but
-does not yet auto-apply it.
 
 ### Package management
 
@@ -804,10 +748,6 @@ description = "Invoice generation and tax calculation"
 license = "MIT"
 authors = ["Alice <alice@example.com>"]
 spore-version = ">=0.5.0"
-
-[capabilities]
-# Project-level capability ceiling — no file may exceed this set
-allowed = ["PaymentGateway", "AuditLog"]
 
 [dependencies]
 json-parser = {
@@ -825,7 +765,9 @@ test-framework = {
 }
 ```
 
-Dependencies are declared **per-project** in `spore.toml`, not per-file. The `[capabilities] allowed` list defines the project-wide ceiling; individual files narrow it with `#![uses(...)]`.
+Dependencies are declared **per-project** in `spore.toml`, not per-file.
+Additional project-wide capability ceilings remain future design work rather than
+part of the current normative MVP surface.
 
 Package names are `kebab-case` and globally unique within a registry. Module paths within a package use `snake_case` segments.
 
@@ -837,6 +779,12 @@ module's **startup function** against its **startup contract**. Under the MVP
 bridge, the selected Platform package manifest names the contract module and
 startup symbol, and that contract module owns the hole-backed startup
 definition whose `spec` items stack with the application's own implementation.
+
+Current CLI behavior also retains a compatibility path for explicit
+`spore run src/...` file execution: when the file lives under a discovered
+project's `src/` tree, the tool derives a project-backed entry path from that
+file location. Named manifest entries remain the canonical durable project
+surface even while that compatibility path exists.
 
 The default emitted executable or run target name is the selected entry name:
 
@@ -907,27 +855,17 @@ Content hashes ensure integrity regardless of source. Community registries provi
 
 #### Capability-based trust model
 
-Packages declare required capabilities in `spore.toml`. The `[capabilities] allowed` list defines the project-wide ceiling. Capabilities do **not** propagate automatically—the consuming package must explicitly grant them:
+Packages declare dependencies and Platform selection in `spore.toml`. Current
+implementation-aligned capability control does **not** add a separate
+project-wide `[capabilities] allowed` ceiling. Instead:
 
-```toml
-[capabilities]
-# Project-level ceiling
-allowed = ["IO", "FileRead", "FileWrite", "Net"]
+- libraries declare required effects on function signatures
+- the selected startup entry's required effects must be satisfied by the chosen
+  Platform package's `[platform].handles` metadata
+- tooling such as `spore audit` reports the resulting dependency/effect graph
 
-# Fine-grained grants for dependencies (future direction)
-grant = [
-    "http:network:listen:*",
-    "logger:filesystem:write:/var/log"
-]
-```
-
-At runtime, the capability ceiling is enforced:
-
-```bash
-spore run src/main.sp
-```
-
-The `spore audit` command reports the full capability graph, flagging any ungrantable or suspicious requirements.
+More granular dependency grants remain future design space rather than part of
+the current shipped MVP.
 
 #### Workspace support
 
@@ -944,7 +882,7 @@ members = [
 
 Alternatively, `path` dependencies provide lightweight monorepo support without requiring a workspace manifest.
 
-A workspace uses a **single `spore.lock`** at the workspace root. Individual members do NOT have their own lock files. This ensures:
+A workspace uses a **single `.spore-lock`** at the workspace root. Individual members do NOT have their own lock files. This ensures:
 
 - All members share the same dependency versions (no diamond dependency conflicts).
 - CI builds are reproducible from a single lock file.
@@ -1067,7 +1005,7 @@ impl = null                             # interface-only dependency
 }
 
 [capabilities]
-"http" = ["NetRead", "NetWrite"]
+"http" = ["NetConnect", "NetListen"]
 "io" = ["FileRead", "FileWrite"]
 
 [[platform-locks]]
@@ -1216,7 +1154,8 @@ spore hash
 
 Holes respect module boundaries:
 
-- A hole in module A can only be filled with code that respects A's capability ceiling.
+- A hole in module A can only be filled with code that respects A's explicit
+  effect requirements and the selected Platform boundary.
 - HoleReport candidates are filtered by visibility.
 - Partial modules (containing holes) are valid compilation units. They export `pub` items normally, but those items have `impl = None`.
 - A module calling a partial function becomes **transitively partial**.
@@ -1384,15 +1323,19 @@ Build: success (2 partial functions)
 | **Effect System** | Algebraic Effects | High | Medium | Koka, Eff |
 | **Spore Platform** | Effect Handlers + Platform | **Very high** | **Very high** | Roc, Spore |
 
-Spore and Roc share the same design philosophy: no built-in Platform; all Platforms are third-party packages.
+Spore and Roc share the same design philosophy: no built-in Platform; all
+Platforms are third-party packages.
+
+The examples below use illustrative future `platform { ... }` sugar. The
+current MVP surface remains package-backed manifests plus contract modules.
 
 #### Web Platform example
 
 ```spore
 platform WebPlatform {
     version: "1.0.0"
-    handles [HttpServer, NetRead, NetWrite, Clock, Spawn, DbQuery]
-    startup: fn(req: Request) -> Response ! HttpServer | DbQuery
+    handles [NetListen, Clock, Spawn, DbQuery]
+    startup: fn(req: Request) -> Response ! NetListen | DbQuery
 
     handler HttpServerHandler {
         Server.listen(port: U16, handler: fn(Request) -> Response) {
@@ -1407,7 +1350,7 @@ platform WebPlatform {
 ```spore
 platform LambdaPlatform {
     version: "1.0.0"
-    handles [NetRead, NetWrite, S3Read, S3Write, DynamoRead, DynamoWrite]
+    handles [NetConnect, S3Read, S3Write, DynamoRead, DynamoWrite]
     startup: fn(event: JsonValue) -> JsonValue ! S3Read | DynamoWrite
 
     handler S3Handler {
@@ -1435,7 +1378,7 @@ handler DirectFfi {
 2. **Effect composition**: Handler translates high-level effects into lower-level ones.
 
 ```spore
-handler HttpClientHandler uses [NetRead, NetWrite] {
+handler HttpClientHandler uses [NetConnect] {
     Http.get(url: Url) -> Result[Response, HttpError] {
         let socket = TcpSocket.connect(url.host, url.port)?
         socket.write(format_http_request(url))?
@@ -1482,11 +1425,12 @@ pub extern "C" fn ffi_read_file(path: SporeBytes) -> FfiResult<SporeBytes> {
 
 #### Record/Replay testing mode
 
-For integration tests, a **RecordingPlatform** captures IO events during real execution:
+For integration tests, a future **RecordingPlatform** sugar could capture IO
+events during real execution:
 
 ```spore
 platform RecordingPlatform {
-    handles [FileRead, NetRead]
+    handles [FileRead, NetConnect]
 
     handler RecordingHandler {
         var log: List[IoEvent] = []
@@ -1500,11 +1444,12 @@ platform RecordingPlatform {
 }
 ```
 
-A **ReplayPlatform** then replays the recorded events deterministically:
+A future **ReplayPlatform** could then replay the recorded events
+deterministically:
 
 ```spore
 platform ReplayPlatform {
-    handles [FileRead, NetRead]
+    handles [FileRead, NetConnect]
 
     handler ReplayHandler {
         var log: List[IoEvent] = load_log("test_recording.log")
@@ -1584,36 +1529,44 @@ Platforms are content-addressed packages like any other, following the same `sig
 
 | Subsystem | Interaction |
 |---|---|
-| **Concurrency** | `Spawn` is an effect; the Platform provides the `SpawnHandler` (backed by a thread pool, tokio, etc.) |
+| **Concurrency** | `Spawn` is an effect surfaced by Platform-owned modules; runtimes may back it with a thread pool, tokio, or another scheduler |
 | **Package management** | Platforms are ordinary Spore packages, fetched and cached via the same content-addressed system |
-| **Capability system** | Platform defines the capability upper bound. `App.uses ⊆ Platform.handles` is verified at compile time |
+| **Capability system** | Platform defines the manifest-declared capability contract. Current implementations verify the selected startup entry's required effects against `Platform.handles`; broader whole-application enforcement remains follow-up work |
 | **Cost model** | Platform effects carry cost annotations: `File.read @cost(io=1)`. The compiler uses these for cost analysis |
-| **Compiler** | Generates an effect routing table mapping each effect to its handler Platform. Embedded in compiled output |
+| **Compiler** | Resolves Platform package metadata and contract modules into the compiled runtime boundary |
 
 #### Platform API reference
 
-**CLI Platform** (complete effect definitions):
+**CLI Platform** (current `basic-cli` package surface):
 
 ```spore
-effect FileRead {
-    fn read(path: Path) -> Result[Bytes, IoError]
-    fn read_to_string(path: Path) -> Result[Str, IoError]
-    fn exists(path: Path) -> Bool
-    fn list_dir(path: Path) -> Result[List[DirEntry], IoError]
-}
+// basic_cli.file
+pub foreign fn file_read(path: Str) -> Str ! IoError uses [FileRead]
+pub foreign fn file_write(path: Str, content: Str) -> () ! IoError uses [FileWrite]
+pub foreign fn file_exists(path: Str) -> Bool uses [FileRead]
+pub foreign fn file_stat(path: Str) -> Str ! IoError uses [FileRead]
 
-effect FileWrite {
-    fn write(path: Path, content: Bytes) -> Result[Unit, IoError]
-    fn append(path: Path, content: Bytes) -> Result[Unit, IoError]
-    fn delete(path: Path) -> Result[Unit, IoError]
-    fn create_dir(path: Path) -> Result[Unit, IoError]
-}
+// basic_cli.dir
+pub foreign fn dir_list(path: Str) -> List[Str] ! IoError uses [FileRead]
+pub foreign fn dir_mkdir(path: Str) -> () ! IoError uses [FileWrite]
 
-effect StdOut { fn println(s: Str) -> Unit; fn print(s: Str) -> Unit }
-effect StdErr { fn eprintln(s: Str) -> Unit }
-effect Clock  { fn now() -> Timestamp; fn sleep(duration: Duration) -> Unit }
-effect Spawn  { fn spawn[T](f: fn() -> T) -> Task[T]; fn await_task[T](task: Task[T]) -> T }
-effect Exit   { fn exit(code: I32) -> Never }
+// basic_cli.stdout
+pub foreign fn print(s: Str) -> () ! IoError uses [Console]
+pub foreign fn println(s: Str) -> () uses [Console]
+pub foreign fn eprint(s: Str) -> () ! IoError uses [Console]
+pub foreign fn eprintln(s: Str) -> () uses [Console]
+
+// basic_cli.stdin
+pub foreign fn read_line() -> Str ! IoError uses [Console]
+
+// basic_cli.env
+pub foreign fn env_get(key: Str) -> Option[Str] uses [Env]
+pub foreign fn env_set(key: Str, value: Str) -> () uses [Env]
+
+// basic_cli.cmd
+pub foreign fn process_run(cmd: Str, args: List[Str]) -> Str ! ExecError uses [Spawn]
+pub foreign fn process_run_status(cmd: Str, args: List[Str]) -> Int ! ExecError uses [Spawn]
+pub foreign fn exit(code: Int) -> Never uses [Exit]
 ```
 
 **Comparison with Roc, Elm, and Koka**:
@@ -1798,12 +1751,12 @@ git push origin main --tags
 | **Named alias** | A human-readable identifier mapping to a specific set of content hashes |
 | **Dependency graph** | DAG of module/package import relationships |
 | **Capability** | A declared permission for a function to perform a specific category of operation |
-| **Capability ceiling** | The maximum set of capabilities a module's functions may use |
+| **Capability ceiling** | A reserved follow-up concept for module- or project-level capability caps; not part of the shipped MVP contract today |
 | **Lock file (`.spore-lock`)** | Machine-generated file recording the full resolved dependency graph with hashes |
 | **Diamond dependency** | When the same module is reached via multiple paths in the dependency graph |
 | **Reproducible build** | A build that produces identical output from identical inputs (ensured by `impl` hashes) |
-| **Platform** | A Spore package that provides effect handlers for IO capabilities |
-| **Effect handler** | Runtime implementation that interprets abstract effect operations |
+| **Platform** | A Spore package that declares startup metadata/contracts and exposes the host-facing modules used by an application |
+| **Effect handler** | A runtime host implementation detail that may sit behind Platform package surfaces; not the primary package contract model |
 | **Hole** | A placeholder (`?name`) in a function body, marking incomplete code |
 | **Partial function** | A function containing holes; has `impl = None` until all holes are filled |
 
@@ -1818,7 +1771,7 @@ git push origin main --tags
 
 ### Workflow ergonomics
 
-- **Structured diagnostics** surface inferred capability declarations for manual or editor-assisted application, lowering the barrier for new users.
+- **Structured diagnostics** surface missing or mismatched `uses [...]` requirements and related import/startup issues, lowering the barrier for new users.
 - **`spore --permit`** provides explicit acknowledgment of breaking changes, preventing accidental API breakage.
 - **No semver** means developers never debate whether a change is "major" or "minor". The compiler decides mechanically.
 
@@ -1828,7 +1781,7 @@ The dual-hash model is more conceptually complex than semver. However, the tooli
 
 ### Error messages
 
-Visibility violations, circular dependencies, capability ceiling breaches, and missing effect handlers all produce structured, actionable diagnostics with `help:` suggestions.
+Visibility violations, circular dependencies, startup-capability mismatches, and missing Platform bindings all produce structured, actionable diagnostics with `help:` suggestions.
 
 ## Agent experience impact
 
@@ -1877,16 +1830,19 @@ impl = "7b8d4f2a1e9c3d5b"
 }
 
 [capabilities]
-"http" = ["network:listen", "network:connect"]
+"http" = ["NetListen", "NetConnect"]
 ```
 
 ### Module interface files (`.spore-sig`)
 
 For interface-only dependencies, the compiler can produce `.spore-sig` files containing only the canonicalized public API. These are sufficient for type-checking without the full implementation.
 
-### Platform capability routing tables
+### Platform binding records
 
-The compiler generates a capability routing table mapping each effect to its handler Platform. This table is embedded in the compiled output and enforced at runtime.
+The compiler resolves the selected Platform package's metadata, startup contract,
+and imported host-facing modules into the compiled output. Current MVP behavior
+centers startup-contract validation plus the selected Platform package boundary;
+broader whole-program capability routing remains follow-up work.
 
 ## Diagnostics impact
 
@@ -1896,12 +1852,12 @@ The compiler generates a capability routing table mapping each effect to its han
 |---|---|---|
 | `E3001` | Visibility violation | Accessing a private function from another module |
 | `E3002` | Circular dependency | Module A → B → A |
-| `E3003` | Capability ceiling breach | Function uses capability not in module ceiling |
+| `E3003` | Capability declaration mismatch | Function calls an operation requiring `FileWrite` without declaring `uses [FileWrite]` |
 | `E3004` | Signature change detected | `sig` hash mismatch in `.spore-lock` |
 | `E3005` | Alias chain | `pub alias` pointing to another alias |
 | `E3006` | Shadowing conflict | Import alias conflicts with module name |
 | `E4201` | Platform binding conflict | Project declares more than one Platform binding |
-| `E4202` | Missing effect handler | No Platform handles a required effect |
+| `E4202` | Unsupported startup capability | Selected startup entry requires a capability not listed in the Platform's `[platform].handles` metadata |
 | `E4203` | Startup contract mismatch | Startup function signature doesn't match Platform requirement |
 
 ### Diagnostic structure
@@ -2036,7 +1992,7 @@ New fields added to `.spore-lock` are ignored by older tools (forward-compatible
 
 The module system does not require wholesale adoption:
 
-- Packages can start with inferred capabilities (no `#![uses(...)]` pragma) and add explicit declarations later once diagnostics show the inferred set.
+- Packages can adopt explicit `uses [...]` signatures incrementally at function boundaries; broader file- or project-level ceilings remain future work.
 - Dependencies can mix Git, local path, and registry sources.
 - The `version` field in `spore.toml` remains available for human communication during the transition from semver.
 
@@ -2046,7 +2002,7 @@ The module system does not require wholesale adoption:
 
 2. **~~Cross-package `pub(pkg)` boundaries in workspaces~~**: Resolved — `pub(pkg)` restricts visibility to the current package (member) only. Items must be promoted to `pub` for cross-member access.
 
-3. **Capability granularity**: The current design uses coarse-grained capability names (e.g., `FileRead`, `NetWrite`). Should fine-grained capabilities (e.g., `filesystem:read:/data`) be part of the language-level type system or remain a tooling concern in `spore.toml`?
+3. **Capability granularity**: The current design uses coarse-grained capability names (e.g., `FileRead`, `NetConnect`). Should fine-grained capabilities (e.g., `filesystem:read:/data`) be part of the language-level type system or remain a tooling concern in `spore.toml`?
 
 4. **Platform versioning**: Platforms themselves evolve. When a Platform changes its handler interface, how are downstream applications notified? Is `spore --permit` sufficient, or do Platforms need a separate compatibility mechanism?
 
@@ -2067,8 +2023,6 @@ The module system does not require wholesale adoption:
 ## Appendix A: Grammar summary
 
 ```text
-// File-level capability pragma (replaces module header)
-file_pragma    ::= '#![uses(' capability (',' capability)* ')]'
 cap_list       ::= '[' capability (',' capability)* ']'
 capability     ::= UPPER_IDENT
 
@@ -2116,7 +2070,6 @@ effect_fn      ::= 'fn' IDENT '(' params ')' '->' type
 
 // spore.toml (TOML subset)
 // [package]       name, version, type, description, license, authors, spore-version, default-entry
-// [capabilities]  allowed
 // [dependencies]  <name> = { git|path|alias, sig, impl?, optional?, branch?, tag?, rev? }
 // [dev-dependencies]
 // [features]      <name> = [deps/features]

--- a/seps/SEP-0009-standard-library.md
+++ b/seps/SEP-0009-standard-library.md
@@ -23,7 +23,7 @@ This SEP specifies the standard library that ships with every Spore implementati
 1. **Prelude** — types and functions available without import
 2. **Core modules** — standard modules available via `import std.*`
 3. **Error types** — a unified error hierarchy
-4. **Platform bindings** — how I/O functions connect to platform effect handlers
+4. **Platform bindings** — how I/O functions connect to selected Platform package modules
 5. **Cost contracts** — cost annotations for all stdlib functions
 
 The stdlib is deliberately small. Spore follows the principle that the standard library should provide exactly the types and functions needed to write idiomatic Spore code, with everything else available as packages.
@@ -67,28 +67,40 @@ Specialized modules require explicit imports:
 import std.math       // sqrt, sin, cos, abs, pow, ...
 import std.string     // split, trim, join, contains, ...
 import std.collections // Map, Set, sorted, grouped, ...
-import std.io         // Platform-provided I/O bindings
+// future: import std.io  // stabilized platform-neutral I/O facade
 import std.time       // DateTime, Duration, now(), ...
 import std.json       // parse_json, to_json
 ```
 
 ### How do I/O functions work?
 
-I/O functions are **not** ordinary Spore functions — they are `foreign fn` declarations provided by the platform (SEP-0008). The stdlib re-exports them with Spore-visible type signatures:
+The current implementation does **not** yet ship a stabilized `std.io`
+abstraction layer. Manifest-backed projects import the selected Platform
+package's modules directly, and those modules expose `foreign fn` declarations
+with explicit `uses [...]` requirements.
 
 ```spore
-// In std.io (provided by platform)
-foreign fn read_file(path: String) -> Result[String, IoError]
-    uses [FileRead]
+import basic_cli.stdout
+import basic_cli.cmd
 
-foreign fn write_file(path: String, content: String) -> Result[Unit, IoError]
-    uses [FileWrite]
-
-foreign fn http_get(url: String) -> Result[String, HttpError]
-    uses [NetRead]
+fn main() -> () uses [Console, Exit] {
+    println("hello")
+    exit(0)
+}
 ```
 
-The platform effect handler mechanism (SEP-0008) ensures these functions are only available when the ambient capability set includes the required capabilities.
+For `basic-cli`, the shipped surface currently lives in modules such as
+`basic_cli.stdout`, `basic_cli.stdin`, `basic_cli.file`, `basic_cli.env`, and
+`basic_cli.cmd`.
+A future `std.io` layer may wrap or re-export a common surface above those
+Platform packages, but that is not today's contract.
+
+There is also a narrower runtime path for declared effects in interpreter-style
+execution: `perform Effect.operation(...)` falls back through registered host
+handlers by the **qualified** `Effect.operation` key. Today that support is
+explicit rather than generic (for example, the CLI runtime supports
+`Console.print`, `Console.println`, and `Console.read_line`). Platform package
+modules remain the main shipped application-facing contract.
 
 ## Reference-level explanation
 
@@ -100,8 +112,8 @@ The prelude is implicitly imported into every module. It contains:
 
 | Type | Description | Default | Size |
 |------|-------------|---------|------|
-| `Int` | Arbitrary-precision integer | `0` | Variable |
-| `Float` | 64-bit IEEE 754 | `0.0` | 8 bytes |
+| `Int` | Canonical integer scalar (`I64` alias) | `0` | 8 bytes |
+| `Float` | Canonical floating-point scalar (`F64` alias) | `0.0` | 8 bytes |
 | `Bool` | Boolean | `false` | 1 byte |
 | `String` | Immutable UTF-8 string | `""` | Variable |
 | `Char` | Unicode scalar value | — | 4 bytes |
@@ -443,77 +455,29 @@ fn from_list[T](items: List[T]) -> Set[T]
     cost O(len(items))
 ```
 
-#### `std.io` (platform-provided)
+#### `std.io` (future standardization layer)
 
-```spore
-module std.io
+`std.io` is not yet the normative surface of the current implementation. Today,
+manifest-backed projects import Platform package modules directly. For
+`basic-cli`, the shipped modules are:
 
-// ── Filesystem ─────────────────────────────────────────────────────
+| Module | Example operations | Required effects |
+|---|---|---|
+| `basic_cli.stdout` | `print`, `println`, `eprint`, `eprintln` | `Console` |
+| `basic_cli.stdin` | `read_line` | `Console` |
+| `basic_cli.file` | `file_read`, `file_write`, `file_exists`, `file_stat` | `FileRead`, `FileWrite` |
+| `basic_cli.dir` | `dir_list`, `dir_mkdir` | `FileRead`, `FileWrite` |
+| `basic_cli.env` | `env_get`, `env_set` | `Env` |
+| `basic_cli.cmd` | `process_run`, `process_run_status`, `exit` | `Spawn`, `Exit` |
 
-foreign fn read_file(path: String) -> Result[String, IoError]
-    uses [FileRead]
-    cost O(file_size)
+`basic_cli.cmd.exit(code)` is the currently shipped explicit process-termination
+surface. In project mode it works together with SEP-0008's startup contract
+(`main() -> ()`), and the runtime converts the resulting structured outcome into
+a host exit status.
 
-foreign fn read_bytes(path: String) -> Result[List[Int], IoError]
-    uses [FileRead]
-    cost O(file_size)
-
-foreign fn write_file(path: String, content: String) -> Result[Unit, IoError]
-    uses [FileWrite]
-    cost O(len(content))
-
-foreign fn append_file(path: String, content: String) -> Result[Unit, IoError]
-    uses [FileWrite]
-    cost O(len(content))
-
-foreign fn list_dir(path: String) -> Result[List[String], IoError]
-    uses [FileRead]
-
-foreign fn create_dir(path: String) -> Result[Unit, IoError]
-    uses [FileWrite]
-
-foreign fn delete(path: String) -> Result[Unit, IoError]
-    uses [FileWrite]
-
-foreign fn file_exists(path: String) -> Result[Bool, IoError]
-    uses [FileRead]
-    cost O(1)
-
-// ── Network ────────────────────────────────────────────────────────
-
-foreign fn http_get(url: String) -> Result[String, HttpError]
-    uses [NetRead]
-
-foreign fn http_post(url: String, body: String) -> Result[String, HttpError]
-    uses [NetWrite]
-
-// ── Console ────────────────────────────────────────────────────────
-
-foreign fn print(msg: String) -> Unit
-    uses [StateWrite]
-    cost O(len(msg))
-
-foreign fn println(msg: String) -> Unit
-    uses [StateWrite]
-    cost O(len(msg))
-
-foreign fn read_line() -> Result[String, IoError]
-    uses [StateRead]
-
-// ── Process ────────────────────────────────────────────────────────
-
-foreign fn exit(code: Int) -> Never
-    uses [Exit]
-    cost O(1)
-
-foreign fn env_var(name: String) -> Option[String]
-    uses [StateRead]
-    cost O(1)
-
-foreign fn args() -> List[String]
-    uses [StateRead]
-    cost O(1)
-```
+A future `std.io` module may standardize a portable wrapper above these Platform
+packages. Until that lands, signatures in this section should be read as future
+design sketches rather than as the current contract.
 
 #### `std.time` (platform-provided)
 
@@ -661,36 +625,38 @@ These 13 traits have special compiler support (SEP-0002). The stdlib provides th
 
 ### 4.6 Platform binding architecture
 
-The stdlib I/O layer uses the platform effect handler mechanism from SEP-0008:
+The current runtime stack for platform-backed I/O looks like this:
 
 ```text
-┌─────────────────────────────────────────┐
-│  User Code                              │
-│  fn main() uses [FileRead] {            │
-│      let content = read_file("a.txt")   │
-│  }                                      │
-├─────────────────────────────────────────┤
-│  std.io (Spore signatures)              │
-│  foreign fn read_file(path) -> Result   │
-│      uses [FileRead]                    │
-├─────────────────────────────────────────┤
-│  Platform (effect handler)              │
-│  handle FileRead {                      │
-│      read_file(path) => rust_read(path) │
-│  }                                      │
-├─────────────────────────────────────────┤
-│  Native Runtime (Rust/C)                │
-│  fn rust_read(path: &str) -> ...        │
-└─────────────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│ User Code                                    │
+│ fn main() -> () uses [Console, Exit] {       │
+│   println("done")                            │
+│   exit(0)                                    │
+│ }                                            │
+├──────────────────────────────────────────────┤
+│ Platform package modules                     │
+│ basic_cli.stdout / basic_cli.stdin /         │
+│ basic_cli.file / basic_cli.env /             │
+│ basic_cli.cmd                                │
+├──────────────────────────────────────────────┤
+│ Selected Platform contract + metadata        │
+│ [project].platform = "basic-cli"             │
+│ startup-contract = "main"                    │
+│ adapter-function = "main_for_host"           │
+│ handles = [..., "Exit"]                      │
+├──────────────────────────────────────────────┤
+│ Native Runtime (Rust/C/host embedding)       │
+└──────────────────────────────────────────────┘
 ```
 
 Key properties:
 
-1. **User code** calls stdlib functions with normal Spore syntax
-2. **Stdlib** declares `foreign fn` with capability requirements
-3. **Platform** provides the actual implementation via effect handlers
-4. **Test platform** can mock any I/O function for deterministic testing
-5. **Capability isolation** — a package declaring `uses [Compute]` cannot call any `foreign fn` that requires I/O capabilities
+1. **User code** imports Platform package modules directly today.
+2. **Each foreign surface** declares explicit capability requirements.
+3. **The selected Platform package** owns startup contracts and handled-effect metadata.
+4. **Some operations** may propagate structured runtime outcomes before host conversion (for example `Exit` in project mode).
+5. **Future stdlib wrappers** may layer above this, but they are not required for the current implementation.
 
 ### 4.7 Cost expression helpers
 
@@ -788,7 +754,9 @@ Rejected. A large stdlib creates maintenance burden and version coupling. Spore'
 
 ### No foreign fn (pure Spore stdlib)
 
-Rejected. I/O operations cannot be expressed in pure Spore. The platform effect handler model is the designed mechanism for I/O (SEP-0008).
+Rejected. I/O operations cannot be expressed in pure Spore. The designed MVP
+mechanism is Platform-owned package modules plus the selected Platform contract
+boundary (SEP-0008).
 
 ## Prior art
 


### PR DESCRIPTION
## Proposal summary

- align `drafts/script-mode.md` with the current shipped `spore run FILE` behavior versus the stricter future split
- sync SEP-0003/0008/0009 to the current basic-cli runtime surface, startup contract, `Exit` path, and `std.io` status
- remove stale wording around effect-handler routing and project-wide capability ceilings from the current MVP path

## Linked discussion

- Follow-up implementation/docs sync for the current platform/runtime canon discussed in the existing Spore language design stream.

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

- This PR intentionally excludes the independent `ci-static-checks` actionlint addition.
