### PR TITLE
🔧 chore: bump zendev to v0.0.5

### DIFF
--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Check PR title
-        uses: zrr1999/zendev-actions/validate-title@9013ad848b32d287d0258fdbc9f51e350b8eca33
+        uses: zrr1999/zendev/actions/validate-title@v0.0.5
         with:
           text: ${{ github.event.pull_request.title }}
 

--- a/prek.toml
+++ b/prek.toml
@@ -52,7 +52,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/zrr1999/zendev"
-rev = "e2a5243899467d0df1cb1ab0ddcb18f3ef33d97b"
+rev = "v0.0.5"
 hooks = [
   { id = "zendev-commit-msg" },
 ]


### PR DESCRIPTION
## Summary
- 🔧 chore: bump zendev to v0.0.5

## Validation
- Compared branch against origin/main
- No additional local checks were run
