### PR TITLE
✨ feat: add canonical registry contract schema

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check SEP index
         run: uv run scripts/check_sep_index.py
 
+      - name: Check contract schemas
+        run: uv run scripts/check_contract_schemas.py
+
       - name: Validate SEP documents
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is the long-lived home for major language, tooling, and process 
 - `drafts/` — unnumbered proposal drafts under active discussion
 - `seps/` — numbered SEP documents and historical process records
 - `templates/` — authoring templates for new proposals
-- `schemas/` — machine-readable rules for SEP metadata
+- `schemas/` — machine-readable rules for SEP metadata and shared machine contracts
 - `scripts/` — repository validation and automation helpers
 
 ## Current entry points

--- a/prek.toml
+++ b/prek.toml
@@ -61,6 +61,7 @@ hooks = [
 repo = "local"
 hooks = [
   { id = "terminology-consistency", name = "terminology-consistency", entry = "uv run scripts/check_terminology_consistency.py", language = "system", files = "^(GLOSSARY\\.md|seps/SEP-000[3468]-.*\\.md)$", pass_filenames = false },
+  { id = "contract-schemas", name = "contract-schemas", entry = "uv run scripts/check_contract_schemas.py", language = "system", files = "^schemas/contracts/.*\\.json$|^scripts/check_contract_schemas\\.py$", pass_filenames = false },
   { id = "sep-index", name = "sep-index", entry = "uv run scripts/check_sep_index.py", language = "system", files = "^(drafts|seps)/.*\\.md$|^seps-index\\.json$", pass_filenames = false },
   { id = "sep-documents", name = "sep-documents", entry = "uv run scripts/validate_sep_documents.py", language = "system", files = "^(drafts|seps)/.*\\.md$", pass_filenames = true },
 ]

--- a/schemas/contracts/catalog.json
+++ b/schemas/contracts/catalog.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "catalog": "https://github.com/spore-lang/spore-evolution/schemas/contracts/catalog.json",
+  "owner": {
+    "repository": "spore-lang/spore-evolution",
+    "path": "schemas/contracts"
+  },
+  "schemas": [
+    {
+      "name": "spore-registry-index-config",
+      "title": "Spore registry sparse index config",
+      "version": 1,
+      "status": "active",
+      "file": "spore-registry-index-config.v1.schema.json",
+      "schema_id": "https://github.com/spore-lang/spore-evolution/schemas/contracts/spore-registry-index-config.v1.schema.json",
+      "instances": [
+        {
+          "producer": "spore-registry",
+          "route": "/api/v1/index/config.json"
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/contracts/spore-registry-index-config.v1.schema.json
+++ b/schemas/contracts/spore-registry-index-config.v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/spore-lang/spore-evolution/schemas/contracts/spore-registry-index-config.v1.schema.json",
+  "title": "Spore registry sparse index config",
+  "description": "Versioned sparse index configuration published by spore-registry and owned canonically by spore-evolution/schemas/contracts.",
+  "type": "object",
+  "required": [
+    "version",
+    "schema",
+    "schema_catalog",
+    "dl",
+    "api",
+    "protocol",
+    "hash_algorithm",
+    "auth_required"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "schema": {
+      "type": "string",
+      "const": "https://github.com/spore-lang/spore-evolution/schemas/contracts/spore-registry-index-config.v1.schema.json"
+    },
+    "schema_catalog": {
+      "type": "string",
+      "const": "https://github.com/spore-lang/spore-evolution/schemas/contracts/catalog.json"
+    },
+    "dl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "api": {
+      "type": "string",
+      "format": "uri"
+    },
+    "protocol": {
+      "type": "string",
+      "const": "sparse"
+    },
+    "hash_algorithm": {
+      "type": "string",
+      "minLength": 1
+    },
+    "auth_required": {
+      "type": "boolean"
+    }
+  }
+}

--- a/scripts/check_contract_schemas.py
+++ b/scripts/check_contract_schemas.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env -S uv run
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONTRACTS_ROOT = ROOT / "schemas" / "contracts"
+CATALOG_PATH = CONTRACTS_ROOT / "catalog.json"
+CATALOG_URL = "https://github.com/spore-lang/spore-evolution/schemas/contracts/catalog.json"
+CATALOG_VERSION = 1
+OWNER = {
+    "repository": "spore-lang/spore-evolution",
+    "path": "schemas/contracts",
+}
+JSON_SCHEMA_DRAFT = "https://json-schema.org/draft/2020-12/schema"
+
+
+def load_json(path: Path) -> tuple[object | None, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except OSError as exc:
+        return None, f"{path}: failed to read JSON file ({exc})"
+    except json.JSONDecodeError as exc:
+        return (
+            None,
+            f"{path}: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}",
+        )
+
+
+def require_string(entry: dict[str, object], key: str, errors: list[str], scope: str) -> str | None:
+    value = entry.get(key)
+    if isinstance(value, str) and value:
+        return value
+    errors.append(f"{scope}: `{key}` must be a non-empty string")
+    return None
+
+
+def require_int(entry: dict[str, object], key: str, errors: list[str], scope: str) -> int | None:
+    value = entry.get(key)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    errors.append(f"{scope}: `{key}` must be an integer")
+    return None
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    if not CATALOG_PATH.exists():
+        print(f"Contract schema catalog is missing: {CATALOG_PATH}", file=sys.stderr)
+        return 1
+
+    catalog, load_error = load_json(CATALOG_PATH)
+    if load_error is not None:
+        print(load_error, file=sys.stderr)
+        return 1
+
+    if not isinstance(catalog, dict):
+        print("Contract schema catalog must be a JSON object.", file=sys.stderr)
+        return 1
+
+    if catalog.get("version") != CATALOG_VERSION:
+        errors.append(f"{CATALOG_PATH}: `version` must be {CATALOG_VERSION}")
+
+    if catalog.get("catalog") != CATALOG_URL:
+        errors.append(f"{CATALOG_PATH}: `catalog` must be `{CATALOG_URL}`")
+
+    if catalog.get("owner") != OWNER:
+        errors.append(
+            f"{CATALOG_PATH}: `owner` must be {json.dumps(OWNER, ensure_ascii=False, sort_keys=True)}"
+        )
+
+    schemas = catalog.get("schemas")
+    if not isinstance(schemas, list) or not schemas:
+        errors.append(f"{CATALOG_PATH}: `schemas` must be a non-empty array")
+        schemas = []
+
+    seen_ids: set[str] = set()
+    for index, entry in enumerate(schemas, start=1):
+        scope = f"{CATALOG_PATH} schema #{index}"
+        if not isinstance(entry, dict):
+            errors.append(f"{scope}: entry must be a JSON object")
+            continue
+
+        name = require_string(entry, "name", errors, scope)
+        title = require_string(entry, "title", errors, scope)
+        file_name = require_string(entry, "file", errors, scope)
+        schema_id = require_string(entry, "schema_id", errors, scope)
+        version = require_int(entry, "version", errors, scope)
+
+        if schema_id is not None:
+            if schema_id in seen_ids:
+                errors.append(f"{scope}: duplicate `schema_id` `{schema_id}`")
+            seen_ids.add(schema_id)
+
+        if version is not None and file_name is not None and f".v{version}." not in file_name:
+            errors.append(f"{scope}: file `{file_name}` must include `.v{version}.`")
+
+        if file_name is None:
+            continue
+
+        schema_path = CONTRACTS_ROOT / file_name
+        if not schema_path.exists():
+            errors.append(f"{scope}: schema file does not exist: {schema_path}")
+            continue
+
+        schema, load_error = load_json(schema_path)
+        if load_error is not None:
+            errors.append(load_error)
+            continue
+
+        if not isinstance(schema, dict):
+            errors.append(f"{schema_path}: schema file must be a JSON object")
+            continue
+
+        if schema.get("$schema") != JSON_SCHEMA_DRAFT:
+            errors.append(f"{schema_path}: `$schema` must be `{JSON_SCHEMA_DRAFT}`")
+
+        if schema_id is not None and schema.get("$id") != schema_id:
+            errors.append(f"{schema_path}: `$id` must match catalog `schema_id`")
+
+        if title is not None and schema.get("title") != title:
+            errors.append(f"{schema_path}: `title` must match catalog entry")
+
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            errors.append(f"{schema_path}: `properties` must be a JSON object")
+            continue
+
+        version_prop = properties.get("version")
+        if not isinstance(version_prop, dict) or version_prop.get("const") != version:
+            errors.append(f"{schema_path}: `properties.version.const` must match catalog version")
+
+        schema_prop = properties.get("schema")
+        if not isinstance(schema_prop, dict) or schema_prop.get("const") != schema_id:
+            errors.append(f"{schema_path}: `properties.schema.const` must match `$id`")
+
+        catalog_prop = properties.get("schema_catalog")
+        if not isinstance(catalog_prop, dict) or catalog_prop.get("const") != CATALOG_URL:
+            errors.append(f"{schema_path}: `properties.schema_catalog.const` must be catalog URL")
+
+        if name is not None:
+            expected_prefix = f"{name}.v"
+            if not file_name.startswith(expected_prefix):
+                errors.append(f"{scope}: file `{file_name}` must start with `{expected_prefix}`")
+
+    if errors:
+        print("Contract schema validation failed:\n", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(schemas)} contract schema(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_contract_schemas.py
+++ b/scripts/check_contract_schemas.py
@@ -46,6 +46,18 @@ def require_int(entry: dict[str, object], key: str, errors: list[str], scope: st
     return None
 
 
+def resolve_schema_path(file_name: str) -> tuple[Path | None, str | None]:
+    contracts_root = CONTRACTS_ROOT.resolve()
+    schema_path = (CONTRACTS_ROOT / file_name).resolve()
+
+    try:
+        schema_path.relative_to(contracts_root)
+    except ValueError:
+        return None, f"`file` must stay within `{CONTRACTS_ROOT}`: {file_name}"
+
+    return schema_path, None
+
+
 def main() -> int:
     errors: list[str] = []
 
@@ -102,7 +114,11 @@ def main() -> int:
         if file_name is None:
             continue
 
-        schema_path = CONTRACTS_ROOT / file_name
+        schema_path, path_error = resolve_schema_path(file_name)
+        if path_error is not None:
+            errors.append(f"{scope}: {path_error}")
+            continue
+
         if not schema_path.exists():
             errors.append(f"{scope}: schema file does not exist: {schema_path}")
             continue


### PR DESCRIPTION
## Summary
- add machine-readable contract catalog and schema for the registry index config
- validate contract schema consistency in local hooks and CI
- document the tooling direction in the README

## Testing
- uv run scripts/check_contract_schemas.py