### PR TITLE
🐛 fix: enforce current capability terminology (P0 term consistency)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -4,7 +4,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 ## A
 
-**Atomic capability** (SEP-0003): One of the 11 indivisible capabilities in Spore's effect system: Compute, FileRead, FileWrite, NetRead, NetWrite, StateRead, StateWrite, Spawn, Clock, Random, Exit.
+**Atomic capability** (SEP-0003): One of the 10 built-in intent-oriented atomic effects in Spore's effect system: Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit. In compiler/tooling contexts, these effect names make up the checked capability set.
 
 **`Add`** (SEP-0002): Compiler-known trait for the `+` operator, enabling operator overloading on user-defined types.
 
@@ -22,13 +22,11 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **Capability** (SEP-0003): A named permission that a function must hold to perform certain effects. Also serves as a trait on execution context (SEP-0002).
 
-**Capability ceiling** (SEP-0003): The maximum set of capabilities available in a module, declared via `uses [...]` at module level.
+**Capability ceiling** (SEP-0003, SEP-0008): The maximum set of capabilities available to a scope. Function-level `uses [...]` clauses are standardized today; broader module/project ceilings remain reserved follow-up design space.
 
 **Capability narrowing** (SEP-0003): Restricting the available capability set when entering a nested scope, ensuring inner code cannot exceed outer permissions.
 
 **Capability set (CapSet)** (SEP-0003): An unordered collection of capabilities associated with a function or scope, written as `uses [Cap1, Cap2]`.
-
-**Capability alias** (SEP-0003): A named shorthand for a set of capabilities, e.g., `capability FileIO = [FileRead, FileWrite]`.
 
 **`Clone`** (SEP-0002): Compiler-known trait for explicitly duplicating a value.
 
@@ -71,6 +69,8 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 **`Eq`** (SEP-0002): Compiler-known trait for structural equality comparison.
 
 **Effect** (SEP-0003): An observable interaction with the outside world (I/O, mutation, randomness), tracked via the capability system.
+
+**Effect alias** (SEP-0003): A named shorthand for a set of atomic effects, written as `effect FileIO = FileRead | FileWrite`.
 
 **Effect handler** (SEP-0008): Platform-provided implementation of a capability's operations, connecting `foreign fn` declarations to native code.
 

--- a/prek.toml
+++ b/prek.toml
@@ -60,6 +60,7 @@ hooks = [
 [[repos]]
 repo = "local"
 hooks = [
+  { id = "terminology-consistency", name = "terminology-consistency", entry = "uv run scripts/check_terminology_consistency.py", language = "system", files = "^(GLOSSARY\\.md|seps/SEP-000[3468]-.*\\.md)$", pass_filenames = false },
   { id = "sep-index", name = "sep-index", entry = "uv run scripts/check_sep_index.py", language = "system", files = "^(drafts|seps)/.*\\.md$|^seps-index\\.json$", pass_filenames = false },
   { id = "sep-documents", name = "sep-documents", entry = "uv run scripts/validate_sep_documents.py", language = "system", files = "^(drafts|seps)/.*\\.md$", pass_filenames = true },
 ]

--- a/scripts/check_terminology_consistency.py
+++ b/scripts/check_terminology_consistency.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env -S uv run
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from sep_common import ROOT
+
+TARGETS = (
+    ROOT / "GLOSSARY.md",
+    ROOT / "seps" / "SEP-0003-effect-capability-system.md",
+    ROOT / "seps" / "SEP-0004-cost-analysis.md",
+    ROOT / "seps" / "SEP-0006-compiler-architecture.md",
+    ROOT / "seps" / "SEP-0008-module-package-system.md",
+)
+
+FORBIDDEN_PATTERNS = (
+    (
+        re.compile(r"\bNetRead\b"),
+        "retired term `NetRead`; use `NetConnect` or `NetListen` depending on intent",
+    ),
+    (
+        re.compile(r"\bNetWrite\b"),
+        "retired term `NetWrite`; use `NetConnect` or `NetListen` depending on intent",
+    ),
+    (
+        re.compile(r"\bStateRead\b"),
+        "retired term `StateRead`; mutable state is no longer a built-in external capability",
+    ),
+    (
+        re.compile(r"\bStateWrite\b"),
+        "retired term `StateWrite`; mutable state is no longer a built-in external capability",
+    ),
+    (
+        re.compile(r"cost\s*<="),
+        "retired ASCII syntax `cost <=`; use `cost ≤`",
+    ),
+)
+
+ALLOWED_LINE_SNIPPETS = {
+    ROOT / "seps" / "SEP-0003-effect-capability-system.md": (
+        "No `StateRead`/`StateWrite`.",
+        "`NetConnect`/`NetListen` instead of `NetRead`/`NetWrite`.",
+    ),
+}
+
+
+def main() -> int:
+    violations: list[str] = []
+
+    for path in TARGETS:
+        text = path.read_text(encoding="utf-8")
+        allowed_snippets = ALLOWED_LINE_SNIPPETS.get(path, ())
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if any(snippet in line for snippet in allowed_snippets):
+                continue
+
+            for pattern, message in FORBIDDEN_PATTERNS:
+                if pattern.search(line):
+                    violations.append(
+                        f"{path.relative_to(ROOT)}:{line_number}: {message}\n    {line}"
+                    )
+
+    if violations:
+        print("Terminology consistency check failed:\n", file=sys.stderr)
+        for violation in violations:
+            print(f"- {violation}", file=sys.stderr)
+        return 1
+
+    print("Terminology consistency check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -1055,7 +1055,7 @@ WARNING [unbounded-cost] fibonacci's cost cannot be statically determined.
 
 ### Cross-validation with capabilities
 
-The cost system and capability system form a cross-validation network. If a function declares `uses []` (pure, no capabilities) but cost analysis discovers W > 0 (I/O operations), the compiler emits `cost-capability-conflict`. Conversely, a function declared `uses [NetRead]` must have W ≥ 1 in at least one code path.
+The cost system and capability system form a cross-validation network. If a function declares `uses []` (pure, no capabilities) but cost analysis discovers W > 0 (I/O operations), the compiler emits `cost-capability-conflict`. Conversely, a function declared `uses [NetConnect]` must have W ≥ 1 in at least one code path.
 
 ---
 

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -1360,11 +1360,11 @@ error[C0101]: undeclared capability
   --> src/report.sp:27:5
    |
 27 |     http.get(endpoint)
-   |     ^^^^^^^^^^^^^^^^^^ requires `NetRead`, not declared in `uses`
+   |     ^^^^^^^^^^^^^^^^^^ requires `NetConnect`, not declared in `uses`
    |
    = note: enclosing function `fetch_data` has `uses []`
-   = note: module ceiling for `report` allows [Compute, FileRead]
-help: add a `uses [NetRead]` clause to `fetch_data`
+   = note: module ceiling for `report` allows [FileRead]
+help: add a `uses [NetConnect]` clause to `fetch_data`
 ```
 
 **Cost violation:**


### PR DESCRIPTION
## Proposal summary

- Correct deprecated capability names in `GLOSSARY.md` (`NetRead`/`NetWrite` → `NetConnect`, etc.)
- Add `scripts/check_terminology_consistency.py` to automatically flag stale capability names
- Wire the script into `prek.toml` pre-commit checks for ongoing enforcement

## Linked discussion

No SEP required — this is a terminology/docs fix, not a language proposal.

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

SEP-0008 conflict was resolved by keeping origin/main's version (it already incorporated the NetConnect terminology through a separate, more comprehensive rewrite). Our change adds the GLOSSARY correction and enforcement script on top.