### PR TITLE
👷 ci: align Python tooling with 3.13

### DIFF
--- a/.github/workflows/ci-static-checks.yml
+++ b/.github/workflows/ci-static-checks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Check SEP index
         run: uv run scripts/check_sep_index.py


### PR DESCRIPTION
## Summary

- Update GitHub Actions uv setup from Python 3.12 to Python 3.13 for static checks and repository script checks.

## Validation

- `uv run --python 3.13 scripts/check_sep_index.py`
- `uv run --python 3.13 scripts/check_contract_schemas.py`
- `uv run --python 3.13 scripts/validate_sep_documents.py`
- `uvx --python 3.13 prek run --all-files`
- `git diff --check`

## Notes

- No blockers.