### PR TITLE
📝 docs: align SEP terminology around the effect system

### DIFF
--- a/.github/styles/Google/WordList.yml
+++ b/.github/styles/Google/WordList.yml
@@ -51,7 +51,7 @@ swap:
   fewer data: less data
   file name: filename
   firewalls: firewall rules
-  functionality: capability|feature
+  functionality: feature
   Google account: Google Account
   Google accounts: Google Accounts
   Googling: search with Google

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -4,7 +4,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 ## A
 
-**Atomic capability** (SEP-0003): One of the 10 built-in intent-oriented atomic effects in Spore's effect system: Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit. In compiler/tooling contexts, these effect names make up the checked capability set.
+**Atomic effect** (SEP-0003): One of the 10 built-in intent-oriented atomic effects in Spore's effect system: Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit. In compiler/tooling contexts, these effect names form the checked effect set.
 
 **`Add`** (SEP-0002): Compiler-known trait for the `+` operator, enabling operator overloading on user-defined types.
 
@@ -20,13 +20,13 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 ## C
 
-**Capability** (SEP-0003): A named permission that a function must hold to perform certain effects. Also serves as a trait on execution context (SEP-0002).
+**Declared effects** (SEP-0003): The effect names explicitly written on a function, module, or manifest surface.
 
-**Capability ceiling** (SEP-0003, SEP-0008): The maximum set of capabilities available to a scope. Function-level `uses [...]` clauses are standardized today; broader module/project ceilings remain reserved follow-up design space.
+**Effect ceiling** (SEP-0003, SEP-0008): The maximum set of effects available to a scope. Function-level `uses [...]` clauses are standardized today; broader module/project ceilings remain reserved follow-up design space.
 
-**Capability narrowing** (SEP-0003): Restricting the available capability set when entering a nested scope, ensuring inner code cannot exceed outer permissions.
+**Effect narrowing** (SEP-0003): Restricting the available effect set when entering a nested scope, ensuring inner code cannot exceed outer permissions.
 
-**Capability set (CapSet)** (SEP-0003): An unordered collection of capabilities associated with a function or scope, written as `uses [Cap1, Cap2]`.
+**Effect set (EffectSet)** (SEP-0003): An unordered collection of effects associated with a function or scope, written as `uses [Effect1, Effect2]`.
 
 **`Clone`** (SEP-0002): Compiler-known trait for explicitly duplicating a value.
 
@@ -56,7 +56,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **`Div`** (SEP-0002): Compiler-known trait for the `/` operator, enabling operator overloading on user-defined types.
 
-**Diagnostic code** (SEP-0006): Structured error/warning identifier in the format `X0NNN`, where X is a category letter: E (type error), C (capability), K (cost), M (module), W (warning).
+**Diagnostic code** (SEP-0006): Structured error/warning identifier in the format `X0NNN`, where X is a category letter: E (type error), C (effect), K (cost), M (module), W (warning).
 
 **Default entry** (SEP-0008): The manifest-selected entry used when project commands omit an explicit entry name.
 
@@ -68,11 +68,11 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **`Eq`** (SEP-0002): Compiler-known trait for structural equality comparison.
 
-**Effect** (SEP-0003): An observable interaction with the outside world (I/O, mutation, randomness), tracked via the capability system.
+**Effect** (SEP-0003): An observable interaction with the outside world (I/O, mutation, randomness), tracked via the effect system.
 
 **Effect alias** (SEP-0003): A named shorthand for a set of atomic effects, written as `effect FileIO = FileRead | FileWrite`.
 
-**Effect handler** (SEP-0008): Platform-provided implementation of a capability's operations, connecting `foreign fn` declarations to native code.
+**Effect handler** (SEP-0008): Platform-provided implementation of an effect's operations, connecting `foreign fn` declarations to native code.
 
 **Enum** (SEP-0002): Algebraic data type with named variants, each optionally carrying data. Defined with `type Name { Variant1(T), Variant2 }`.
 
@@ -88,11 +88,11 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **`Hash`** (SEP-0002): Compiler-known trait for computing hash values, often required alongside `Eq` for use in hash-based collections.
 
-**Hole** (SEP-0005): A typed placeholder in source code written as `?name`, representing incomplete code that carries type, capability, and cost context for agent-assisted completion.
+**Hole** (SEP-0005): A typed placeholder in source code written as `?name`, representing incomplete code that carries type, effect, and cost context for agent-assisted completion.
 
-**Hole context** (SEP-0005): The full type environment, capability set, cost budget, and dependency information associated with a typed hole.
+**Hole context** (SEP-0005): The full type environment, effect set, cost budget, and dependency information associated with a typed hole.
 
-**Hole Dependency Graph** (SEP-0005): DAG ordering typed holes by data-flow, type, capability, and cost dependencies for parallel fill scheduling.
+**Hole Dependency Graph** (SEP-0005): DAG ordering typed holes by data-flow, type, effect, and cost dependencies for parallel fill scheduling.
 
 **Hole state machine** (SEP-0005): Lifecycle of a hole: Open → Filling → Filled → Accepted.
 
@@ -110,7 +110,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **`Mul`** (SEP-0002): Compiler-known trait for the `*` operator, enabling operator overloading on user-defined types.
 
-**Module** (SEP-0008): A single Spore source file that declares its own visibility boundaries and capability requirements.
+**Module** (SEP-0008): A single Spore source file that declares its own visibility boundaries and effect requirements.
 
 ## N
 
@@ -146,9 +146,9 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **SEP (Spore Enhancement Proposal)** (SEP-0000): A design document proposing a change or addition to Spore, following a structured review process.
 
-**Signature hash (sig hash)** (SEP-0006): Content hash of a function's public interface (name, params, return type, capabilities), used for dependency tracking — a change in sig hash invalidates all callers.
+**Signature hash (sig hash)** (SEP-0006): Content hash of a function's public interface (name, params, return type, required effects), used for dependency tracking — a change in sig hash invalidates all callers.
 
-**`spawn`** (SEP-0007): Expression that creates a new `Task[T]` for concurrent execution, requiring the `Spawn` capability.
+**`spawn`** (SEP-0007): Expression that creates a new `Task[T]` for concurrent execution, requiring the `Spawn` effect.
 
 **`Sub`** (SEP-0002): Compiler-known trait for the `-` operator, enabling operator overloading on user-defined types.
 
@@ -172,7 +172,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 ## U
 
-**`uses` clause** (SEP-0003): Annotation on a function or module declaring required capabilities, written as `uses [Cap1, Cap2]`.
+**`uses` clause** (SEP-0003): Annotation on a function or module declaring required effects, written as `uses [Effect1, Effect2]`.
 
 ## V
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,12 +27,12 @@ Design basis: [SEP-0002](seps/SEP-0002-type-system.md)
 - L1 abstract interpretation propagation (value flow analysis, no SMT)
 - Property-based test generation from refinement predicates
 
-## Capability and effect system
+## Effect system
 
-Design basis: [SEP-0003](seps/SEP-0003-effect-capability-system.md)
+Design basis: [SEP-0003](seps/SEP-0003-effect-system.md)
 
 - Platform effect handler dispatch (runtime)
-- Capability hierarchy formalization (lattice properties)
+- Effect hierarchy formalization (lattice properties)
 - Reference CLI platform: filesystem, network, process, clock, random
 - Reference web platform: HTTP server, request/response
 
@@ -90,7 +90,7 @@ Design basis: [SEP-0006](seps/SEP-0006-compiler-architecture.md)
 
 These are not committed but may influence future design:
 
-- Distributed capability delegation with cryptographic attestation
+- Distributed effect delegation with cryptographic attestation
 - Optional formal verification mode for safety-critical paths
 - Visual hole explorer for interactive dependency graph navigation
-- Cross-platform compilation: WASM, embedded, GPU via capability-gated backends
+- Cross-platform compilation: WASM, embedded, GPU via effect-gated backends

--- a/VISION.md
+++ b/VISION.md
@@ -6,7 +6,7 @@ Spore is a compiled, general-purpose programming language where **intent is a fi
 
 ### 1. Signatures are gravity centers
 
-A function signature is a complete specification: input/output types, error sets, cost budget, and required capabilities. All downstream analysis flows from the signature. The body can be empty — the intent is already fully expressed.
+A function signature is a complete specification: input/output types, error sets, cost budget, and required effects. All downstream analysis flows from the signature. The body can be empty — the intent is already fully expressed.
 
 ### 2. Holes are collaboration points, not errors
 
@@ -20,9 +20,9 @@ The recommended workflow is top-down: define signatures and types, verify the sk
 
 Every compiler output — diagnostics, hole reports, incremental events, dependency graphs — is available in both human-readable and machine-readable form. Humans see clear error messages with repair hints; Agents see structured JSON suitable for automated reasoning.
 
-### 5. Explicit capability and cost models
+### 5. Explicit effect and cost models
 
-Every side effect requires a declared capability. Every computational cost can be bounded and verified at compile time. A function's impact is fully assessable from its signature alone.
+Every side effect must be covered by declared effects. Every computational cost can be bounded and verified at compile time. A function's impact is fully assessable from its signature alone.
 
 ### 6. Content-addressed, not version-numbered
 

--- a/drafts/script-mode.md
+++ b/drafts/script-mode.md
@@ -145,7 +145,7 @@ This is also **proposed CLI surface**, not current shipped behavior. In the
 current implementation, project mode is only reached when the explicit file path
 passed to `spore run` resolves to a manifest-backed entry under `src/`. When
 that happens, the selected entry must satisfy both the Platform startup
-signature and the selected Platform package's `[platform].handles` capability
+signature and the selected Platform package's `[platform].handled-effects` effect
 contract.
 
 ### Future example: passing script or entry arguments
@@ -437,7 +437,7 @@ project-backed entry resolution.
   - show the value of copyable, low-ceremony scripts
 
 Spore differs by combining these ideas with a stronger project model,
-capability-gated Platform execution, and agent-oriented reproducibility.
+effect-gated Platform execution, and agent-oriented reproducibility.
 
 ## Backward compatibility and migration
 

--- a/scripts/check_terminology_consistency.py
+++ b/scripts/check_terminology_consistency.py
@@ -10,7 +10,7 @@ from sep_common import ROOT
 
 TARGETS = (
     ROOT / "GLOSSARY.md",
-    ROOT / "seps" / "SEP-0003-effect-capability-system.md",
+    ROOT / "seps" / "SEP-0003-effect-system.md",
     ROOT / "seps" / "SEP-0004-cost-analysis.md",
     ROOT / "seps" / "SEP-0006-compiler-architecture.md",
     ROOT / "seps" / "SEP-0008-module-package-system.md",
@@ -27,11 +27,11 @@ FORBIDDEN_PATTERNS = (
     ),
     (
         re.compile(r"\bStateRead\b"),
-        "retired term `StateRead`; mutable state is no longer a built-in external capability",
+        "retired term `StateRead`; mutable state is no longer a built-in external effect",
     ),
     (
         re.compile(r"\bStateWrite\b"),
-        "retired term `StateWrite`; mutable state is no longer a built-in external capability",
+        "retired term `StateWrite`; mutable state is no longer a built-in external effect",
     ),
     (
         re.compile(r"cost\s*<="),
@@ -40,7 +40,7 @@ FORBIDDEN_PATTERNS = (
 )
 
 ALLOWED_LINE_SNIPPETS = {
-    ROOT / "seps" / "SEP-0003-effect-capability-system.md": (
+    ROOT / "seps" / "SEP-0003-effect-system.md": (
         "No `StateRead`/`StateWrite`.",
         "`NetConnect`/`NetListen` instead of `NetRead`/`NetWrite`.",
     ),

--- a/seps-index.json
+++ b/seps-index.json
@@ -49,7 +49,7 @@
       "superseded_by": null
     },
     {
-      "path": "seps/SEP-0003-effect-capability-system.md",
+      "path": "seps/SEP-0003-effect-system.md",
       "sep": 3,
       "title": "SEP-0003: Effect System",
       "status": "Draft",

--- a/seps/SEP-0000-process.md
+++ b/seps/SEP-0000-process.md
@@ -29,7 +29,7 @@ Spore is attempting to design a language and toolchain around a fairly ambitious
 - intent-first APIs
 - structured collaboration between humans and Agents
 - holes as first-class collaboration points
-- explicit capability and cost models
+- explicit effect and cost models
 - machine-readable diagnostics and language protocols
 
 These changes have broad, long-term consequences. Normal implementation pull requests are not enough to capture:
@@ -78,7 +78,7 @@ An SEP is expected for substantial changes to any of the following:
 
 - language syntax
 - language semantics or typing rules
-- module, package, content-addressing, effect, capability, or cost systems
+- module, package, content-addressing, effect, or cost systems
 - standard library or core tooling surface
 - compiler output and machine-readable protocol design
 - hole protocol, diagnostics protocol, or other human/Agent interface contracts

--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -324,7 +324,7 @@ The full signature order is:
 ```text
 fn name[T](params) -> ReturnType ! ErrorSet
 where T: Bound
-uses [effects]
+uses [Effect1, Effect2]
 cost ≤ N
 spec {
     example "...": ...
@@ -1358,7 +1358,7 @@ At minimum, the shared hole object includes:
 - `expected_type` / `type_inferred_from`
 - `function` / `enclosing_signature`
 - `bindings` / `binding_dependencies`
-- `capabilities`, `errors_to_handle`, `cost_budget`
+- `effects`, `errors_to_handle`, `cost_budget`
 - `candidates`, `dependent_holes`, `confidence`, `error_clusters`
 
 When a function has both a `spec` block and a hole body, that shared hole object may surface the `spec` items as additional behavioral context for tooling. The authoritative transport and evolution rules remain in SEP-0005 so SEP-0001 does not accidentally freeze a stale field layout.
@@ -1936,7 +1936,7 @@ As this is the initial v0.1 specification, there are no backward compatibility c
 
 12. **Error type subtyping**: If function `f` declares `! NetworkError` and function `g` declares `! NetworkError | ParseError`, can `g` call `f` directly? How does error set subtyping work?
 
-13. **`property` with `uses`**: If a property calls a function that has side effects, what capability scope applies? Current proposal: property items inherit the enclosing function's `uses` set.
+13. **`property` with `uses`**: If a property calls a function that has side effects, what effect scope applies? Current proposal: property items inherit the enclosing function's `uses` set.
 
 14. **Future trait-level behavioral contracts**: Should a later SEP allow `spec` blocks on trait methods, and if so how should implementations inherit or refine them? This amendment leaves trait-level `spec` syntax and semantics unspecified.
 

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -28,7 +28,7 @@ Ty ::= Int | Float | Bool | Str | Char | Unit | Never
       | Named(name)
       | App(name, [Ty])
       | Record([(name, Ty)])
-      | Fn([Ty], Ty, CapSet)
+      | Fn([Ty], Ty, EffectSet)
       | Var(u32)
       | Hole(name)
       | Error
@@ -37,7 +37,7 @@ Ty ::= Int | Float | Bool | Str | Char | Unit | Never
 Key design decisions:
 
 - **Signatures are gravity centers** — function signatures must be richly typed and fully explicit; bodies are inferred.
-- **CapSet = BTreeSet\<String\>** is encoded directly in function types, making effect tracking a first-class part of the type.
+- **EffectSet = BTreeSet\<String\>** is encoded directly in function types, making effect tracking a first-class part of the type.
 - **Bidirectional type inference** — top-down checking from signatures, bottom-up synthesis from expressions.
 - **Two-pass module checking** — `register_item` (collect all signatures) then `check_fn` (verify bodies).
 - **Generics via square-bracket application** — `List[Int]`, `Result[T, E]`.
@@ -205,7 +205,7 @@ summarize(data: { count: named.count, total: named.total })   // OK
 
 ### 3.5 Function types with effects
 
-Function types carry a **CapSet** — the set of effects the function requires:
+Function types carry a **EffectSet** — the set of effects the function requires:
 
 ```spore
 type Logger = Fn(msg: String) -> () uses [FileWrite]
@@ -998,7 +998,7 @@ Where:
 
 - `n` ranges over identifiers (strings).
 - `id` ranges over `u32` (unique unification variable IDs).
-- `C` is a **CapSet** = `BTreeSet<String>`, the set of effect names the function requires.
+- `C` is a **EffectSet** = `BTreeSet<String>`, the set of effect names the function requires.
 - `f` ranges over field names (strings) in anonymous records.
 
 **Never type.** `Ty::Never` is the bottom type — a subtype of all types. It is produced by diverging expressions (`panic`, non-terminating recursion). During unification, `unify(τ, Never) = ok` for all `τ`.
@@ -1009,24 +1009,24 @@ Where:
 
 **Hole type.** `Ty::Hole(name)` represents an unfilled hole. During unification, holes are compatible with anything — the checker records the expected type for diagnostic purposes without blocking further checking.
 
-### 4.2 Effect sets (CapSet)
+### 4.2 Effect sets (EffectSet)
 
 ```rust
-pub type CapSet = BTreeSet<String>;
+pub type EffectSet = BTreeSet<String>;
 ```
 
-A `CapSet` is a sorted set of effect names. It appears as the third component of `Ty::Fn`:
+A `EffectSet` is a sorted set of effect names. It appears as the third component of `Ty::Fn`:
 
 ```text
 Fn([τ₁, …, τₙ], τᵣ, { cap₁, cap₂, … })
 ```
 
-**CapSet rules:**
+**EffectSet rules:**
 
-1. A function may only call another function whose CapSet is a **subset** of its own.
-2. A pure function has `CapSet = ∅`.
-3. CapSets propagate through higher-order calls: passing a `Fn(...) uses [NetConnect]` to a higher-order function requires the caller to declare `NetConnect`.
-4. `uses [Cap1, Cap2]` in source syntax maps directly to `CapSet = {"Cap1", "Cap2"}`.
+1. A function may only call another function whose EffectSet is a **subset** of its own.
+2. A pure function has `EffectSet = ∅`.
+3. EffectSets propagate through higher-order calls: passing a `Fn(...) uses [NetConnect]` to a higher-order function requires the caller to declare `NetConnect`.
+4. `uses [Effect1, Effect2]` in source syntax maps directly to `EffectSet = {"Effect1", "Effect2"}`.
 
 **Formal effect checking rule:**
 
@@ -1297,7 +1297,7 @@ apply_subst(Record(fields))       = Record([(f, apply_subst(τ)) for (f, τ) in 
 apply_subst(τ)                    = τ                  for all other τ
 ```
 
-Note that `CapSet` is **not** subject to substitution — effects are always concrete strings, never type variables.
+Note that `EffectSet` is **not** subject to substitution — effects are always concrete strings, never type variables.
 
 #### Unification algorithm
 
@@ -1346,14 +1346,14 @@ pub fn check_module(&mut self, module: &Module) {
 
 **Pass 1 — `register_item`:** Iterates over all top-level items (functions, structs, type definitions) and registers their signatures in the `TypeRegistry`:
 
-- **Functions:** Parameter types are resolved, return type is resolved (default `Unit`), CapSet is extracted from `uses` clause, and type parameters from `where` clause are recorded.
+- **Functions:** Parameter types are resolved, return type is resolved (default `Unit`), EffectSet is extracted from `uses` clause, and type parameters from `where` clause are recorded.
 - **Structs:** Field names and types are resolved and stored.
 - **Type defs (enums):** Variant names and field types are resolved and stored.
 - **Effects and imports:** Deferred (no registration needed).
 
 **Pass 2 — `check_fn`:** For each function with a body:
 
-1. Set the current CapSet from the function's `uses` clause.
+1. Set the current EffectSet from the function's `uses` clause.
 2. Push a new scope in the environment.
 3. Bind each parameter to its declared type.
 4. Synthesize the body type via `check_expr`.
@@ -1415,7 +1415,7 @@ Record(fields₁) <: Record(fields₂)
 
 ### 4.8 Function types
 
-Function types are `Ty::Fn(params, ret, CapSet)`:
+Function types are `Ty::Fn(params, ret, EffectSet)`:
 
 ```text
 Fn([σ₁, …, σₙ], τᵣ, C)
@@ -1561,7 +1561,7 @@ Traits are registered in a `TraitRegistry` alongside the `TypeRegistry`. Each tr
 
 - Trait name
 - Supertrait requirements (e.g., `Ord: Eq`)
-- Method signatures (name, parameter types, return type, CapSet)
+- Method signatures (name, parameter types, return type, EffectSet)
 - Associated type declarations
 - Default method implementations (if any)
 
@@ -1713,7 +1713,7 @@ Rich type signatures give Agents strong guidance for code generation:
 
 - Parameter types constrain what values are available.
 - Return types constrain what the body must produce.
-- CapSet constrains which side-effectful functions may be called.
+- EffectSet constrains which side-effectful functions may be called.
 - Hole types (`Ty::Hole`) tell the Agent exactly what type to produce.
 
 ### Structured type information
@@ -1760,7 +1760,7 @@ All types implement `Display` with a canonical format:
 
 ### Snapshot hashes
 
-Function signatures (parameter types, return type, error set, CapSet, cost bound, generic constraints) are included in snapshot hashes. Body changes and `@allows` annotations are excluded. This ensures:
+Function signatures (parameter types, return type, error set, EffectSet, cost bound, generic constraints) are included in snapshot hashes. Body changes and `@allows` annotations are excluded. This ensures:
 
 - API-breaking changes require explicit `--permit`.
 - Implementation refactoring does not break downstream consumers.
@@ -1823,7 +1823,7 @@ Hole ?h1 in function `example`:
 
 1. **Nominal rigidity.** The nominal-primary design means newtypes require explicit wrap/unwrap. This adds verbosity for simple delegation patterns. Anonymous records provide a structural escape hatch, but they cannot implement traits.
 
-2. **CapSet as BTreeSet\<String\>.** String-based effect names lack static verification at the `Ty` level — a misspelled effect name is only caught when matching against registered effects, not during type construction.
+2. **EffectSet as BTreeSet\<String\>.** String-based effect names lack static verification at the `Ty` level — a misspelled effect name is only caught when matching against registered effects, not during type construction.
 
 3. **No higher-kinded types.** GATs + associated types cover most use cases, but abstracting over container kinds generically (functor-map over any container) requires either code generation or per-container implementations.
 
@@ -1882,7 +1882,7 @@ Hole ?h1 in function `example`:
 
 ### Alternative 6: Row-polymorphic effect sets
 
-**Considered for future.** Making CapSets row-polymorphic would allow:
+**Considered for future.** Making EffectSets row-polymorphic would allow:
 
 ```spore
 fn apply[C](f: Fn(x: Int) -> Int uses C, x: Int) -> Int uses C
@@ -1941,7 +1941,7 @@ Since this is the first formal type system specification (v0.1 → SEP), there i
 
 1. **Ty enum stability.** The variants `Int`, `Float`, `Bool`, `Str`, `Char`, `Unit`, `Never`, `Named`, `App`, `Record`, `Fn`, `Var`, `Hole`, `Error` are stable. New variants may be added but existing variants will not be removed or renamed without a new SEP.
 
-2. **CapSet representation.** `BTreeSet<String>` is the current representation. Future SEPs may introduce effect variables for row-polymorphic effects, but the concrete string-based API will remain supported.
+2. **EffectSet representation.** `BTreeSet<String>` is the current representation. Future SEPs may introduce effect variables for row-polymorphic effects, but the concrete string-based API will remain supported.
 
 3. **Two-pass checking.** The `register_item` → `check_fn` architecture is stable. Future passes (e.g., trait resolution, cost checking) will be added after these two, not replace them.
 
@@ -1953,11 +1953,11 @@ Since this is the first formal type system specification (v0.1 → SEP), there i
 |---|---|
 | Refinement types (L0) | Add `Ty::Refined(Box<Ty>, Predicate)` variant; extend `resolve_type` |
 | Const generics | Add `Ty::Const(value)` variant; extend `App` to accept const args |
-| Row-polymorphic effects | Extend CapSet with effect variables alongside concrete strings |
+| Row-polymorphic effects | Extend EffectSet with effect variables alongside concrete strings |
 
 ## Unresolved questions
 
-1. **CapSet in unification.** Currently, function type unification ignores CapSets (the `_` in `Fn(p1, r1, _), Fn(p2, r2, _)`). Should CapSets participate in unification, or remain checked separately? Separate checking is simpler but could miss effect mismatches in higher-order function arguments.
+1. **EffectSet in unification.** Currently, function type unification ignores EffectSets (the `_` in `Fn(p1, r1, _), Fn(p2, r2, _)`). Should EffectSets participate in unification, or remain checked separately? Separate checking is simpler but could miss effect mismatches in higher-order function arguments.
 
 2. **Generic syntax: square brackets vs angle brackets.** The implemented `Ty::App` uses parenthesized syntax in the AST (`List[Int]`), but some spec examples use angle brackets (`List<T>`). This SEP uses square brackets as the intended syntax; a separate SEP should finalize the concrete syntax.
 
@@ -1980,4 +1980,4 @@ The following questions from earlier drafts are now resolved by this specificati
 
 2. **Never type semantics.** ✅ Resolved — `unify(τ, Never) = ok` for all `τ` (§4.16). Never is handled as a bottom type directly within the unifier.
 
-3. **Error type representation.** ✅ Resolved — error sets are a component of `Ty::Fn`, making it `Fn(params, ret, CapSet, ErrorSet)` (§4.15). Error set unions are computed during `?` propagation.
+3. **Error type representation.** ✅ Resolved — error sets are a component of `Ty::Fn`, making it `Fn(params, ret, EffectSet, ErrorSet)` (§4.15). Error set unions are computed during `?` propagation.

--- a/seps/SEP-0003-effect-system.md
+++ b/seps/SEP-0003-effect-system.md
@@ -15,13 +15,13 @@ superseded_by: null
 
 # SEP-0003: Effect System
 
-> **Executive Summary**: Defines Spore's effect system as a flat capability-set model with 10 built-in intent-oriented atomic effects (Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit) plus user-defined effects. The canonical surface syntax uses explicit `effect` declarations, `perform Effect.op(...)`, top-level `handler`, and `handle { ... } with { ... }`, while semantic checking remains a subset test over capability sets. Concrete grammar is centralized in SEP-0001; this SEP specifies effect algebra, handler semantics, narrowing rules, and diagnostics.
+> **Executive Summary**: Defines Spore's effect system as a flat effect-set model with 10 built-in intent-oriented atomic effects (Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit) plus user-defined effects. The canonical surface syntax uses explicit `effect` declarations, `perform Effect.op(...)`, top-level `handler`, and `handle { ... } with { ... }`, while semantic checking remains a subset test over effect sets. Concrete grammar is centralized in SEP-0001; this SEP specifies effect algebra, handler semantics, narrowing rules, and diagnostics.
 
 ## Summary
 
 This SEP introduces Spore's **effect system**: a compile-time mechanism that tracks how functions interact with the outside world. Every function declares — via a `uses [...]` clause — the set of *atomic effects* it requires. The compiler verifies that a function body never exercises an effect absent from its declared set, auto-infers semantic properties (pure, deterministic, total) from that set, and uses set-inclusion as the basis for subtyping and effect narrowing.
 
-The built-in effect vocabulary is **intent-oriented**: each built-in effect answers "What does this code intend to do with the outside world?" Pure computation is the default state — no effect declaration is needed for it. Mutable state is tracked by the language semantics, not by built-in external effect names. In compiler internals and tooling protocols, these effect names form the capability set used for subset checks, platform ceilings, and machine-readable fields such as `capabilities`.
+The built-in effect vocabulary is **intent-oriented**: each built-in effect answers "What does this code intend to do with the outside world?" Pure computation is the default state — no effect declaration is needed for it. Mutable state is tracked by the language semantics, not by built-in external effect names. In compiler internals and tooling protocols, these effect names form the effect set used for subset checks, platform ceilings, and machine-readable fields such as `effects`.
 
 The design is intentionally **flat and monomorphic**: effect sets are finite sets of atomic identifiers with no effect variables, no row types, and no effect polymorphism. Named aliases (`effect X = A | B`) provide ergonomics without adding expressiveness. Higher-order functions such as `map` accept only pure (`uses []`) closures; effectful iteration is expressed through `parallel_scope` + `spawn`.
 
@@ -54,7 +54,7 @@ Modern programs interleave pure computation with diverse side effects — file I
 | Composable aliases | `effect` keyword for named groups and aliases |
 | Sound subtyping | Set inclusion on effect sets |
 | Auto-inferred properties | `pure`, `deterministic`, `total` derived from `uses` |
-| Agent integration | Capability set emitted in `HoleReport` JSON |
+| Agent integration | `available_effects` emitted in `HoleReport` JSON |
 
 ---
 
@@ -268,7 +268,7 @@ fn save_data(data: Data) -> Unit {
 ```
 
 ```text
-error[cap-violation]: function body uses undeclared effect
+error[effect-violation]: function body uses undeclared effect
   --> src/storage.sp:1:1
    |
  1 | fn save_data(data: Data) -> Unit {
@@ -319,13 +319,13 @@ A representative machine-readable view is:
     {
       "name": "validate",
       "type_match": 1.0,
-      "capability_fit": 1.0,
+      "required_effects_fit": 1.0,
       "overall": 1.0
     },
     {
       "name": "sanitize",
       "type_match": 1.0,
-      "capability_fit": 1.0,
+      "required_effects_fit": 1.0,
       "overall": 1.0
     }
   ]
@@ -415,7 +415,7 @@ builtin hierarchy.
 
 The canonical checked path for `perform` is:
 
-1. the current capability set must contain the named effect after alias
+1. the current effect set must contain the named effect after alias
    expansion, and
 2. the effect name must resolve to a declared effect/interface with a known
    operation signature.
@@ -428,7 +428,7 @@ module boundaries, so cross-module `perform Effect.op(...)` is typechecked
 against the imported signature rather than against an untyped name stub.
 Ambiguous imported same-name effects with different signatures are rejected.
 
-### 4. Function types and CapSet encoding
+### 4. Function types and EffectSet encoding
 
 #### 4.1 Complete function type
 
@@ -440,7 +440,7 @@ where:
 
 - `T₁ … Tₙ` — parameter types
 - `R` — return type
-- `S` — effect set (CapSet)
+- `S` — effect set (EffectSet)
 - `[E₁ …]` — error type set
 
 #### 4.2 Internal representation
@@ -448,10 +448,10 @@ where:
 In the compiler's type IR the function type is represented as:
 
 ```rust
-Ty::Fn(Vec<Ty>, Box<Ty>, CapSet)
+Ty::Fn(Vec<Ty>, Box<Ty>, EffectSet)
 ```
 
-where `CapSet = BTreeSet<String>`. A `BTreeSet` is chosen over `HashSet` for deterministic ordering in diagnostics and serialisation.
+where `EffectSet = BTreeSet<String>`. A `BTreeSet` is chosen over `HashSet` for deterministic ordering in diagnostics and serialisation.
 
 #### 4.3 Shorthand
 
@@ -618,7 +618,7 @@ The compiler performs effect checking during type-checking as a single pass:
 
 $$S_{\text{body}} \subseteq S_{\text{declared}}$$
 
-If the check fails, the compiler emits a `cap-violation` diagnostic listing the excess effects.
+If the check fails, the compiler emits a `effect-violation` diagnostic listing the excess effects.
 
 4. **Closure inference.** For closures, the compiler infers the minimal effect set from the closure body. This inferred set is used for subtype checking when the closure is passed to a higher-order function.
 
@@ -642,7 +642,7 @@ uses [FileRead, NetConnect]
 
 ### 11. Interaction with the Hole system
 
-When the compiler encounters a Hole (`?name`), the shared SEP-0005 hole object includes the capability set available at that program point under the field name `capabilities`:
+When the compiler encounters a Hole (`?name`), the shared SEP-0005 hole object includes the effect set available at that program point under the field name `available_effects`:
 
 ```json
 {
@@ -653,7 +653,7 @@ When the compiler encounters a Hole (`?name`), the shared SEP-0005 hole object i
     "url": "Url",
     "timeout": "Duration"
   },
-  "capabilities": ["NetConnect"],
+  "effects": ["NetConnect"],
   "cost_budget": {
     "budget_total": 5000,
     "cost_before_hole": 0,
@@ -663,7 +663,7 @@ When the compiler encounters a Hole (`?name`), the shared SEP-0005 hole object i
     {
       "name": "http.get",
       "type_match": 1.0,
-      "capability_fit": 1.0,
+      "required_effects_fit": 1.0,
       "overall": 1.0
     }
   ]
@@ -681,15 +681,15 @@ The Hole system filters candidate functions so that only those whose `uses S` sa
 When an agent or developer fills a Hole with code that exceeds the available set, the compiler emits a detailed diagnostic:
 
 ```text
-ERROR [cap-violation] Hole ?fetch_logic filled code uses unauthorised effects:
+ERROR [effect-violation] Hole ?fetch_logic filled code uses unauthorised effects:
   --> src/service.sp:15:5
    |
 15 |     ?fetch_logic    // filled with: fetch_and_save(url)
    |     ^^^^^^^^^^^^ hole fill exceeds available effects
    |
-   = available capabilities: [NetConnect]
+   = available effects: [NetConnect]
    = fill code requires:     [NetConnect, FileWrite]
-   = excess capabilities:    [FileWrite]
+   = excess effects:    [FileWrite]
    = help: either add FileWrite to the enclosing function's `uses` clause,
      or choose a candidate that only requires [NetConnect]
 ```
@@ -852,7 +852,7 @@ The `uses` clause makes a function's external interactions visible at a glance. 
 
 ### Structured effect information in HoleReport
 
-LLM-based agents filling Holes receive the `capabilities` field in the shared SEP-0005 hole object. This enables agents to:
+LLM-based agents filling Holes receive the `effects` field in the shared SEP-0005 hole object. This enables agents to:
 
 1. **Constrain code generation.** The agent knows which operations are permissible and avoids generating code that would fail effect checks.
 2. **Filter candidate functions.** Only functions whose `uses S` satisfies S ⊆ S_available are presented as candidates.
@@ -872,14 +872,14 @@ The explicit effect set narrows the space of valid completions, reducing the lik
 
 ### Function type serialisation
 
-The canonical serialised form of a function type includes the CapSet:
+The canonical serialised form of a function type includes the EffectSet:
 
 ```json
 {
   "kind": "Fn",
   "params": ["Int", "Int"],
   "return": "Int",
-  "capabilities": [],
+  "effects": [],
   "errors": []
 }
 ```
@@ -889,7 +889,7 @@ The canonical serialised form of a function type includes the CapSet:
   "kind": "Fn",
   "params": ["Url"],
   "return": "Response",
-  "capabilities": ["NetConnect"],
+  "effects": ["NetConnect"],
   "errors": ["NetworkError"]
 }
 ```
@@ -925,7 +925,7 @@ The language server protocol integration should expose effect information throug
 
 | Code | Severity | Message template |
 |---|---|---|
-| `cap-violation` | Error | Function body uses effect `{cap}` not declared in `uses` clause. Declared: `{declared}`. Required: `{required}`. Excess: `{excess}`. |
+| `effect-violation` | Error | Function body uses effect `{cap}` not declared in `uses` clause. Declared: `{declared}`. Required: `{required}`. Excess: `{excess}`. |
 | `cap-closure-violation` | Error | Closure passed to `{fn_name}` must be pure (`uses []`), but it uses `{caps}`. |
 | `cap-spawn-missing` | Error | `spawn` expression requires `Spawn` effect, but current scope declares `uses {scope_caps}`. |
 | `cap-narrowing-violation` | Error | Spawn body uses `{child_caps}` which is not a subset of parent scope `{parent_caps}`. Excess: `{excess}`. |
@@ -942,7 +942,7 @@ The language server protocol integration should expose effect information throug
 Example diagnostic:
 
 ```text
-error[cap-violation]: function body uses undeclared effect
+error[effect-violation]: function body uses undeclared effect
   --> src/app.sp:12:5
    |
 10 | fn process(data: Data) -> Result
@@ -974,7 +974,7 @@ error[cap-violation]: function body uses undeclared effect
 
 5. **Alias is expansion only.** Effect aliases do not create new abstract effects. This prevents hiding implementation details behind an alias boundary — the caller always sees the expanded set.
 
-6. **String-based CapSet.** Using `BTreeSet<String>` for the internal representation is simple but offers no compile-time interning or efficient bitset operations. This may need revisiting for large-scale codebases with many effects.
+6. **String-based EffectSet.** Using `BTreeSet<String>` for the internal representation is simple but offers no compile-time interning or efficient bitset operations. This may need revisiting for large-scale codebases with many effects.
 
 ---
 
@@ -1037,7 +1037,7 @@ Encoding effects in the type system via monads (e.g., `IO a`, `State s a`).
 | **Scala (ZIO)** | Environment type `R` in `ZIO[R, E, A]` | Similar in spirit; ZIO's `R` is an intersection type, Spore uses a flat set |
 | **Unison** | Ability types (algebraic effects) | Close conceptual ancestor; Spore simplifies by removing polymorphism |
 | **Android Manifest** | Permission declarations | Same "declare what you need" philosophy at the OS level |
-| **Wasm Component Model** | Import/export capabilities | Static effect declaration before instantiation |
+| **Wasm Component Model** | Import/export effects | Static effect declaration before instantiation |
 | **Java (checked exceptions)** | `throws` clause | Spore's `uses` is analogous but tracks effects rather than error types |
 
 ---
@@ -1050,14 +1050,14 @@ Spore is a new language and this SEP defines a core feature of its type system. 
 
 ### Interaction with SEP-0002
 
-This SEP depends on SEP-0002 (Type System). The `CapSet` is integrated into the function type representation defined there:
+This SEP depends on SEP-0002 (Type System). The `EffectSet` is integrated into the function type representation defined there:
 
 ```rust
 enum Ty {
     Int,
     Bool,
     String,
-    Fn(Vec<Ty>, Box<Ty>, CapSet),  // params, return, effects
+    Fn(Vec<Ty>, Box<Ty>, EffectSet),  // params, return, effects
     // ...
 }
 ```
@@ -1093,7 +1093,7 @@ Can third-party libraries define new atomic effects? If so, how are they scoped 
 
 Is `FileRead` / `FileWrite` the right granularity, or should effects be path-scoped (e.g., `FileRead("/etc/config")`)? Path-scoping adds expressiveness but complicates the set algebra.
 
-### 5. Granularity of `Console` capability
+### 5. Granularity of `Console` effect
 
 Should `Console` be split further (e.g., `ConsoleRead` for stdin vs `ConsoleWrite` for stdout/stderr)? A single `Console` is simpler and covers the common case where terminal I/O is bidirectional, but finer granularity may be useful for sandboxing scenarios where a program should print output but not read input.
 

--- a/seps/SEP-0003-effect-system.md
+++ b/seps/SEP-0003-effect-system.md
@@ -653,7 +653,7 @@ When the compiler encounters a Hole (`?name`), the shared SEP-0005 hole object i
     "url": "Url",
     "timeout": "Duration"
   },
-  "effects": ["NetConnect"],
+  "available_effects": ["NetConnect"],
   "cost_budget": {
     "budget_total": 5000,
     "cost_before_hole": 0,
@@ -852,7 +852,7 @@ The `uses` clause makes a function's external interactions visible at a glance. 
 
 ### Structured effect information in HoleReport
 
-LLM-based agents filling Holes receive the `effects` field in the shared SEP-0005 hole object. This enables agents to:
+LLM-based agents filling Holes receive the `available_effects` field in the shared SEP-0005 hole object. This enables agents to:
 
 1. **Constrain code generation.** The agent knows which operations are permissible and avoids generating code that would fail effect checks.
 2. **Filter candidate functions.** Only functions whose `uses S` satisfies S ⊆ S_available are presented as candidates.

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -828,7 +828,6 @@ Bounded types provide compile-time size information for cost verification:
 ```spore
 fn process_batch(items: List[Order, max: 500]) -> BatchResult ! TooLarge
     cost ≤ 25000
-    uses [Compute]
 {
     items |> map(|order| validate(order)) |> fold(BatchResult.empty(), merge)
 }
@@ -848,13 +847,11 @@ Foreign functions have no Spore body for the compiler to analyse. They **must** 
 
 ```spore
 extern fn c_sort[T](data: List[T]) -> List[T]
-    uses [Compute]
     cost ≤ n * log(n)    // declared, not computed; n = len(data)
 ```
 
 ```spore
 extern fn openssl_encrypt(data: Bytes, key: Key) -> Bytes ! CryptoError
-    uses [Compute]
     cost ≤ len(data) * 3 + 500
 ```
 

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -45,7 +45,7 @@ Spore's language design creates a unique opportunity for compile-time cost analy
 1. **No loops.** All iteration is expressed through recursion and higher-order functions (`map`, `fold`, `filter`). This means cost analysis reduces entirely to recursion analysis — there is no separate "loop analysis" pass.
 2. **Algebraic data types.** The vast majority of recursive functions naturally follow the structure of their data (structural recursion), which is automatically detectable and provably terminating.
 3. **Pure functions.** In the absence of side effects, a function's cost is determined entirely by its parameters, enabling symbolic cost propagation.
-4. **Capability system.** The `uses [...]` declarations cross-validate with cost dimensions — a function declared `uses []` (pure) must have zero io(call) cost.
+4. **Effect system.** The `uses [...]` declarations cross-validate with cost dimensions — a function declared `uses []` (pure) must have zero io(call) cost.
 
 ### Design goals
 
@@ -803,7 +803,7 @@ Source Code
   ↓
 [1] Parse to AST
   ↓
-[2] Type Check + Capability Check
+[2] Type Check + Effect Check
   ↓
 [3] Abstract Interpretation (Cost Inference)
     ├── Build control flow graph (CFG)
@@ -1022,7 +1022,7 @@ The Language Server Protocol exposes:
 | `unbounded-function` | Warning | Function marked `@unbounded` |
 | `unbounded-in-bounded-context` | Error | `@unbounded` function called from `cost ≤ K` context without `with_cost_limit` |
 | `unverified-cost-bound` | Warning | `cost ≤ expr` declared but compiler cannot verify it |
-| `cost-capability-conflict` | Error | `uses []` (pure) declared but W > 0 inferred |
+| `cost-effect-conflict` | Error | `uses []` (pure) declared but W > 0 inferred |
 
 ### Example diagnostics
 
@@ -1053,9 +1053,9 @@ WARNING [unbounded-cost] fibonacci's cost cannot be statically determined.
   (c) Rewrite using structural recursion or tail recursion + iteration bound
 ```
 
-### Cross-validation with capabilities
+### Cross-validation with effects
 
-The cost system and capability system form a cross-validation network. If a function declares `uses []` (pure, no capabilities) but cost analysis discovers W > 0 (I/O operations), the compiler emits `cost-capability-conflict`. Conversely, a function declared `uses [NetConnect]` must have W ≥ 1 in at least one code path.
+The cost system and effect system form a cross-validation network. If a function declares `uses []` (pure, no effects) but cost analysis discovers W > 0 (I/O operations), the compiler emits `cost-effect-conflict`. Conversely, a function declared `uses [NetConnect]` must have W ≥ 1 in at least one code path.
 
 ---
 
@@ -1167,7 +1167,7 @@ Sized types annotate data types with size information (e.g., `List[T, max: n]`) 
 
 ### This is a new feature
 
-Cost analysis is introduced as a new compiler capability. No existing Spore code is broken by this SEP.
+Cost analysis is introduced as a new compiler effect. No existing Spore code is broken by this SEP.
 
 ### Migration path
 

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -23,7 +23,7 @@ superseded_by: null
 
 This SEP specifies Spore's **Hole System** — a first-class language mechanism that treats unfinished code as a structured, typed, compiler-mediated collaboration interface between humans and AI Agents.
 
-A *hole* is written `?name` (optionally `?name: Type`) in any expression position within a function body. The compiler accepts programs containing holes, classifies those functions as **partial**, and produces a shared typed hole report. The stable machine protocol reuses one hole object across both batch and single-hole queries: `sporec holes FILE --json` emits `{ "holes": [...], "dependency_graph": ... }`, while `sporec query-hole FILE ?name --json` returns the matching hole object directly. That shared object now carries the fields agents actually consume today, including `name`, `display_name`, `location`, `expected_type`, `type_inferred_from`, `function`, `enclosing_signature`, `bindings`, `binding_dependencies`, `effects`, `errors_to_handle`, `cost_budget`, `candidates`, `dependent_holes`, `confidence`, and `error_clusters`.
+A *hole* is written `?name` (optionally `?name: Type`) in any expression position within a function body. The compiler accepts programs containing holes, classifies those functions as **partial**, and produces a shared typed hole report. The stable machine protocol reuses one hole object across both batch and single-hole queries: `sporec holes FILE --json` emits `{ "holes": [...], "dependency_graph": ... }`, while `sporec query-hole FILE ?name --json` returns the matching hole object directly. That shared object now carries the fields agents actually consume today, including `name`, `display_name`, `location`, `expected_type`, `type_inferred_from`, `function`, `enclosing_signature`, `bindings`, `binding_dependencies`, `available_effects`, `errors_to_handle`, `cost_budget`, `candidates`, `dependent_holes`, `confidence`, and `error_clusters`.
 
 Multiple holes still form a **Hole Dependency Graph** (DAG), enabling topological ordering and parallel filling by multiple Agents. The long-term **Agent Protocol** defines a five-state machine (DISCOVER → ANALYZE → PROPOSE → VERIFY → ACCEPT/REJECT) for autonomous filling workflows. Today, however, `spore watch --json` remains a thinner transport: it emits per-cycle `compile_result` plus a summary `hole_graph_update`, while richer per-hole watch events remain the target architecture rather than the stable contract.
 
@@ -253,7 +253,7 @@ HoleReport v0.3 is a **superset** of v0.2. The schema version advances from `"sp
 | `type.expected` | The type this hole must produce, including error variants |
 | `type.inferred_from` | Human-readable explanation of why this type is expected |
 | `bindings` | Variables in scope with name, type, and simulated value (`symbolic` or `computed`) |
-| `effects` | The `uses` list from the enclosing function |
+| `available_effects` | The `uses` list available at the hole site |
 | `errors_to_handle` | Error types not yet handled before the hole |
 | `cost.budget_total` | The `cost ≤ N` from the enclosing function |
 | `cost.cost_before_hole` | Cumulative cost of statements before the hole |
@@ -976,7 +976,7 @@ A HoleReport v0.3 is **self-contained**. An Agent reading a report needs zero ad
 
 1. **What to produce**: `type.expected` with `type.inferred_from` explaining why
 2. **What is available**: `bindings` with types, simulated values, and `binding_dependencies` showing data-flow
-3. **What is permitted**: `effects` (what the fill can call), `cost.budget_remaining` (how expensive it can be)
+3. **What is permitted**: `available_effects` (what the fill can call), `cost.budget_remaining` (how expensive it can be)
 4. **What errors to handle**: `errors_to_handle` flat list plus `error_clusters` with per-source grouping and handling suggestions
 5. **What functions might work**: `candidates` with multi-dimensional `scores`, `overall` ranking, and `adjustments`
 6. **How confident the compiler is**: `confidence.type_inference` and `confidence.candidate_ranking`
@@ -1148,7 +1148,7 @@ All hole-related commands support `--json` for machine consumption.
         "order": [],
         "validated": ["order"]
       },
-      "effects": ["Inventory", "PaymentGateway"],
+      "available_effects": ["Inventory", "PaymentGateway"],
       "errors_to_handle": ["PaymentFailed"],
       "cost_budget": {
         "budget_total": 5000,

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -17,13 +17,13 @@ superseded_by: null
 
 # SEP-0005: Hole System & Agent Protocol
 
-> **Executive Summary**: Defines typed holes (`?name`) as first-class language constructs that carry type, capability, and cost context. The current stable machine surface is a shared typed hole protocol: `sporec holes FILE --json` emits a root object with `holes` and `dependency_graph`, and `sporec query-hole FILE ?name --json` returns the same per-hole object directly. This SEP also keeps the richer long-term agent/watch protocol — dependency-aware fill ordering, cross-hole coordination, and the `DISCOVER → ANALYZE → PROPOSE → VERIFY → ACCEPT/REJECT` workflow — while documenting that today's `spore watch --json` still emits `compile_result` plus a summary-style `hole_graph_update`, not the full target graph payload.
+> **Executive Summary**: Defines typed holes (`?name`) as first-class language constructs that carry type, effect, and cost context. The current stable machine surface is a shared typed hole protocol: `sporec holes FILE --json` emits a root object with `holes` and `dependency_graph`, and `sporec query-hole FILE ?name --json` returns the same per-hole object directly. This SEP also keeps the richer long-term agent/watch protocol — dependency-aware fill ordering, cross-hole coordination, and the `DISCOVER → ANALYZE → PROPOSE → VERIFY → ACCEPT/REJECT` workflow — while documenting that today's `spore watch --json` still emits `compile_result` plus a summary-style `hole_graph_update`, not the full target graph payload.
 
 ## Summary
 
 This SEP specifies Spore's **Hole System** — a first-class language mechanism that treats unfinished code as a structured, typed, compiler-mediated collaboration interface between humans and AI Agents.
 
-A *hole* is written `?name` (optionally `?name: Type`) in any expression position within a function body. The compiler accepts programs containing holes, classifies those functions as **partial**, and produces a shared typed hole report. The stable machine protocol reuses one hole object across both batch and single-hole queries: `sporec holes FILE --json` emits `{ "holes": [...], "dependency_graph": ... }`, while `sporec query-hole FILE ?name --json` returns the matching hole object directly. That shared object now carries the fields agents actually consume today, including `name`, `display_name`, `location`, `expected_type`, `type_inferred_from`, `function`, `enclosing_signature`, `bindings`, `binding_dependencies`, `capabilities`, `errors_to_handle`, `cost_budget`, `candidates`, `dependent_holes`, `confidence`, and `error_clusters`.
+A *hole* is written `?name` (optionally `?name: Type`) in any expression position within a function body. The compiler accepts programs containing holes, classifies those functions as **partial**, and produces a shared typed hole report. The stable machine protocol reuses one hole object across both batch and single-hole queries: `sporec holes FILE --json` emits `{ "holes": [...], "dependency_graph": ... }`, while `sporec query-hole FILE ?name --json` returns the matching hole object directly. That shared object now carries the fields agents actually consume today, including `name`, `display_name`, `location`, `expected_type`, `type_inferred_from`, `function`, `enclosing_signature`, `bindings`, `binding_dependencies`, `effects`, `errors_to_handle`, `cost_budget`, `candidates`, `dependent_holes`, `confidence`, and `error_clusters`.
 
 Multiple holes still form a **Hole Dependency Graph** (DAG), enabling topological ordering and parallel filling by multiple Agents. The long-term **Agent Protocol** defines a five-state machine (DISCOVER → ANALYZE → PROPOSE → VERIFY → ACCEPT/REJECT) for autonomous filling workflows. Today, however, `spore watch --json` remains a thinner transport: it emits per-cycle `compile_result` plus a summary `hole_graph_update`, while richer per-hole watch events remain the target architecture rather than the stable contract.
 
@@ -45,7 +45,7 @@ Traditional languages treat unfinished code as an error — `todo!()`, `unimplem
 
 This creates two problems:
 
-1. **For humans**: Developers cannot express partial intent. They know the function's contract (signature, error types, cost bound, capability requirements) but haven't decided on the implementation yet. Traditional languages offer no way to say "this part is intentionally unfinished, here is what I need" in a way the compiler understands.
+1. **For humans**: Developers cannot express partial intent. They know the function's contract (signature, error types, cost bound, effect requirements) but haven't decided on the implementation yet. Traditional languages offer no way to say "this part is intentionally unfinished, here is what I need" in a way the compiler understands.
 
 2. **For AI Agents**: Without structured information about what is missing, Agents must reverse-engineer context from error messages, heuristically guess types, and operate without compiler guidance. The quality ceiling is low and the failure rate is high.
 
@@ -253,7 +253,7 @@ HoleReport v0.3 is a **superset** of v0.2. The schema version advances from `"sp
 | `type.expected` | The type this hole must produce, including error variants |
 | `type.inferred_from` | Human-readable explanation of why this type is expected |
 | `bindings` | Variables in scope with name, type, and simulated value (`symbolic` or `computed`) |
-| `capabilities` | The `uses` list from the enclosing function |
+| `effects` | The `uses` list from the enclosing function |
 | `errors_to_handle` | Error types not yet handled before the hole |
 | `cost.budget_total` | The `cost ≤ N` from the enclosing function |
 | `cost.cost_before_hole` | Cumulative cost of statements before the hole |
@@ -300,7 +300,7 @@ Replaces the coarse `match_quality: "exact" | "partial"` string with a four-dime
 |---|---|---|---|
 | Type match | `type_match` | `[0, 1]` | Return type + parameter type match degree |
 | Cost fit | `cost_fit` | `[0, 1]` | Estimated cost vs. remaining budget fit |
-| Capability fit | `capability_fit` | `{0, 1}` | All required capabilities available (boolean) |
+| Effect fit | `required_effects_fit` | `{0, 1}` | All required effects available (boolean) |
 | Error coverage | `error_coverage` | `[0, 1]` | Fraction of candidate's declared errors covered by context |
 
 **Type match formula:**
@@ -326,7 +326,7 @@ cost_fit(candidate, hole) =
 **Overall score:**
 
 ```text
-overall = 0.40 × type_match + 0.20 × cost_fit + 0.25 × capability_fit + 0.15 × error_coverage
+overall = 0.40 × type_match + 0.20 × cost_fit + 0.25 × required_effects_fit + 0.15 × error_coverage
 ```
 
 Weights are hard-coded in the compiler. Candidates are sorted by `overall` descending, with `type_match` as tiebreaker, then `cost_fit`, then lexicographic name for stability.
@@ -909,7 +909,7 @@ The `origin` field distinguishes closure parameters from captured bindings, enab
 
 A hole in a function inferred as `pure` (i.e., `uses []`) is itself pure by definition — it does nothing. The compiler does not flag a purity violation for the hole's presence. However, the **filling** must satisfy the purity constraint:
 
-**Formal rule:** If function `f` has `uses []` (and is therefore inferred as `pure`), any expression that replaces a hole `?h` in `f`'s body must also be pure — it may not call functions requiring IO or State capabilities.
+**Formal rule:** If function `f` has `uses []` (and is therefore inferred as `pure`), any expression that replaces a hole `?h` in `f`'s body must also be pure — it may not call functions requiring IO or State effects.
 
 ```spore
 fn pure_fn(x: Int) -> Int
@@ -922,7 +922,7 @@ If the Agent fills with an impure expression:
 
 ```text
 [error] pure_fn is inferred as pure (uses []) but the filling of ?must_be_pure
-        calls print() which requires capability: IO
+        calls print() which requires effect: IO
 ```
 
 ---
@@ -976,7 +976,7 @@ A HoleReport v0.3 is **self-contained**. An Agent reading a report needs zero ad
 
 1. **What to produce**: `type.expected` with `type.inferred_from` explaining why
 2. **What is available**: `bindings` with types, simulated values, and `binding_dependencies` showing data-flow
-3. **What is permitted**: `capabilities` (what the fill can call), `cost.budget_remaining` (how expensive it can be)
+3. **What is permitted**: `effects` (what the fill can call), `cost.budget_remaining` (how expensive it can be)
 4. **What errors to handle**: `errors_to_handle` flat list plus `error_clusters` with per-source grouping and handling suggestions
 5. **What functions might work**: `candidates` with multi-dimensional `scores`, `overall` ranking, and `adjustments`
 6. **How confident the compiler is**: `confidence.type_inference` and `confidence.candidate_ranking`
@@ -986,14 +986,14 @@ This design eliminates the "context gathering" phase that plagues current AI cod
 
 ### Scoring Vectors Enable Principled Selection
 
-The four-dimensional scoring vector (`type_match`, `cost_fit`, `capability_fit`, `error_coverage`) enables Agents to make decisions based on numeric comparison rather than string parsing. An Agent's selection logic becomes:
+The four-dimensional scoring vector (`type_match`, `cost_fit`, `required_effects_fit`, `error_coverage`) enables Agents to make decisions based on numeric comparison rather than string parsing. An Agent's selection logic becomes:
 
 ```text
 if confidence.candidate_ranking == "unique_best":
     select candidates[0]
 elif confidence.candidate_ranking == "ambiguous":
     for each candidate in candidates:
-        if candidate.scores.capability_fit == 0:
+        if candidate.scores.required_effects_fit == 0:
             skip  # hard constraint
         weight type_match and cost_fit by task priority
     select best by adjusted score
@@ -1034,7 +1034,7 @@ Today, the stable implementation approximates this by combining the shared batch
 
 ### Failure Recovery
 
-On REJECT, the Agent receives structured diagnostics with `root_cause` classification (`type_mismatch`, `cost_exceeded`, `capability_violation`, `error_unhandled`) and `fix_hints`. This is richer than typical compiler errors:
+On REJECT, the Agent receives structured diagnostics with `root_cause` classification (`type_mismatch`, `cost_exceeded`, `effect_violation`, `error_unhandled`) and `fix_hints`. This is richer than typical compiler errors:
 
 - `root_cause` categorization lets the Agent choose a recovery strategy without natural-language parsing
 - `fix_hints` provide specific, actionable suggestions
@@ -1148,7 +1148,7 @@ All hole-related commands support `--json` for machine consumption.
         "order": [],
         "validated": ["order"]
       },
-      "capabilities": ["Inventory", "PaymentGateway"],
+      "effects": ["Inventory", "PaymentGateway"],
       "errors_to_handle": ["PaymentFailed"],
       "cost_budget": {
         "budget_total": 5000,
@@ -1160,7 +1160,7 @@ All hole-related commands support `--json` for machine consumption.
           "name": "gateway_charge",
           "type_match": 1.0,
           "cost_fit": 0.92,
-          "capability_fit": 1.0,
+          "required_effects_fit": 1.0,
           "error_coverage": 1.0,
           "overall": 0.97
         }
@@ -1309,7 +1309,7 @@ Rejected. RETRY adds state machine complexity without new information — REJECT
 Agda's holes (written `?` or `{! !}`) are the closest precedent. Agda provides typed holes with goal type, context bindings, and refinement commands. Key differences from Spore:
 
 - Agda holes are interactive (Emacs/VS Code mode); Spore holes are CLI/JSON-first
-- Agda has no cost system, capability system, or scoring vectors
+- Agda has no cost system, effect system, or scoring vectors
 - Agda has no concept of parallel Agent filling
 - Agda holes can appear in type positions; Spore separates type holes from value holes
 
@@ -1333,8 +1333,8 @@ GHC's `_` syntax produces type error messages listing the expected type and bind
 
 Lean 4's `sorry` and `_` produce goal states with the expected type and local context. Lean's tactic mode allows interactive proof construction. Differences:
 
-- Lean is proof-oriented; Spore is software-engineering-oriented (cost, capabilities, errors)
-- Lean has no cost budget or capability constraints on holes
+- Lean is proof-oriented; Spore is software-engineering-oriented (cost, effects, errors)
+- Lean has no cost budget or effect constraints on holes
 - Lean has no parallel fill protocol
 
 ### Rust `todo!()` / TypeScript `// TODO`

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -19,7 +19,7 @@ superseded_by: null
 
 # SEP-0006: Compiler Architecture
 
-> **Executive Summary**: Defines a 6-phase compiler pipeline (Lex → Parse → Resolve → TypeCheck → Lower → Codegen) with SEP-aligned diagnostic codes organized by category — E0xxx (type errors), C0xxx (capability violations), K0xxx (cost budget), M0xxx (module errors), W0xxx (warnings). The architecture centers on a shared diagnostics pipeline consumed by CLI JSON, LSP, and the hole/reporting surfaces, while `spore watch --json` currently provides summary NDJSON events (`compile_result` plus `hole_graph_update`) and leaves richer watch transports as a later layer.
+> **Executive Summary**: Defines a 6-phase compiler pipeline (Lex → Parse → Resolve → TypeCheck → Lower → Codegen) with SEP-aligned diagnostic codes organized by category — E0xxx (type errors), C0xxx (effect violations), K0xxx (cost budget), M0xxx (module errors), W0xxx (warnings). The architecture centers on a shared diagnostics pipeline consumed by CLI JSON, LSP, and the hole/reporting surfaces, while `spore watch --json` currently provides summary NDJSON events (`compile_result` plus `hole_graph_update`) and leaves richer watch transports as a later layer.
 
 ## Summary
 
@@ -65,7 +65,7 @@ needs a compiler whose architecture is:
 Existing compiler architectures either carry unnecessary complexity (Rust's MIR
 for borrow checking, Zig's ZIR for comptime) or are too simplistic for Spore's
 needs (Gleam's two-layer AST lacks a desugared IR). This SEP defines a pipeline
-tuned precisely to Spore's feature set: algebraic types, capabilities, cost
+tuned precisely to Spore's feature set: algebraic types, effects, cost
 models, holes, and content-addressed modules.
 
 ---
@@ -205,15 +205,15 @@ Source Text (.sp files)
     ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
 │  Pass 4: TYPECHECK + CAPCHECK + COSTCHECK                               │
-│  HIR → TypedHIR (fully typed, capability-verified, cost-verified)       │
+│  HIR → TypedHIR (fully typed, effect-verified, cost-verified)       │
 │  ─ Bidirectional type inference (signatures annotated, bodies inferred)  │
-│  ─ Trait / Capability resolution (Capability = Trait)                    │
+│  ─ Trait / Effect resolution (Effect = Trait)                    │
 │  ─ Associated types + GAT instantiation                                 │
 │  ─ Const generics evaluation                                            │
 │  ─ Exhaustiveness checking (match expressions)                          │
 │  ─ Error set propagation and consistency (! Errors)                   │
 │  ─ Refinement types: L0 decidable predicates + L1 abstract propagation  │
-│  ─ Capability check: body uses ⊆ declared uses, module ceiling check    │
+│  ─ Effect check: body uses ⊆ declared uses, module ceiling check    │
 │  ─ Cost check: abstract interpretation of 4D cost vector                 │
 │  ─ Hole report generation with full context                             │
 │  ─ ** impl hash computed here **                                        │
@@ -294,7 +294,7 @@ Spanned<T> { node: T, span: Span }
 Span { file: FileId, start: u32, end: u32 }
 
 Module { items: Vec<Spanned<Item>> }
-Item = FnDef | StructDef | TypeDef | CapabilityDef | Import | ...
+Item = FnDef | StructDef | TypeDef | TraitDef | Import | ...
 FnDef {
     name, params, return_type, error_set,
     where_clause, cost_clause, uses_clause,
@@ -331,7 +331,7 @@ The Desugar pass (merged into Resolve) canonicalizes all syntactic sugar:
 
 - Function name, parameter types, return type
 - Error set declarations
-- Effect / capability declarations
+- Effect / effect declarations
 - Cost declarations
 
 It does **not** cover function bodies. When sig hash is unchanged, downstream
@@ -339,7 +339,7 @@ dependent modules skip resolve and type-check entirely.
 
 #### Layer 3: TypedHIR (Typed High-level IR)
 
-**Purpose:** Fully type-checked, capability-verified, cost-verified IR. This is
+**Purpose:** Fully type-checked, effect-verified, cost-verified IR. This is
 the input to codegen.
 
 The unified TypeCheck pass performs:
@@ -347,17 +347,17 @@ The unified TypeCheck pass performs:
 | Sub-pass | Responsibility |
 |----------|---------------|
 | **Type inference** | Bidirectional: signatures fully annotated, function bodies inferred |
-| **Trait resolution** | Trait/Capability resolution, associated types, GAT instantiation |
+| **Trait resolution** | Trait/Effect resolution, associated types, GAT instantiation |
 | **Const generics** | Evaluation of compile-time constant generic parameters |
 | **Exhaustiveness** | Verify match expressions cover all variants |
 | **Error sets** | Propagation and consistency of `! ErrorType` declarations |
 | **Refinement types** | L0 decidable predicates + L1 abstract interpretation propagation |
-| **CapCheck** | Function body capability usage ⊆ declared `uses` set; module ceiling check |
+| **CapCheck** | Function body effect usage ⊆ declared `uses` set; module ceiling check |
 | **CostCheck** | Abstract interpretation of 4D cost vector: `compute(op) + alloc(cell) + io(call) + parallel(lane)`; verify ≤ declared bound |
-| **Hole reports** | Generate full context: type, available bindings, capability set, cost budget, candidate functions |
+| **Hole reports** | Generate full context: type, available bindings, effect set, cost budget, candidate functions |
 
-Capability checking is merged into TypeCheck because `Capability = Trait` in
-Spore — capability resolution shares the same infrastructure as trait resolution.
+Effect checking is merged into TypeCheck because `Effect = Trait` in
+Spore — effect resolution shares the same infrastructure as trait resolution.
 
 Cost checking is merged into TypeCheck because cost analysis depends on resolved
 types and call-graph information already computed during type checking.
@@ -461,7 +461,7 @@ The incremental compilation strategy relies on two content-addressed hashes:
                                                 recheck (direct deps)
 ```
 
-**sig hash** covers: exported type/function signatures, capability requirements,
+**sig hash** covers: exported type/function signatures, effect requirements,
 cost annotations. It does *not* cover: function bodies, private definitions,
 comments, internal hole states.
 
@@ -583,7 +583,7 @@ $ spore watch src/main.sp
 
   Warnings:
     src/net/http.sp:23:5  unused import: `Timeout`        [W0102]
-    src/db/query.sp:45:12 unused capability: `FileSystem`  [W0105]
+    src/db/query.sp:45:12 unused effect: `FileSystem`  [W0105]
 
   Holes (5):
     ◯ src/auth/login.sp:30   authenticate     : User -> Token
@@ -673,7 +673,7 @@ type ModuleInfo:
     path: Path
     impl_hash: Hash
     sig_hash: Hash
-    capabilities: Set Capability
+    effects: Set Effect
     cost_annotation: CostBound
     holes: List Hole
 ```
@@ -697,23 +697,23 @@ fn update_dep_graph(module_id: ModuleId, old_deps: Set<ModuleId>, new_deps: Set<
         emit_error("circular dependency", module_id)
 ```
 
-#### Capability propagation watch output
+#### Effect propagation watch output
 
 ```text
-[watch] sig hash changed (capability set changed)
-[watch] Capability change: HttpClient: {Network} → {Network, FileSystem}
-[watch] Checking project capability ceiling...
+[watch] sig hash changed (effect set changed)
+[watch] Effect change: HttpClient: {Network} → {Network, FileSystem}
+[watch] Checking project effect ceiling...
          ceiling allows: {Network, FileSystem, Clock} → ✓ within bounds
-[watch] Downstream capability compatibility:
+[watch] Downstream effect compatibility:
          ├─ src/api/client.sp → OK
          └─ src/app.sp → propagation stops
-[watch] ✓ 3 modules recompiled, 0 errors, 1 capability warning
+[watch] ✓ 3 modules recompiled, 0 errors, 1 effect warning
 ```
 
 When the ceiling is exceeded:
 
 ```text
-[watch] ✗ Error: HttpClient added capability `Crypto`
+[watch] ✗ Error: HttpClient added effect `Crypto`
          Project ceiling: {Network, FileSystem, Clock}
          `Crypto` not in ceiling — update ceiling or remove usage
 ```
@@ -823,7 +823,7 @@ Appends additional analysis blocks after each diagnostic:
 - **Inference chain:** step-by-step type derivation
 - **Candidates considered:** possible conversions, overloads, alternative
   functions
-- **Capability context:** which capabilities are in scope at the error site
+- **Effect context:** which effects are in scope at the error site
 - **Cost context:** cost used so far vs. budget
 
 Example:
@@ -846,7 +846,7 @@ help: try `Money.from_string("fifty dollars")`
     String -> Money via Money.from_string  ✓ (exact match)
     String -> Money via Money.parse        ✓ (may raise ParseError)
 
-  capability context: [PaymentGateway]
+  effect context: [PaymentGateway]
   cost at this point: 120 / budget 500
 ```
 
@@ -891,7 +891,7 @@ make richer analysis payloads an explicit later layer.
 ```
 
 The base IR deliberately excludes richer fields such as inference chains,
-candidate rankings, capability/cost context blobs, and machine-edit payloads.
+candidate rankings, effect/cost context blobs, and machine-edit payloads.
 Those may be layered later as extension data or adjacent protocols, but they are
 not part of the minimal stable contract.
 
@@ -966,7 +966,7 @@ All diagnostics carry categorized codes:
 |--------|----------|----------|
 | `E0xxx` | Type errors | type mismatch, missing field, arity error |
 | `W0xxx` | Warnings | unused variable, redundant pattern, shadowing |
-| `C0xxx` | Capability violations | undeclared capability, exceeding ceiling |
+| `C0xxx` | Effect violations | undeclared effect, exceeding ceiling |
 | `K0xxx` | Cost violations | budget exceeded, unbounded call |
 | `H0xxx` | Hole diagnostics | hole report, partial function, type conflict |
 | `M0xxx` | Module errors | circular dependency, visibility violation |
@@ -1009,7 +1009,7 @@ Target latencies (aspirational, not hard guarantees):
 
 | Operation | Target | Notes |
 |-----------|--------|-------|
-| Single module recompilation | < 100ms | Type check + capability + cost |
+| Single module recompilation | < 100ms | Type check + effect + cost |
 | Dependency graph traversal | < 10ms | Topological sort of module DAG |
 | Hash computation (single module) | < 5ms | blake3 of module content |
 | Full project initial analysis (~100 modules) | < 5s | Cold start, parallel compilation |
@@ -1040,14 +1040,14 @@ analyses in one pass:
 
 ```text
 Source → Parse → Name Resolution → Type Inference
-                                    ├── Capability Check (inline)
+                                    ├── Effect Check (inline)
                                     ├── Cost Analysis (post-typecheck)
                                     └── Lint Pass (post-typecheck)
 ```
 
 All diagnostics are collected into a single `Vec<Diagnostic>` and sorted by file
 position. This ensures the developer sees **all** issues in one invocation rather
-than fixing types first, then capabilities, then costs.
+than fixing types first, then effects, then costs.
 
 **Cost violations** are emitted as **warnings** (severity = Warning, code prefix
 `K`), not errors. They do not cause a non-zero exit code unless `--deny-warnings`
@@ -1117,7 +1117,7 @@ error) and visually structured with Rust-style gutters and underlines, making
 
 - Real-time error/warning diagnostics on file save
 - Hole progress tracking (total holes, filled this cycle, ready to fill, blocked)
-- Capability and cost propagation alerts when signatures change
+- Effect and cost propagation alerts when signatures change
 
 The watch output is designed to be "glanceable" — a developer can look at the
 terminal and immediately know whether the codebase is healthy.
@@ -1353,10 +1353,10 @@ error[E0301]: type mismatch
 help: try `Money.from_string("fifty dollars")`
 ```
 
-**Capability violation:**
+**Effect violation:**
 
 ```text
-error[C0101]: undeclared capability
+error[C0101]: undeclared effect
   --> src/report.sp:27:5
    |
 27 |     http.get(endpoint)
@@ -1391,7 +1391,7 @@ note[H0101]: hole `tax_logic` requires filling
    |     ^^^^^^^^^^ expected type: `Money`, remaining cost budget: 400 op
    |
    = note: available bindings: income: Money, region: Region
-   = note: available capabilities: [TaxTable]
+   = note: available effects: [TaxTable]
    = note: candidate: `tax_table.lookup(region, income) -> Money`
 help: run `sporec query-hole src/tax.sp ?tax_logic` for full HoleReport
 ```
@@ -1463,24 +1463,24 @@ All diagnostics carry a categorized code. Every code is queryable: `sporec expla
 | `W0102` | unused-import | Module import never referenced |
 | `W0103` | unused-function | Private function never called |
 | `W0104` | unused-type | Private type never referenced |
-| `W0105` | unused-capability | Declared capability never exercised |
+| `W0105` | unused-effect | Declared effect never exercised |
 | `W0201` | redundant-pattern | Match arm unreachable due to prior arm |
 | `W0202` | redundant-constraint | Generic constraint implied by another |
 | `W0203` | redundant-parentheses | Unnecessary parentheses around expression |
 | `W0301` | shadowing | Variable shadows binding in outer scope |
 | `W0302` | implicit-discard | Expression result discarded without explicit `_` |
 
-#### C0xxx — Capability Violations
+#### C0xxx — Effect Violations
 
 | Code | Name | Description |
 |------|------|-------------|
-| `C0101` | undeclared-capability | Function uses capability not in `uses` |
+| `C0101` | undeclared-effect | Function uses effect not in `uses` |
 | `C0102` | exceeds-ceiling | Function `uses` exceeds module ceiling |
-| `C0103` | callee-capability-leak | Calling function whose `uses` exceeds caller's |
-| `C0104` | transitive-capability | Transitive callee introduces undeclared capability |
-| `C0201` | platform-capability-denied | Package requests capability Platform does not grant |
-| `C0202` | platform-missing | No Platform provides required capability |
-| `C0301` | capability-purity-conflict | `uses []` (pure) function calls impure code |
+| `C0103` | callee-effect-leak | Calling function whose `uses` exceeds caller's |
+| `C0104` | transitive-effect | Transitive callee introduces undeclared effect |
+| `C0201` | platform-effect-denied | Package requests effect Platform does not grant |
+| `C0202` | platform-missing | No Platform provides required effect |
+| `C0301` | effect-purity-conflict | `uses []` (pure) function calls impure code |
 
 #### K0xxx — Cost Violations
 
@@ -1543,15 +1543,15 @@ Diagnostics do not exist in isolation — they connect to every major Spore subs
 - richer cost-breakdown payloads can be layered later as verbose or extension
   data; they are not part of the minimal frozen IR
 
-#### Capability System integration
+#### Effect System integration
 
 Three enforcement levels:
 
 1. **Function level** (`C0101`): body uses operations beyond declared `uses`
 2. **Module level** (`C0102`): function `uses` exceeds module ceiling
-3. **Platform level** (`C0201`): package requests capabilities Platform does not grant
+3. **Platform level** (`C0201`): package requests effects Platform does not grant
 
-Capability context may be rendered in notes or future verbose/extension data, but
+Effect context may be rendered in notes or future verbose/extension data, but
 it is not a required field in the minimal frozen IR.
 
 #### Snapshot System integration
@@ -1652,10 +1652,10 @@ The 100ms debounce window after save still provides near-instant feedback.
 
 ### 6. Separate passes for CapCheck and CostCheck
 
-We considered making capability checking and cost checking independent passes
+We considered making effect checking and cost checking independent passes
 after type checking.
 
-**Rejected because:** `Capability = Trait` in Spore, so capability resolution
+**Rejected because:** `Effect = Trait` in Spore, so effect resolution
 shares trait resolution infrastructure. Cost checking depends on fully resolved
 types and call graphs. Merging all three into a unified TypeCheck pass avoids
 redundant tree traversals and simplifies the impl hash boundary.
@@ -1693,7 +1693,7 @@ The prefix convention (E/W/C/K/H/M) maps directly to Spore's major subsystems.
 **Rationale:** DX is the highest-ROI investment; content-addressing naturally supports incremental compilation.
 **Consequence:** No runtime module replacement protocol; single-machine development scenarios only.
 
-#### ADR-002: Three capabilities
+#### ADR-002: Three effects
 
 **Decision:** "Program-as-Service" manifests as incremental compilation + real-time diagnostics + hole status tracking.
 **Rationale:** These cover the core feedback needs during coding: correctness, problem location, progress tracking.
@@ -1845,7 +1845,7 @@ TypedHIR layer; a new "opt hash" could gate the MIR → Cranelift translation.
    enabling offline analysis tools to process the history?
 
 10. **Tree-walking interpreter scope.** How much of the language should the
-    PoC interpreter support? Full semantics (including capabilities and cost
+    PoC interpreter support? Full semantics (including effects and cost
     tracking at runtime) or a minimal subset for early testing? This affects
     the PoC timeline and determines how much behavior can be validated before
     Cranelift codegen is ready.
@@ -1877,8 +1877,8 @@ Suppression is limited to **warnings only** — errors and notes cannot be suppr
 | **impl hash** | Hash of module implementation content; determines whether to recompile this module |
 | **sig hash** | Hash of module public interface; determines whether downstream dependents need rechecking |
 | **hole** | Source-code placeholder (`?name`) for unfinished implementation, carrying type information |
-| **capability** | A declared system permission (e.g., `Network`, `FileSystem`) required to perform certain operations |
-| **capability ceiling** | Project-level maximum capability set; no module may exceed it |
+| **effect** | A declared system permission (e.g., `Network`, `FileSystem`) required to perform certain operations |
+| **effect ceiling** | Project-level maximum effect set; no module may exceed it |
 | **cost annotation** | A declared upper bound on a function's computational cost (`cost ≤ K`) |
 | **debounce** | Coalescing multiple rapid file-system events into a single compilation trigger |
 | **NDJSON** | Newline-Delimited JSON — each line is a complete, independent JSON object |

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -41,7 +41,7 @@ The design unifies five properties that no existing language achieves simultaneo
 |----------|---------|-------------|
 | **Colorless functions** | Concurrency does not introduce `async`/`await` syntax bifurcation | All developers |
 | **Structured lifetimes** | Child tasks cannot escape the parent scope | Resource management, debugging |
-| **Explicit capabilities** | Concurrent tasks may only use declared capabilities | Security audits |
+| **Explicit effects** | Concurrent tasks may only use declared effects | Security audits |
 | **Bounded cost** | Compiler statically verifies `cost ≤ N` and `parallel(lane)` | Performance predictability |
 | **Simulatable execution** | Handlers are replaceable—same code compiles to simulation / deterministic test / production parallel | Agents, CI |
 
@@ -601,7 +601,7 @@ effect ChanRecv[T] {
 }
 ```
 
-Functions using channels must declare the corresponding capabilities:
+Functions using channels must declare the corresponding effects:
 
 ```spore
 fn producer(tx: Sender[Int]) -> Unit ! ChannelClosed

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -16,13 +16,13 @@ superseded_by: null
 
 # SEP-0008: Module & Package System
 
-> **Executive Summary**: Defines a content-addressed package system (BLAKE3 dual-hash) with platform-as-package architecture, where a selected Platform package declares its startup contract, host adapter, and handled effects via manifest metadata and package modules. Uses 1-file-=1-module mapping with dot-separated import paths (`import billing.invoice`) and `spore.toml` for project configuration. Enforces visibility rules (pub/pub(pkg)/private) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through explicit function-level effects plus Platform metadata. Broader project/file capability ceilings remain follow-up work rather than part of the current shipped contract.
+> **Executive Summary**: Defines a content-addressed package system (BLAKE3 dual-hash) with platform-as-package architecture, where a selected Platform package declares its startup contract, host adapter, and handled effects via manifest metadata and package modules. Uses 1-file-=1-module mapping with dot-separated import paths (`import billing.invoice`) and `spore.toml` for project configuration. Enforces visibility rules (pub/pub(pkg)/private) at module boundaries, supports multi-file compilation with explicit import resolution, and achieves supply-chain security through explicit function-level effects plus Platform metadata. Broader project/file effect ceilings remain follow-up work rather than part of the current shipped contract.
 
 ## Summary
 
-This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via dot-separated paths (`import billing.invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `.spore-lock` for reproducible builds, how dependencies are resolved without semantic versioning, and how IO is abstracted through selected Platform packages and startup contracts. Additional project-wide or file-level capability ceilings remain reserved for later SEP work instead of being part of the current implementation-aligned contract.
+This SEP specifies the complete module and package system for the Spore programming language. It defines how code is organized (one file = one module, no explicit `module` declarations), how modules are imported via dot-separated paths (`import billing.invoice`), how visibility is controlled (private / `pub(pkg)` / `pub`), how functions are content-addressed via a dual-hash scheme (signature hash + implementation AST hash using BLAKE3), how packages are structured around `spore.toml` manifests with a `.spore-lock` for reproducible builds, how dependencies are resolved without semantic versioning, and how IO is abstracted through selected Platform packages and startup contracts. Additional project-wide or file-level effect ceilings remain reserved for later SEP work instead of being part of the current implementation-aligned contract.
 
-The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Elixir/Python (dot-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the import/alias separation, reserved capability-ceiling design space, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
+The design synthesizes ideas from Unison (content-addressing), Roc (platform/package separation), Elixir/Python (dot-separated import paths), Elm/Go (file-based modules, no circular dependencies), and Rust (three-level visibility), while introducing novel concepts such as the import/alias separation, reserved effect-ceiling design space, and the dual-hash content-addressing scheme that decouples API stability from implementation pinning.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ Traditional package ecosystems rely on semantic versioning (semver) to communica
 
 Spore eliminates these problems by giving every function two content hashes computed via BLAKE3:
 
-1. **Signature hash (`sig`)**: Covers the function's public contract—parameter names, parameter types, return type, error types, effects, cost bound, capabilities, and generic constraints. This hash changes **only** when the API changes.
+1. **Signature hash (`sig`)**: Covers the function's public contract—parameter names, parameter types, return type, error types, effects, cost bound, effects, and generic constraints. This hash changes **only** when the API changes.
 2. **Implementation AST hash (`impl`)**: Covers the compiled AST of the function body. This hash changes whenever the implementation changes. Partial functions (those containing holes) have `impl = None`.
 
 This dual-hash scheme provides two independent guarantees:
@@ -58,9 +58,9 @@ A human-readable `version` field remains available in `spore.toml` for documenta
 
 In traditional languages, IO operations are built into the standard library, making them impossible to substitute for testing, impossible to sandbox for security, and impossible to port across runtimes without rewriting application code. Spore's Platform system, inspired by Roc, makes IO a pluggable concern:
 
-- **Application code declares capabilities explicitly**: Functions write `uses [...]` clauses and call platform-owned APIs; they do not issue raw host operations directly.
+- **Application code declares effects explicitly**: Functions write `uses [...]` clauses and call platform-owned APIs; they do not issue raw host operations directly.
 - **Platform packages define the runtime boundary**: A Platform package publishes foreign-function modules, a startup contract, and a host adapter.
-- **Alternative Platforms can preserve the same application surface**: CLI, test, web, or embedded runtimes can supply different implementations for the same declared capabilities.
+- **Alternative Platforms can preserve the same application surface**: CLI, test, web, or embedded runtimes can supply different implementations for the same declared effects.
 - **Supply-chain security comes from explicit effects plus Platform metadata**: A package cannot manufacture filesystem, process, or network access unless the selected Platform exposes and handles those operations.
 
 ## Guide-level explanation
@@ -79,7 +79,7 @@ The canonical source extension in docs and manifests is `.sp`. Compatibility-onl
 | `src/utils.sp` | `utils` |
 | `src/main.sp` | `main` |
 
-There is no `module` keyword — the filesystem **is** the declaration. Current implementations do not require or standardize an additional file-level `#![uses(...)]` ceiling; capability requirements remain attached to individual function signatures.
+There is no `module` keyword — the filesystem **is** the declaration. Current implementations do not require or standardize an additional file-level `#![uses(...)]` ceiling; effect requirements remain attached to individual function signatures.
 
 ```spore
 // src/billing/invoice.sp
@@ -138,7 +138,7 @@ Key rules:
 - Imported functions preserve the metadata needed for downstream checking:
   parameter/return types, `uses [...]`, declared `!errors`, generic parameters,
   and `where` bounds.
-- Imported `pub effect` / capability interfaces preserve operation signatures
+- Imported `pub effect` / effect interfaces preserve operation signatures
   across module boundaries, so `perform Effect.op(...)` keeps operation typing
   after import.
 - Ambiguous imported same-name functions or effect interfaces with conflicting
@@ -187,7 +187,7 @@ Three package types exist:
 
 | Type | Has Platform? | Can do IO? | Use Case |
 |---|---|---|---|
-| `package` | No | No (declares capability requirements) | Libraries, reusable components |
+| `package` | No | No (declares effect requirements) | Libraries, reusable components |
 | `application` | Yes | Yes (via Platform) | Executables, services |
 | `platform` | Is the Platform | Yes (raw syscalls) | Runtime providers |
 
@@ -219,8 +219,8 @@ fn main() -> () uses [Console, Exit] {
 For `basic-cli`, project mode currently requires `main() -> ()`. Explicit process termination is modeled as a Platform API (`basic_cli.cmd.exit`) requiring `uses [Exit]`; the runtime carries that as a structured project outcome and the CLI converts that outcome to a host exit status at the process boundary.
 
 In the current implementation, project mode also validates the selected entry's
-startup capability requirements against the selected Platform package's
-`[platform].handles` manifest field. A manifest-backed application may only
+startup effect requirements against the selected Platform package's
+`[platform].handled-effects` manifest field. A manifest-backed application may only
 start if its entry function's required effects are listed in that Platform
 contract metadata.
 
@@ -247,7 +247,7 @@ convention, not by special module semantics.
 
 #### Empty modules
 
-An empty `.sp` file is a valid module. It compiles successfully, exports nothing, and has no capabilities:
+An empty `.sp` file is a valid module. It compiles successfully, exports nothing, and has no effects:
 
 ```spore
 // src/billing/future.sp
@@ -259,7 +259,7 @@ $ spore check src/billing/future.sp
 
 [ok] billing.future
   exports: (none)
-  capabilities: []
+  effects: []
 ```
 
 Use cases include namespace placeholders, future feature stubs, and organizational markers within a package directory.
@@ -340,7 +340,7 @@ sig = BLAKE3(canonicalize(
     error_types,
     effect_annotations,
     cost_bound,
-    capability_requirements,
+    required_effects,
     generic_constraints
 ))
 ```
@@ -365,7 +365,7 @@ For partial functions (those containing holes), `impl = None`. When a hole is fi
 | Error type set: Add `[ValidationError]` | **Yes** | **Yes** |
 | Effects: `pure` → `deterministic` | **Yes** | **Yes** |
 | Cost bound: `≤ 3000` → `≤ 5000` | **Yes** | **Yes** |
-| Capabilities: Add `AuditLog` | **Yes** | **Yes** |
+| Effects: Add `AuditLog` | **Yes** | **Yes** |
 | Generic constraints: `T: Eq` → `T: Eq + Hash` | **Yes** | **Yes** |
 | Function body: Refactor internals | **No** | **Yes** |
 | Hole filling: Replace `?logic` with code | **No** | `None` → concrete |
@@ -536,7 +536,7 @@ alias invoice = billing.types.Invoice    // ERROR: 'invoice' conflicts with modu
 
 #### IO via Platform boundary
 
-Application code declares capability requirements and crosses the runtime
+Application code declares effect requirements and crosses the runtime
 boundary through the selected Platform package. In the current MVP,
 manifest-backed project mode resolves those calls through Platform-owned modules
 plus the Platform's startup contract:
@@ -552,14 +552,14 @@ uses [FileWrite]
 ```
 
 The type system tracks all effects. Effects propagate upward: if you call an
-operation requiring capability `C`, your function must also declare
+operation requiring effect `C`, your function must also declare
 `uses [C]`.
 
 #### Platform definition
 
 A Platform declares three things:
 
-1. **Capability set**: Which IO capabilities it handles.
+1. **Effect set**: Which IO effects it handles.
 2. **Startup contract**: The function contract that the selected module's
    startup function must satisfy.
 3. **Host adapter surface**: The package-owned adapter that bridges the
@@ -578,7 +578,7 @@ type = "platform"
 contract-module = "platform_contract"
 startup-contract = "main"
 adapter-function = "main_for_host"
-handles = ["Console", "FileRead", "FileWrite", "Env", "Spawn", "Exit"]
+handled-effects = ["Console", "FileRead", "FileWrite", "Env", "Spawn", "Exit"]
 ```
 
 ```spore
@@ -596,8 +596,8 @@ pub fn main_for_host(app_main: () -> ()) -> () {
 The hole-backed startup function in the Platform contract module is the
 authoritative startup signature. Applications targeting that Platform must
 implement the same startup function name plus the same parameter/return shape in
-their entry module. Current MVP capability requirements are checked separately:
-the selected startup entry's `uses [...]` set must fit within `[platform].handles`
+their entry module. Current MVP effect requirements are checked separately:
+the selected startup entry's `uses [...]` set must fit within `[platform].handled-effects`
 rather than being encoded into the adapter's callable Rust-facing shape. Any
 `spec` items attached to the Platform contract and the application
 implementation both apply.
@@ -637,7 +637,7 @@ path = "src/main.sp"
 
 The compiler verifies:
 
-- The selected startup entry's required capabilities are listed in the selected Platform package's `[platform]` metadata.
+- The selected startup entry's required effects are listed in the selected Platform package's `[platform]` metadata.
 - The startup function in the selected entry module matches the Platform contract module's startup contract.
 - The selected Platform package exports the named adapter from its contract module.
 - Test and mock Platforms may be substituted during testing, but a project binds to one Platform at a time.
@@ -695,45 +695,45 @@ Test result: ok. 3 passed; 0 failed
 
 #### Security model
 
-1. **Pure packages cannot perform IO**. They may declare capability requirements, but they do not carry Platform implementations.
+1. **Pure packages cannot perform IO**. They may declare effect requirements, but they do not carry Platform implementations.
 2. **Only Platform packages bridge to raw host operations**. No user package can invoke host operations without going through the selected Platform.
-3. **Capabilities are explicit**. An auditor can inspect any function's `uses` clause to know exactly what it can do.
+3. **Effects are explicit**. An auditor can inspect any function's `uses` clause to know exactly what it can do.
 4. **Supply-chain safety**: A downloaded package cannot gain hidden filesystem, process, or network access through an implicit stdlib shim; those surfaces must be provided by the selected Platform package.
 
 ```text
 $ spore audit billing-lib
 
 Package: billing-lib
-  required capabilities: [PaymentGateway, AuditLog]
+  required effects: [PaymentGateway, AuditLog]
 
-  Module capability breakdown:
+  Module effect breakdown:
     billing.invoice:  [PaymentGateway, AuditLog]
     billing.tax:      []  (pure)
     billing.types:    []  (pure)
 
   ✓ No RawSyscall usage
-  ✓ No undeclared capabilities
+  ✓ No undeclared effects
   ✓ Startup entry requirements fit the selected Platform metadata
 ```
 
-### Module capabilities
+### Module effects
 
-#### Capability checking today
+#### Effect checking today
 
-The current implementation-aligned model standardizes capability checking at two
+The current implementation-aligned model standardizes effect checking at two
 places:
 
 1. function signatures (`uses [...]`)
 2. selected Platform boundaries and Platform metadata
 
-Additional project-wide or file-level ceilings such as `[capabilities] allowed`
+Additional project-wide or file-level ceilings such as `[effects].declared`
 or `#![uses(...)]` remain reserved for follow-up design work. They are not part
 of the shipped MVP contract today, and tooling should not treat them as
 normative.
 
-#### Capability propagation
+#### Effect propagation
 
-Importing a module does **not** grant its capabilities. If you call a function that requires capability `C`, your function must also declare `uses [C]`. Capabilities propagate upward through the call graph.
+Importing a module does **not** grant its effects. If you call a function that requires effect `C`, your function must also declare `uses [C]`. Effects propagate upward through the call graph.
 
 ### Package management
 
@@ -766,7 +766,7 @@ test-framework = {
 ```
 
 Dependencies are declared **per-project** in `spore.toml`, not per-file.
-Additional project-wide capability ceilings remain future design work rather than
+Additional project-wide effect ceilings remain future design work rather than
 part of the current normative MVP surface.
 
 Package names are `kebab-case` and globally unique within a registry. Module paths within a package use `snake_case` segments.
@@ -853,15 +853,15 @@ Spore has **no central registry**. Packages are fetched from:
 
 Content hashes ensure integrity regardless of source. Community registries provide searchability but store only metadata—not code.
 
-#### Capability-based trust model
+#### Effect-based trust model
 
 Packages declare dependencies and Platform selection in `spore.toml`. Current
-implementation-aligned capability control does **not** add a separate
-project-wide `[capabilities] allowed` ceiling. Instead:
+implementation-aligned effect control does **not** add a separate
+project-wide `[effects].declared` ceiling. Instead:
 
 - libraries declare required effects on function signatures
 - the selected startup entry's required effects must be satisfied by the chosen
-  Platform package's `[platform].handles` metadata
+  Platform package's `[platform].handled-effects` metadata
 - tooling such as `spore audit` reports the resulting dependency/effect graph
 
 More granular dependency grants remain future design space rather than part of
@@ -1004,7 +1004,7 @@ impl = null                             # interface-only dependency
     verified-at = "2024-01-15T10:30:05Z"
 }
 
-[capabilities]
+[effects]
 "http" = ["NetConnect", "NetListen"]
 "io" = ["FileRead", "FileWrite"]
 
@@ -1084,9 +1084,9 @@ spore gc --all         # remove all cached entries
 
 GC algorithm: (1) scan all `.spore-lock` files in known project directories, (2) mark all referenced hashes, (3) delete unmarked entries from `.spore-store/`.
 
-### Fine-grained capabilities (design direction)
+### Fine-grained effects (design direction)
 
-For v0.1, Spore uses **coarse-grained** capability names in the language-level type system:
+For v0.1, Spore uses **coarse-grained** effect names in the language-level type system:
 
 ```spore
 fn read_config() -> Config ! IoError
@@ -1094,10 +1094,10 @@ fn read_config() -> Config ! IoError
 { ... }
 ```
 
-A future direction introduces **path-style fine-grained capabilities** in `spore.toml`:
+A future direction introduces **path-style fine-grained effects** in `spore.toml`:
 
 ```toml
-[capabilities]
+[effects]
 require = [
     "network:listen:8080",
     "filesystem:read:/data",
@@ -1106,7 +1106,7 @@ require = [
 ]
 ```
 
-The fine-grained capability tree:
+The fine-grained effect tree:
 
 ```text
 network:          filesystem:        env:            process:
@@ -1118,7 +1118,7 @@ network:          filesystem:        env:            process:
                                       monotonic       fast
 ```
 
-For v0.1, the language-level `uses [FileRead]` maps to coarse categories. Fine-grained path restrictions are enforced in `spore.toml` and at runtime via platform policy / host configuration, not in the type system. Promoting fine-grained capabilities into the type system is reserved for a future SEP.
+For v0.1, the language-level `uses [FileRead]` maps to coarse categories. Fine-grained path restrictions are enforced in `spore.toml` and at runtime via platform policy / host configuration, not in the type system. Promoting fine-grained effects into the type system is reserved for a future SEP.
 
 ### Publish and discovery flow
 
@@ -1168,7 +1168,7 @@ Holes by module:
   billing.invoice (partial)
     ?invoice_logic at line 12
       type: Invoice ! TaxError
-      capabilities: [PaymentGateway, AuditLog]
+      effects: [PaymentGateway, AuditLog]
       budget remaining: 2400 ops
 
   api.handler (partial — depends on partial billing.invoice)
@@ -1240,7 +1240,7 @@ $ spore check src/billing/types.sp
 
 [ok] billing.types
   exports: Invoice, InvoiceStatus, LineItem
-  capabilities: []
+  effects: []
   cost: 0 (types only)
 ```
 
@@ -1531,7 +1531,7 @@ Platforms are content-addressed packages like any other, following the same `sig
 |---|---|
 | **Concurrency** | `Spawn` is an effect surfaced by Platform-owned modules; runtimes may back it with a thread pool, tokio, or another scheduler |
 | **Package management** | Platforms are ordinary Spore packages, fetched and cached via the same content-addressed system |
-| **Capability system** | Platform defines the manifest-declared capability contract. Current implementations verify the selected startup entry's required effects against `Platform.handles`; broader whole-application enforcement remains follow-up work |
+| **Effect system** | Platform defines the manifest-declared effect contract. Current implementations verify the selected startup entry's required effects against `[platform].handled-effects`; broader whole-application enforcement remains follow-up work |
 | **Cost model** | Platform effects carry cost annotations: `File.read @cost(io=1)`. The compiler uses these for cost analysis |
 | **Compiler** | Resolves Platform package metadata and contract modules into the compiled runtime boundary |
 
@@ -1635,8 +1635,8 @@ spore lock --verify           Verify .spore-lock integrity
 #### Audit and inspection commands
 
 ```text
-spore audit [package]         Audit package capability usage
-spore audit --all             Full audit (capabilities, hashes, cycles, unused)
+spore audit [package]         Audit package effect usage
+spore audit --all             Full audit (effects, hashes, cycles, unused)
 spore deps [module]           Show dependency tree
 spore deps --reverse <mod>    Show what depends on a module
 spore deps --depth <N>        Limit tree depth
@@ -1695,7 +1695,7 @@ spore run src/main.sp
 spore deps                      # view current dependency tree
 spore update http               # update to latest commit
 spore test tests/http_test.sp   # verify tests still pass
-spore audit                     # check for capability changes
+spore audit                     # check for effect changes
 git add .spore-lock spore.toml
 git commit -m "Update http to latest"
 ```
@@ -1746,12 +1746,12 @@ git push origin main --tags
 | Term | Definition |
 |---|---|
 | **Content-addressed** | Identifying resources by the hash of their content rather than by name or location |
-| **Signature hash (`sig`)** | BLAKE3 hash of a function's public contract (params, return type, errors, capabilities, cost) |
+| **Signature hash (`sig`)** | BLAKE3 hash of a function's public contract (params, return type, errors, effects, cost) |
 | **Implementation hash (`impl`)** | BLAKE3 hash of a function's compiled AST; `None` for partial functions |
 | **Named alias** | A human-readable identifier mapping to a specific set of content hashes |
 | **Dependency graph** | DAG of module/package import relationships |
-| **Capability** | A declared permission for a function to perform a specific category of operation |
-| **Capability ceiling** | A reserved follow-up concept for module- or project-level capability caps; not part of the shipped MVP contract today |
+| **Effect** | A declared permission for a function to perform a specific category of operation |
+| **Effect ceiling** | A reserved follow-up concept for module- or project-level effect caps; not part of the shipped MVP contract today |
 | **Lock file (`.spore-lock`)** | Machine-generated file recording the full resolved dependency graph with hashes |
 | **Diamond dependency** | When the same module is reached via multiple paths in the dependency graph |
 | **Reproducible build** | A build that produces identical output from identical inputs (ensured by `impl` hashes) |
@@ -1781,7 +1781,7 @@ The dual-hash model is more conceptually complex than semver. However, the tooli
 
 ### Error messages
 
-Visibility violations, circular dependencies, startup-capability mismatches, and missing Platform bindings all produce structured, actionable diagnostics with `help:` suggestions.
+Visibility violations, circular dependencies, startup-effect mismatches, and missing Platform bindings all produce structured, actionable diagnostics with `help:` suggestions.
 
 ## Agent experience impact
 
@@ -1792,7 +1792,7 @@ The module system is designed for agent-friendly navigation:
 - Module names are deterministically derived from file paths.
 - Dependency graphs are acyclic DAGs, trivially traversable.
 - Visibility rules are encoded in the AST—an agent can enumerate a module's public API without human guidance.
-- Capability requirements are explicit in `uses [...]` clauses.
+- Effect requirements are explicit in `uses [...]` clauses.
 
 ### Content addressing for agents
 
@@ -1804,13 +1804,13 @@ Dual hashes give agents precise anchors:
 
 ### Structured diagnostics
 
-All compiler diagnostics (visibility violations, cycle detection, capability mismatches) are emitted in both human-readable and JSON formats, enabling agent tooling to parse and act on errors programmatically.
+All compiler diagnostics (visibility violations, cycle detection, effect mismatches) are emitted in both human-readable and JSON formats, enabling agent tooling to parse and act on errors programmatically.
 
 ## Structured representation / protocol impact
 
 ### `.spore-lock` as the canonical dependency record
 
-The `.spore-lock` file is a TOML document that encodes the full dependency graph with both `sig` and `impl` hashes, source locations, capability records, and verification timestamps:
+The `.spore-lock` file is a TOML document that encodes the full dependency graph with both `sig` and `impl` hashes, source locations, effect records, and verification timestamps:
 
 ```toml
 [[package]]
@@ -1829,7 +1829,7 @@ impl = "7b8d4f2a1e9c3d5b"
     verified-at = "2024-01-15T10:30:05Z"
 }
 
-[capabilities]
+[effects]
 "http" = ["NetListen", "NetConnect"]
 ```
 
@@ -1842,7 +1842,7 @@ For interface-only dependencies, the compiler can produce `.spore-sig` files con
 The compiler resolves the selected Platform package's metadata, startup contract,
 and imported host-facing modules into the compiled output. Current MVP behavior
 centers startup-contract validation plus the selected Platform package boundary;
-broader whole-program capability routing remains follow-up work.
+broader whole-program effect routing remains follow-up work.
 
 ## Diagnostics impact
 
@@ -1852,12 +1852,12 @@ broader whole-program capability routing remains follow-up work.
 |---|---|---|
 | `E3001` | Visibility violation | Accessing a private function from another module |
 | `E3002` | Circular dependency | Module A → B → A |
-| `E3003` | Capability declaration mismatch | Function calls an operation requiring `FileWrite` without declaring `uses [FileWrite]` |
+| `E3003` | Effect declaration mismatch | Function calls an operation requiring `FileWrite` without declaring `uses [FileWrite]` |
 | `E3004` | Signature change detected | `sig` hash mismatch in `.spore-lock` |
 | `E3005` | Alias chain | `pub alias` pointing to another alias |
 | `E3006` | Shadowing conflict | Import alias conflicts with module name |
 | `E4201` | Platform binding conflict | Project declares more than one Platform binding |
-| `E4202` | Unsupported startup capability | Selected startup entry requires a capability not listed in the Platform's `[platform].handles` metadata |
+| `E4202` | Unsupported startup effect | Selected startup entry requires an effect not listed in the Platform's `[platform].handled-effects` metadata |
 | `E4203` | Startup contract mismatch | Startup function signature doesn't match Platform requirement |
 
 ### Diagnostic structure
@@ -1886,7 +1886,7 @@ Diagnostics are available in both human-readable (terminal) and machine-readable
 
 5. **No circular dependencies**: Occasionally forces extraction of shared types into third modules, adding structural overhead. In practice, the Elm and Go communities have found this constraint beneficial.
 
-6. **No functors or parameterized modules**: Some patterns natural with OCaml/SML functors require more boilerplate with generics and capabilities. The trade-off is reduced conceptual surface area.
+6. **No functors or parameterized modules**: Some patterns natural with OCaml/SML functors require more boilerplate with generics and effects. The trade-off is reduced conceptual surface area.
 
 7. **Decentralized discovery**: Without a central registry, finding packages relies on community indices, search engines, and "awesome lists". This is a discoverability trade-off for resilience.
 
@@ -1918,7 +1918,7 @@ Fine-grained visibility like `pub(in path)` is rarely used and adds cognitive lo
 
 ### Functors / parameterized modules (OCaml-style)
 
-OCaml/SML functors are the most powerful module system in any language, but they add a separate "module language" that doubles the conceptual surface area. Spore's combination of generics (`where T: Constraint`) and capabilities (`uses [...]`) covers the same use cases with less overhead.
+OCaml/SML functors are the most powerful module system in any language, but they add a separate "module language" that doubles the conceptual surface area. Spore's combination of generics (`where T: Constraint`) and effects (`uses [...]`) covers the same use cases with less overhead.
 
 ### Built-in Platform (standard library IO)
 
@@ -1948,7 +1948,7 @@ Rust's `pub(crate)` visibility level and Cargo's `Cargo.lock` file informed Spor
 
 ### Koka
 
-Koka's algebraic effect system inspired Spore's integration of effects with module capabilities. Koka demonstrates that effects and modules should be designed together. Spore adds the Platform concept on top of Koka-style effects.
+Koka's algebraic effect system inspired Spore's integration of effects with module effects. Koka demonstrates that effects and modules should be designed together. Spore adds the Platform concept on top of Koka-style effects.
 
 ### Nix
 
@@ -2002,7 +2002,7 @@ The module system does not require wholesale adoption:
 
 2. **~~Cross-package `pub(pkg)` boundaries in workspaces~~**: Resolved — `pub(pkg)` restricts visibility to the current package (member) only. Items must be promoted to `pub` for cross-member access.
 
-3. **Capability granularity**: The current design uses coarse-grained capability names (e.g., `FileRead`, `NetConnect`). Should fine-grained capabilities (e.g., `filesystem:read:/data`) be part of the language-level type system or remain a tooling concern in `spore.toml`?
+3. **Effect granularity**: The current design uses coarse-grained effect names (e.g., `FileRead`, `NetConnect`). Should fine-grained effects (e.g., `filesystem:read:/data`) be part of the language-level type system or remain a tooling concern in `spore.toml`?
 
 4. **Platform versioning**: Platforms themselves evolve. When a Platform changes its handler interface, how are downstream applications notified? Is `spore --permit` sufficient, or do Platforms need a separate compatibility mechanism?
 
@@ -2012,7 +2012,7 @@ The module system does not require wholesale adoption:
 
 7. **Diamond dependencies with different `impl` hashes**: When two transitive dependencies require the same module with the same `sig` but different `impl` hashes, the current design allows both to coexist. Should the linker deduplicate? Should the developer be warned? What are the binary size implications?
 
-8. **Effect handler composition**: When an application-defined effect maps to Platform effects (e.g., `Logger` → `StdOut`/`StdErr`), how are capability requirements tracked through the composition? Is the current `uses [...]` propagation sufficient?
+8. **Effect handler composition**: When an application-defined effect maps to Platform effects (e.g., `Logger` → `StdOut`/`StdErr`), how are effect requirements tracked through the composition? Is the current `uses [...]` propagation sufficient?
 
 9. **Conditional compilation**: The `[features]` mechanism in `spore.toml` enables optional dependencies, but the interaction between features and content hashes is underspecified. Does enabling a feature change the `sig` hash?
 
@@ -2023,8 +2023,8 @@ The module system does not require wholesale adoption:
 ## Appendix A: Grammar summary
 
 ```text
-cap_list       ::= '[' capability (',' capability)* ']'
-capability     ::= UPPER_IDENT
+cap_list       ::= '[' effect (',' effect)* ']'
+effect     ::= UPPER_IDENT
 
 // Imports and aliases
 import_decl    ::= 'import' module_path ('as' IDENT)?
@@ -2122,7 +2122,7 @@ effect_fn      ::= 'fn' IDENT '(' params ')' '->' type
 
 | Command | Description |
 |---|---|
-| `spore audit` | Audit package capabilities, hashes, cycles |
+| `spore audit` | Audit package effects, hashes, cycles |
 | `spore deps` | Show dependency tree |
 | `spore deps --reverse <m>` | Show reverse dependencies |
 | `spore gc` | Clean unused cache entries |

--- a/seps/SEP-0009-standard-library.md
+++ b/seps/SEP-0009-standard-library.md
@@ -12,7 +12,7 @@ pr: null
 superseded_by: null
 ---
 
-> **Executive Summary**: Defines the standard library surface for Spore — the set of built-in types, functions, traits, and error types that every Spore program can rely on. Organizes the stdlib into a layered prelude (always-available primitives), core modules (opt-in via import), and platform-provided I/O bindings. Every function carries capability requirements and cost annotations per SEP-0003 and SEP-0004.
+> **Executive Summary**: Defines the standard library surface for Spore — the set of built-in types, functions, traits, and error types that every Spore program can rely on. Organizes the stdlib into a layered prelude (always-available primitives), core modules (opt-in via import), and platform-provided I/O bindings. Every function carries effect requirements and cost annotations per SEP-0003 and SEP-0004.
 
 # SEP-0009: Standard Library Surface
 
@@ -644,7 +644,7 @@ The current runtime stack for platform-backed I/O looks like this:
 │ [project].platform = "basic-cli"             │
 │ startup-contract = "main"                    │
 │ adapter-function = "main_for_host"           │
-│ handles = [..., "Exit"]                      │
+│ handled-effects = [..., "Exit"]              │
 ├──────────────────────────────────────────────┤
 │ Native Runtime (Rust/C/host embedding)       │
 └──────────────────────────────────────────────┘
@@ -653,7 +653,7 @@ The current runtime stack for platform-backed I/O looks like this:
 Key properties:
 
 1. **User code** imports Platform package modules directly today.
-2. **Each foreign surface** declares explicit capability requirements.
+2. **Each foreign surface** declares explicit effect requirements.
 3. **The selected Platform package** owns startup contracts and handled-effect metadata.
 4. **Some operations** may propagate structured runtime outcomes before host conversion (for example `Exit` in project mode).
 5. **Future stdlib wrappers** may layer above this, but they are not required for the current implementation.
@@ -682,7 +682,7 @@ The stdlib is designed for progressive discovery:
 2. **Module names are predictable**: `std.math`, `std.string`, `std.collections` follow standard conventions
 3. **Cost annotations are readable**: `cost O(len(list))` reads naturally
 4. **Error types are descriptive**: Enum variants like `NotFound(String)` carry context
-5. **No hidden effects**: Every I/O function explicitly declares its capability requirements
+5. **No hidden effects**: Every I/O function explicitly declares its effect requirements
 
 ## Agent experience impact
 
@@ -690,7 +690,7 @@ Agents benefit from:
 
 1. **Complete enumeration**: All stdlib functions are listed with signatures, enabling auto-completion
 2. **Cost contracts**: Agents can reason about algorithmic complexity when filling holes
-3. **Capability requirements**: Agents can verify that generated code satisfies capability constraints
+3. **Effect requirements**: Agents can verify that generated code satisfies effect constraints
 4. **Structured errors**: Error type hierarchy enables pattern-matching on failure modes
 5. **JSON protocol**: `std.json` provides the serialization layer for hole protocol (SEP-0005)
 
@@ -708,7 +708,7 @@ The stdlib is represented in the module system as:
       "params": [{"name": "list", "type": "List[A]"}, {"name": "f", "type": "(A) -> B"}],
       "return_type": "List[B]",
       "cost": "len(list) * cost(f) + O(len(list))",
-      "capabilities": []
+      "effects": []
     }
   ],
   "types": [
@@ -788,6 +788,6 @@ This is a new specification — no backward compatibility concerns. However:
 
 5. **Iterator protocol**: Should there be a lazy `Iterator[T]` trait instead of materializing `List[T]` for all operations? This would change cost signatures significantly.
 
-6. **Error recovery**: How should `PanicError` interact with the capability system? Should `panic` require a capability?
+6. **Error recovery**: How should `PanicError` interact with the effect system? Should `panic` require an effect?
 
 7. **FFI type mapping**: How do Spore types map to Rust/C types across the FFI boundary? (e.g., `Int` → `i64` or `BigInt`?)


### PR DESCRIPTION
## Proposal summary
- rename SEP-0003 to `effect system` and update the canonical path to `seps/SEP-0003-effect-system.md`
- replace capability-era terminology in glossary/spec prose with the frozen effect-family vocabulary, including `effect set`, `[effects].declared`, and `[platform].handled-effects`
- update in-repo references and generated metadata so links and examples stay coherent across the proposal set

## Linked discussion
- Terminology cutover coordinated with the matching implementation PRs in the active Spore ecosystem repos.

## Checklist
- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers
- This is a terminology-only alignment pass; it does not change the intended semantics of the effect system.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
