### PR TITLE
🔧 chore: move actionlint into prek

### DIFF
--- a/.github/workflows/ci-static-checks.yml
+++ b/.github/workflows/ci-static-checks.yml
@@ -12,17 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  actionlint:
-    name: actionlint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.12
-
   prek:
     name: prek
     runs-on: ubuntu-latest

--- a/prek.toml
+++ b/prek.toml
@@ -30,6 +30,13 @@ hooks = [
 ]
 
 [[repos]]
+repo = "https://github.com/rhysd/actionlint"
+rev = "v1.7.12"
+hooks = [
+  { id = "actionlint" },
+]
+
+[[repos]]
 repo = "https://github.com/crate-ci/typos"
 rev = "v1.33.1"
 hooks = [


### PR DESCRIPTION
## Summary
- 🔧 chore: move actionlint into prek

## Validation
- Compared branch against origin/main
- No additional local checks were run
