### PR TITLE
📝 docs: clarify SEP release safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ Proposal repository for the Spore programming project.
 
 This repository is the long-lived home for major language, tooling, and process proposals that affect Spore as a whole.
 
+## Release-safety notice
+
+The SEPs in this repository are design records and proposal texts. They are not,
+by themselves, the current implementation truth, a compatibility guarantee, or a
+public release contract for Spore.
+
+All numbered SEPs are currently `Draft`. During this bootstrap phase, readers
+should expect some examples and terminology to lag behind the implementation.
+For current release behavior, installation guidance, supported syntax, and
+implementation status, use the implementation repository first:
+
+- [`spore/README.md`](https://github.com/spore-lang/spore/blob/main/README.md)
+- [`spore/docs/DESIGN.md`](https://github.com/spore-lang/spore/blob/main/docs/DESIGN.md)
+
+In particular, older SEP examples may use historical spellings such as
+`String`/`Unit`/`Int`/`Float` or scalar cost forms such as `cost ≤ expr` and
+`@cost`. Current implementation-facing docs use the active primitive spellings
+and the four-slot `cost [compute, alloc, io, parallel]` form where applicable.
+
 ## What lives here
 
 - `drafts/` — unnumbered proposal drafts under active discussion

--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@ public release contract for Spore.
 All numbered SEPs are currently `Draft`. During this bootstrap phase, readers
 should expect some examples and terminology to lag behind the implementation.
 For current release behavior, installation guidance, supported syntax, and
-implementation status, use the implementation repository first:
-
-- [`spore/README.md`](https://github.com/spore-lang/spore/blob/main/README.md)
-- [`spore/docs/DESIGN.md`](https://github.com/spore-lang/spore/blob/main/docs/DESIGN.md)
+implementation status, use the implementation repository first: `spore/README.md`
+and `spore/docs/DESIGN.md`.
 
 In particular, older SEP examples may use historical spellings such as
 `String`/`Unit`/`Int`/`Float` or scalar cost forms such as `cost ≤ expr` and

--- a/seps/SEP-0000-process.md
+++ b/seps/SEP-0000-process.md
@@ -217,10 +217,8 @@ SEP status should describe the **decision state of the proposal**, not the rollo
 SEPs are design records for language, tooling, and process discussion. They are
 not, by themselves, the current implementation truth, a compatibility guarantee,
 or a public release contract. Public readers who need current release behavior
-should start with the implementation repository, especially
-[`spore/README.md`](https://github.com/spore-lang/spore/blob/main/README.md)
-and
-[`spore/docs/DESIGN.md`](https://github.com/spore-lang/spore/blob/main/docs/DESIGN.md).
+should start with the implementation repository, especially `spore/README.md`
+and `spore/docs/DESIGN.md`.
 
 In particular:
 

--- a/seps/SEP-0000-process.md
+++ b/seps/SEP-0000-process.md
@@ -214,6 +214,14 @@ Maintainers may still add merge-summary comments when useful, but Spore does not
 
 SEP status should describe the **decision state of the proposal**, not the rollout or maturity state of its implementation.
 
+SEPs are design records for language, tooling, and process discussion. They are
+not, by themselves, the current implementation truth, a compatibility guarantee,
+or a public release contract. Public readers who need current release behavior
+should start with the implementation repository, especially
+[`spore/README.md`](https://github.com/spore-lang/spore/blob/main/README.md)
+and
+[`spore/docs/DESIGN.md`](https://github.com/spore-lang/spore/blob/main/docs/DESIGN.md).
+
 In particular:
 
 - `Accepted` means the design direction is approved
@@ -235,9 +243,10 @@ This separation keeps SEP status focused on design governance rather than releas
 
 During Spore's bootstrap phase, maintainers may keep repository-defining SEPs in `Draft`
 while the process, terminology, and review mechanics are still settling. In this phase,
-`Draft` means "still revisable as process text," not "non-authoritative." Repository
-planning, templates, and follow-on SEPs may still treat these draft SEPs as the current
-design baseline until they are explicitly superseded or replaced.
+`Draft` means "still revisable as process text," not "released behavior." Repository
+planning, templates, and follow-on SEPs may still treat these draft SEPs as the working
+design baseline until they are explicitly superseded or replaced, but external release
+expectations should come from implementation docs, release notes, and shipped artifacts.
 
 ## Roles and responsibilities
 

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -22,6 +22,14 @@ superseded_by: null
 
 This SEP specifies Spore's compile-time cost analysis system — a three-tier mechanism that statically determines or verifies upper bounds on resource consumption for every function. The system operates along four cost dimensions — **compute(op)**, **alloc(cell)**, **io(call)**, **parallel(lane)** — and leverages the fact that Spore has **no loops** (all iteration is expressed via recursion and higher-order functions) to make cost analysis equivalent to recursion analysis.
 
+> **Release-safety note**: This is a `Draft` design record, not the current
+> implementation contract. Some examples below intentionally preserve older
+> proposal syntax such as `cost ≤ expr` and `@unbounded`. For current release
+> behavior and active cost syntax, start with
+> [`spore/README.md`](https://github.com/spore-lang/spore/blob/main/README.md),
+> which documents the four-slot `cost [compute, alloc, io, parallel]` form used
+> by implementation-facing examples.
+
 The three tiers are:
 
 1. **Tier 1 — Automatic structural recursion detection** (~70% of functions): the compiler detects that one argument strictly decreases along a well-founded relation on every recursive call and automatically infers a cost bound.

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -25,10 +25,10 @@ This SEP specifies Spore's compile-time cost analysis system — a three-tier me
 > **Release-safety note**: This is a `Draft` design record, not the current
 > implementation contract. Some examples below intentionally preserve older
 > proposal syntax such as `cost ≤ expr` and `@unbounded`. For current release
-> behavior and active cost syntax, start with
-> [`spore/README.md`](https://github.com/spore-lang/spore/blob/main/README.md),
-> which documents the four-slot `cost [compute, alloc, io, parallel]` form used
-> by implementation-facing examples.
+> behavior and active cost syntax, start with the implementation repository's
+> `spore/README.md`, which documents the four-slot
+> `cost [compute, alloc, io, parallel]` form used by implementation-facing
+> examples.
 
 The three tiers are:
 


### PR DESCRIPTION
## Proposal summary

- Add a repository-level release-safety notice clarifying that Draft SEPs are design records, not implementation truth or public release contracts.
- Point readers to the implementation repository README and design docs for current release behavior without using private GitHub blob links that fail unauthenticated link checks.
- Caveat the draft cost-analysis SEP where older cost syntax is likely to be copied.

## Linked discussion

Canonical discussion: https://github.com/spore-lang/spore-evolution/discussions/4

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

Validation run locally:

- uvx prek run --all-files
- uv run scripts/check_sep_index.py
- uv run scripts/check_contract_schemas.py
- uv run scripts/validate_sep_documents.py
- git diff --check

Kept changes focused on release-safety wording and link-check-safe implementation doc references; did not mass-modernize normative SEP syntax or change language design.