### PR TITLE
👷 ci: add actionlint to ci-static-checks

### DIFF
--- a/.github/workflows/ci-static-checks.yml
+++ b/.github/workflows/ci-static-checks.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.12
 
   prek:
     name: prek

--- a/.github/workflows/ci-static-checks.yml
+++ b/.github/workflows/ci-static-checks.yml
@@ -12,6 +12,17 @@ permissions:
   contents: read
 
 jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+
   prek:
     name: prek
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposal summary

- add an `actionlint` job to `ci-static-checks`
- keep the existing `prek` job unchanged

## Linked discussion

- Follow-up CI hygiene slice for the repo; no language-design content changes.

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

- Split from PR #27 so infra review stays isolated from the runtime/docs alignment.
