### PR TITLE
📝 docs: align standalone CLI return semantics

### DIFF
--- a/drafts/script-mode.md
+++ b/drafts/script-mode.md
@@ -91,8 +91,9 @@ project mode.
 ### Example: standalone file
 
 ```spore
-fn main() -> I32 {
-    42
+fn main() -> () {
+    println("hello")
+    return
 }
 ```
 
@@ -100,12 +101,13 @@ Running the file today:
 
 ```bash
 spore run tools/hello.sp
-42
+hello
 ```
 
-Current standalone-file execution still permits `fn main() -> I32`. The
-returned value is printed by `spore run`; it does **not** become the host
-process exit status.
+Current standalone-file execution still permits compatibility cases like
+`fn main() -> I32`, but `spore run` no longer gives the completion value any
+default host meaning. It is not printed automatically, and it does **not**
+become the host process exit status.
 
 ### Example: explicit file inside a project tree
 
@@ -269,9 +271,9 @@ In standalone file mode:
 - files outside any project's `src/` tree run this way, even if they live
   elsewhere under a project root (for example `tools/migrate.sp`)
 - standalone execution does **not** use a Platform contract module
-- `fn main() -> I32` is still accepted and its result is printed as a normal
-  value
-- standalone execution does **not** convert the return value into the host
+- compatibility forms like `fn main() -> I32` are still accepted, but
+  standalone execution does **not** print completion values automatically
+- standalone execution does **not** convert return values into the host
   process exit status
 
 The explicit `Exit` effect path is currently a project-mode Platform feature,


### PR DESCRIPTION
## Proposal summary

- update the script-mode draft to match the latest CLI canon: explicit stdout stays explicit, completion values are not printed by default, and standalone return values do not become host exit codes
- replace the old `fn main() -> I32 { 42 }` example with an explicit-output `main() -> ()` example
- keep compatibility wording explicit: standalone non-unit `main` may still run, but the CLI gives its completion value no default host meaning

## Linked discussion

- https://github.com/spore-lang/spore/pull/102

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

- this is a wording-sync PR for an existing draft, not a new language-surface proposal
- the companion implementation change lives in `spore#102`, which removes default completion-value printing from `spore run`
