### PR TITLE
📝 docs: align compositional semantics slice across SEPs

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -8,7 +8,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **`Add`** (SEP-0002): Compiler-known trait for the `+` operator, enabling operator overloading on user-defined types.
 
-**`@allow`** (SEP-0004): Annotation that locally suppresses a cost budget violation, used as a second-tier escape for cost analysis.
+**`@allows`** (SEP-0004): Annotation that locally suppresses a cost budget violation, used as a second-tier escape for cost analysis.
 
 **`@unbounded`** (SEP-0004): Annotation declaring that a function's cost is intentionally unanalyzed, opting out of cost verification entirely.
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -164,6 +164,10 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **Startup function** (SEP-0008): The callable inside the selected entry module that satisfies the Platform's startup contract. Today this is usually `main`.
 
+**`Str`** (SEP-0002): The UTF-8 text primitive in Spore surface syntax (not `String`). Single Unicode scalars use length-1 `Str` values; there is no separate `Char` type (see implementation PR #113).
+
+**Default literals** (SEP-0002): In the reference compiler (`sporec-typeck`), unsuffixed integer literals synthesize as **`I64`** and float literals as **`F64`**, unless a signature or context fixes another width (see metavariables **ι** / **φ** in SEP-0002 for other fixed sizes).
+
 ## T
 
 **`Task[T]`** (SEP-0007): Typed future representing an asynchronous computation that will produce a value of type `T`.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -6,9 +6,9 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **Atomic effect** (SEP-0003): One of the 10 built-in intent-oriented atomic effects in Spore's effect system: Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit. In compiler/tooling contexts, these effect names form the checked effect set.
 
-**`Add`** (SEP-0002): Compiler-known trait for the `+` operator, enabling operator overloading on user-defined types.
+**`Add`** (SEP-0002): Compiler-known trait for the `+` operator on types that explicitly implement addition.
 
-**`@allows`** (SEP-0004): Annotation that locally suppresses a cost budget violation, used as a second-tier escape for cost analysis.
+**`@allows`** (SEP-0002, SEP-0003, SEP-0005): Hole-level annotation that restricts which candidate functions may be used to fill a specific Hole. It cannot suppress resource checks.
 
 **`@unbounded`** (SEP-0004): Annotation declaring that a function's cost is intentionally unanalyzed, opting out of cost verification entirely.
 
@@ -38,9 +38,11 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **Cost dimension** (SEP-0004): One of four orthogonal resource axes in a CostVector: compute, alloc, io, parallel.
 
-**Cost expression (CostExpr)** (SEP-0004): Arithmetic expression over cost variables, restricted to `+`, `×`, `^const`, `log`, `max`, `min` to ensure decidability.
+**Cost expression (CostExpr)** (SEP-0004): Arithmetic expression over compile-time Index symbols and `cost(f)` summaries. CostExpr does not reference ordinary runtime values.
 
 **CostVector** (SEP-0004): A 4-tuple `(compute(op), alloc(cell), io(call), parallel(lane))` representing multidimensional resource usage.
+
+**`Count[N]`** (SEP-0002, SEP-0009): Runtime non-negative count value that carries a compile-time Index parameter `N`. Cost analysis sees `N`, not the runtime integer.
 
 ## D
 
@@ -54,7 +56,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **`Display`** (SEP-0002): Compiler-known trait for user-facing string representation.
 
-**`Div`** (SEP-0002): Compiler-known trait for the `/` operator, enabling operator overloading on user-defined types.
+**`Div`** (SEP-0002): Compiler-known trait for the `/` operator on types that explicitly implement division.
 
 **Diagnostic code** (SEP-0006): Structured error/warning identifier in the format `X0NNN`, where X is a category letter: E (type error), C (effect), K (cost), M (module), W (warning).
 
@@ -102,13 +104,15 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **Import resolution** (SEP-0008): The process of mapping `import pkg.module` declarations to concrete module files and verifying symbol visibility.
 
+**Index** (SEP-0002, SEP-0004): Compile-time non-negative size kind used by cost analysis. Index parameters such as `N: Index` are the only variables that may appear directly in CostExpr.
+
 ## L
 
 **Lane** (SEP-0007): The parallel cost dimension — each `spawn` creates a new lane, tracked in CostVector's `parallel` field.
 
 ## M
 
-**`Mul`** (SEP-0002): Compiler-known trait for the `*` operator, enabling operator overloading on user-defined types.
+**`Mul`** (SEP-0002): Compiler-known trait for the `*` operator on types that explicitly implement multiplication.
 
 **Module** (SEP-0008): A single Spore source file that declares its own visibility boundaries and effect requirements.
 
@@ -150,7 +154,7 @@ Unified terminology index for Spore. Each term links to the SEP where it is auth
 
 **`spawn`** (SEP-0007): Expression that creates a new `Task[T]` for concurrent execution, requiring the `Spawn` effect.
 
-**`Sub`** (SEP-0002): Compiler-known trait for the `-` operator, enabling operator overloading on user-defined types.
+**`Sub`** (SEP-0002): Compiler-known trait for the `-` operator on types that explicitly implement subtraction.
 
 **Struct** (SEP-0002): Product type with named fields, defined as `struct Name { field1: T1, field2: T2 }`.
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ For current release behavior, installation guidance, supported syntax, and
 implementation status, use the implementation repository first: `spore/README.md`
 and `spore/docs/DESIGN.md`.
 
-In particular, older SEP examples may use historical spellings such as
-`String`/`Unit`/`Int`/`Float` or scalar cost forms such as `cost ≤ expr` and
-`@cost`. Current implementation-facing docs use the active primitive spellings
-and the four-slot `cost [compute, alloc, io, parallel]` form where applicable.
+**Authoritative surface typing (as of the alignment pass):** default unsuffixed literals are **`I64`** (integer) and **`F64`** (float); UTF-8 text is **`Str`**; there is **no `Char`**. Full rules, metavariables **ι** / **φ** for other widths, and “Platform decides” ABI details are in [SEP-0002 §3.1 / Summary](seps/SEP-0002-type-system.md).
 
 ## What lives here
 

--- a/prek.toml
+++ b/prek.toml
@@ -1,6 +1,5 @@
 [[repos]]
-repo = "https://github.com/pre-commit/pre-commit-hooks"
-rev = "v6.0.0"
+repo = "builtin"
 hooks = [
   { id = "check-added-large-files" },
   { id = "check-case-conflict" },

--- a/schemas/contracts/catalog.json
+++ b/schemas/contracts/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "catalog": "https://github.com/spore-lang/spore-evolution/schemas/contracts/catalog.json",
+  "catalog": "https://raw.githubusercontent.com/spore-lang/spore-evolution/main/schemas/contracts/catalog.json",
   "owner": {
     "repository": "spore-lang/spore-evolution",
     "path": "schemas/contracts"
@@ -12,7 +12,7 @@
       "version": 1,
       "status": "active",
       "file": "spore-registry-index-config.v1.schema.json",
-      "schema_id": "https://github.com/spore-lang/spore-evolution/schemas/contracts/spore-registry-index-config.v1.schema.json",
+      "schema_id": "https://raw.githubusercontent.com/spore-lang/spore-evolution/main/schemas/contracts/spore-registry-index-config.v1.schema.json",
       "instances": [
         {
           "producer": "spore-registry",

--- a/schemas/contracts/spore-registry-index-config.v1.schema.json
+++ b/schemas/contracts/spore-registry-index-config.v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/spore-lang/spore-evolution/schemas/contracts/spore-registry-index-config.v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/spore-lang/spore-evolution/main/schemas/contracts/spore-registry-index-config.v1.schema.json",
   "title": "Spore registry sparse index config",
   "description": "Versioned sparse index configuration published by spore-registry and owned canonically by spore-evolution/schemas/contracts.",
   "type": "object",
@@ -22,11 +22,11 @@
     },
     "schema": {
       "type": "string",
-      "const": "https://github.com/spore-lang/spore-evolution/schemas/contracts/spore-registry-index-config.v1.schema.json"
+      "const": "https://raw.githubusercontent.com/spore-lang/spore-evolution/main/schemas/contracts/spore-registry-index-config.v1.schema.json"
     },
     "schema_catalog": {
       "type": "string",
-      "const": "https://github.com/spore-lang/spore-evolution/schemas/contracts/catalog.json"
+      "const": "https://raw.githubusercontent.com/spore-lang/spore-evolution/main/schemas/contracts/catalog.json"
     },
     "dl": {
       "type": "string",

--- a/schemas/sep-frontmatter.schema.json
+++ b/schemas/sep-frontmatter.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/spore-lang/spore-evolution/schemas/sep-frontmatter.schema.json",
+  "$id": "https://raw.githubusercontent.com/spore-lang/spore-evolution/main/schemas/sep-frontmatter.schema.json",
   "title": "SEP front matter",
   "type": "object",
   "required": [

--- a/scripts/check_contract_schemas.py
+++ b/scripts/check_contract_schemas.py
@@ -9,7 +9,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 CONTRACTS_ROOT = ROOT / "schemas" / "contracts"
 CATALOG_PATH = CONTRACTS_ROOT / "catalog.json"
-CATALOG_URL = "https://github.com/spore-lang/spore-evolution/schemas/contracts/catalog.json"
+CATALOG_URL = "https://raw.githubusercontent.com/spore-lang/spore-evolution/main/schemas/contracts/catalog.json"
 CATALOG_VERSION = 1
 OWNER = {
     "repository": "spore-lang/spore-evolution",

--- a/scripts/check_terminology_consistency.py
+++ b/scripts/check_terminology_consistency.py
@@ -35,7 +35,7 @@ FORBIDDEN_PATTERNS = (
     ),
     (
         re.compile(r"cost\s*<="),
-        "retired ASCII syntax `cost <=`; use `cost ≤`",
+        "retired ASCII syntax `cost <=`; use four-slot `cost [compute, alloc, io, parallel]`",
     ),
 )
 

--- a/scripts/normalize_spore_surface_types.py
+++ b/scripts/normalize_spore_surface_types.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env -S uv run
+
+"""Rewrite legacy surface names inside ```spore / ```Spore fences only.
+
+Substitutions (whole words):
+- String -> Str
+- Int -> I64
+- Float -> F64
+
+Does not modify other code fences (Rust, text, etc.)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from sep_common import ROOT
+
+# ```spore or ```Spore, consume optional info string after language token.
+FENCE_OPEN = re.compile(r"^```[Ss]pore[^\n]*\n", re.MULTILINE)
+FENCE_CLOSE = re.compile(r"^```\s*$", re.MULTILINE)
+
+WORD_STRING = re.compile(r"\bString\b")
+WORD_INT = re.compile(r"\bInt\b")
+WORD_FLOAT = re.compile(r"\bFloat\b")
+
+
+def transform_spore_block(body: str) -> str:
+    body = WORD_STRING.sub("Str", body)
+    body = WORD_INT.sub("I64", body)
+    body = WORD_FLOAT.sub("F64", body)
+    return body
+
+
+def iter_spore_blocks(text: str) -> list[tuple[int, int, str, int]]:
+    """(body_start, body_end, body, next_scan_pos). body_end starts at ``` line."""
+    spans: list[tuple[int, int, str, int]] = []
+    pos = 0
+    while True:
+        m_open = FENCE_OPEN.search(text, pos)
+        if not m_open:
+            break
+        body_start = m_open.end()
+        m_close = FENCE_CLOSE.search(text[body_start:])
+        if not m_close:
+            break
+        body_end = body_start + m_close.start()
+        body = text[body_start:body_end]
+        next_pos = body_start + m_close.end()
+        spans.append((body_start, body_end, body, next_pos))
+        pos = next_pos
+    return spans
+
+
+def process_file(path: Path) -> bool:
+    raw = path.read_text(encoding="utf-8")
+    spans = iter_spore_blocks(raw)
+    if not spans:
+        return False
+
+    pieces: list[str] = []
+    last = 0
+    changed = False
+    for body_start, body_end, body, next_pos in spans:
+        pieces.append(raw[last:body_start])
+        new_body = transform_spore_block(body)
+        if new_body != body:
+            changed = True
+        pieces.append(new_body)
+        # Keep original closing fence + prose between fences verbatim.
+        pieces.append(raw[body_end:next_pos])
+        last = next_pos
+    pieces.append(raw[last:])
+    if not changed:
+        return False
+    path.write_text("".join(pieces), encoding="utf-8", newline="\n")
+    return True
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(p) for p in argv[1:]] if len(argv) > 1 else sorted((ROOT / "seps").glob("SEP-*.md"))
+    updated = sum(process_file(p) for p in paths)
+    print(f"Updated {updated} file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/seps/SEP-0000-process.md
+++ b/seps/SEP-0000-process.md
@@ -410,7 +410,7 @@ authors:
   - Your Name
 created: YYYY-MM-DD
 requires: []
-discussion: "https://github.com/spore-lang/spore-evolution/discussions/123"
+discussion: "https://github.com/spore-lang/spore-evolution/discussions"
 pr: "https://github.com/spore-lang/spore-evolution/pull/45"
 superseded_by: null
 ---

--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -18,7 +18,7 @@ superseded_by: null
 
 ## Summary
 
-This proposal defines the complete core syntax and function signature system for the Spore programming language v0.1. Spore is an expression-based, statically typed language with effect tracking, explicit resource cost tracking, and guaranteed tail-call optimization. The language draws from Rust, OCaml, Roc, Gleam, and Elm, combining curly-brace block scoping with Rust-style semicolon semantics, algebraic data types, exhaustive pattern matching, and a novel function signature system that encodes generic constraints (`where`), effect requirements (`uses`), error sets (`!`), and cost bounds (`cost`) as composable clauses. Spore deliberately eliminates loops in favor of recursion and higher-order functions, uses square brackets for generics (`List[Int]`), auto-infers effect properties from the `uses` set, and provides a pipe operator (`|>`) for readable data-flow composition.
+This proposal defines the complete core syntax and function signature system for the Spore programming language v0.1. Spore is an expression-based, statically typed language with effect tracking, explicit resource cost tracking, and guaranteed tail-call optimization. The language draws from Rust, OCaml, Roc, Gleam, and Elm, combining curly-brace block scoping with Rust-style semicolon semantics, algebraic data types, exhaustive pattern matching, and a novel function signature system that encodes generic constraints (`where`), effect requirements (`uses`), error sets (`!`), and a four-slot **`cost [compute, alloc, io, parallel]`** clause as composable signature metadata. Spore deliberately eliminates loops in favor of recursion and higher-order functions, uses square brackets for generics (`List[Int]`), auto-infers effect properties from the `uses` set, and provides a pipe operator (`|>`) for readable data-flow composition.
 
 ## Motivation
 
@@ -47,7 +47,7 @@ This section introduces Spore's syntax from a user's perspective, building from 
 The simplest Spore function looks familiar to anyone who has used Rust, Go, or TypeScript:
 
 ```spore
-fn add(a: Int, b: Int) -> Int {
+fn add(a: I64, b: I64) -> I64 {
     a + b
 }
 ```
@@ -117,11 +117,11 @@ let category = if age < 13 {
 
 ```spore
 type Shape =
-    | Circle(radius: Float)
-    | Rectangle(width: Float, height: Float)
-    | Triangle(base: Float, height: Float);
+    Circle(radius: F64)
+    | Rectangle(width: F64, height: F64)
+    | Triangle(base: F64, height: F64);
 
-fn area(shape: Shape) -> Float {
+fn area(shape: Shape) -> F64 {
     match shape {
         Circle(r) => 3.14159 * r * r,
         Rectangle(w, h) => w * h,
@@ -152,13 +152,13 @@ Spore has **no** `for`, `while`, `loop`, `break`, or `continue`. All iteration u
 
 ```spore
 // Sum a list using fold
-fn sum(numbers: List[Int]) -> Int {
+fn sum(numbers: List[I64]) -> I64 {
     numbers.fold(0, |acc, x| acc + x)
 }
 
 // Factorial using tail recursion (TCO guaranteed)
-fn factorial(n: Int) -> Int {
-    fn go(n: Int, acc: Int) -> Int {
+fn factorial(n: I64) -> I64 {
+    fn go(n: I64, acc: I64) -> I64 {
         if n <= 1 { acc } else { go(n - 1, n * acc) }
     }
     go(n, 1)
@@ -240,23 +240,29 @@ Errors are declared in the function signature with `!` and propagated with `?`:
 
 ```spore
 type FileError =
-    | NotFound(path: String)
-    | PermissionDenied(path: String)
-    | IoError(message: String);
+    NotFound(path: Str)
+    | PermissionDenied(path: Str)
+    | IoError(message: Str);
 
-fn read_config(path: String) -> Config ! FileError | ParseError {
+fn read_config(path: Str) -> Config ! FileError | ParseError {
     let content = read_file(path)?;     // propagates FileError
     let config = parse_toml(content)?;  // propagates ParseError
     config
 }
 ```
 
+Current implementation note: the parser surface already accepts `! E1 | E2`, and
+the checker currently validates `?` through call/pipeline propagation rules. This
+wave standardizes the **target** canonicalization-first error-set semantics on top
+of that shipping surface. It does **not** require a new top-level
+`error Alias = ...` declaration form.
+
 #### Error conversion
 
 When a function's error set differs from a callee's, Spore can automatically convert errors if a conversion exists:
 
 ```spore
-fn load_config(path: String) -> Config ! ConfigError {
+fn load_config(path: Str) -> Config ! ConfigError {
     let content = read_file(path)?;       // FileError -> ConfigError (auto-converted)
     let config = parse_toml(content)?;    // ParseError -> ConfigError (auto-converted)
     config
@@ -279,8 +285,8 @@ fn get_config() -> Config {
 }
 
 // Retry with tail recursion (TCO guaranteed)
-fn fetch_with_retry(url: String, max_retries: Int) -> Data ! NetworkError {
-    fn retry(url: String, attempts: Int, max: Int) -> Data ! NetworkError {
+fn fetch_with_retry(url: Str, max_retries: I64) -> Data ! NetworkError {
+    fn retry(url: Str, attempts: I64, max: I64) -> Data ! NetworkError {
         match fetch(url) {
             Ok(data) => data,
             Err(NetworkError.Timeout) if attempts < max => {
@@ -300,11 +306,11 @@ Spore uses square brackets for generics, not angle brackets:
 
 ```spore
 type Option[T] =
-    | Some(T)
+    Some(T)
     | None;
 
 type Result[T, E] =
-    | Ok(T)
+    Ok(T)
     | Err(E);
 
 struct Pair[A, B] {
@@ -325,7 +331,7 @@ The full signature order is:
 fn name[T](params) -> ReturnType ! ErrorSet
 where T: Bound
 uses [Effect1, Effect2]
-cost ≤ N
+cost [compute, alloc, io, parallel]
 spec {
     example "...": ...
     property "...": |param: Type| ...
@@ -339,19 +345,19 @@ But you only write what you need:
 
 ```spore
 // 1. Simple pure function — zero overhead
-fn add(a: Int, b: Int) -> Int {
+fn add(a: I64, b: I64) -> I64 {
     a + b
 }
 
 // 2. Function with errors
-fn parse_int(input: String) -> Int ! InvalidFormat {
+fn parse_int(input: Str) -> I64 ! InvalidFormat {
     ...
 }
 
 // 3. With generic constraints and behavioral spec
 fn serialize[T](value: T) -> Bytes ! SerializeError
 where T: Serialize
-cost ≤ 500
+cost [500, 50, 0, 1]
 spec {
     example "empty struct": serialize(Empty {}) == Ok(b"")
 }
@@ -363,7 +369,7 @@ spec {
 /// @idempotent
 fn sync_user_data(user_id: UserId, source: DataSource) -> SyncReport ! NetworkTimeout | AuthExpired
 uses [NetConnect, FileRead, Clock]
-cost ≤ 8500
+cost [8500, 200, 800, 4]
 spec {
     example "returns report on success" {
         let report = sync_user_data(UserId(1), MockSource.success());
@@ -440,7 +446,7 @@ uses [CLI]
 Spore functions can include a `spec` block that expresses behavioral intent as typechecked contracts. The `spec` clause sits after `where`, `uses`, and `cost`, immediately before the function body — making intent structurally part of the signature, visible to the compiler, surfaced in documentation, and available to testing and hole-reporting tooling.
 
 ```spore
-fn add(a: Int, b: Int) -> Int
+fn add(a: I64, b: I64) -> I64
 spec {
     example "positive inputs": add(2, 3) == 5
     example "identity":        add(0, 42) == 42
@@ -470,12 +476,12 @@ example "handles leap year" {
 **`property` items** express universally quantified assertions using explicitly typed lambda syntax. The compiler generates random inputs for property-based testing:
 
 ```spore
-fn parse_date(s: String) -> Result[Date, ParseError] ! ParseError
+fn parse_date(s: Str) -> Result[Date, ParseError] ! ParseError
 spec {
     example "ISO 8601":          parse_date("2024-01-15") == Ok(Date(2024, 1, 15))
     example "rejects ambiguous": parse_date("01/15/24")   == Err(AmbiguousFormat)
 
-    property "total":      |s: String| parse_date(s).is_ok() || parse_date(s).is_err()
+    property "total":      |s: Str| parse_date(s).is_ok() || parse_date(s).is_err()
     property "round-trip": |d: Date| parse_date(d.to_iso_string()) == Ok(d)
 }
 {
@@ -489,47 +495,45 @@ Key design properties:
 - **Current amendment scope**: This amendment defines `spec` for ordinary function declarations and `impl` methods with bodies. Trait-method `spec` syntax and inheritance semantics are deferred to a later amendment.
 - **MissingSpec warning**: `pub` functions without a `spec` block emit a compiler warning (not error), encouraging behavioral documentation without forcing it.
 
-Effect operations and handler binding are also centralized here. `perform` is a reserved keyword for effect-operation expressions. `handle` accepts one or more `with` clauses. SEP-0003 defines the effect algebra and handler semantics; this SEP only fixes the settled outer syntax. The grammar intentionally leaves each handler operand as an expression because the richer handler/`handle` model is still pending the item-3 decision.
-
 ### Struct and type definitions
 
 ```spore
 // Named-field struct
 struct User {
-    id: Int,
-    name: String,
-    email: String,
+    id: I64,
+    name: Str,
+    email: Str,
 }
 
 impl Display for User {
-    fn to_string(self) -> String {
+    fn to_string(self) -> Str {
         f"User({self.name}, {self.email})"
     }
 }
 
 impl Serialize for User {
-    fn serialize(self) -> String ! SerializeError {
+    fn serialize(self) -> Str ! SerializeError {
         ...
     }
 }
 
 // Tuple struct
-struct Color(Int, Int, Int);
+struct Color(I64, I64, I64);
 
 // Unit struct
 struct NoData;
 
 // Sum type (algebraic data type)
 type BinaryTree[T] =
-    | Leaf(T)
+    Leaf(T)
     | Node(left: BinaryTree[T], value: T, right: BinaryTree[T])
     | Empty;
 
 // Refinement type
-type PositiveInt = Int if |n| n > 0;
-type Percentage = Float if |p| p >= 0.0 && p <= 100.0;
-type I32 = Int if |n| n >= -2147483648 && n <= 2147483647;
-type U8 = Int if |n| n >= 0 && n <= 255;
+type PositiveInt = I64 if |n| n > 0;
+type Percentage = F64 if |p| p >= 0.0 && p <= 100.0;
+type I32 = I64 if |n| n >= -2147483648 && n <= 2147483647;
+type U8 = I64 if |n| n >= 0 && n <= 255;
 ```
 
 Field punning allows omitting the value when the variable name matches the field name, both in construction and pattern matching:
@@ -606,7 +610,7 @@ parallel_scope {
 Channels are multi-producer, single-consumer (MPSC). Senders can be cloned; receivers cannot:
 
 ```spore
-let (tx, rx) = Channel.new[Int](buffer: 10);
+let (tx, rx) = Channel.new[I64](buffer: 10);
 
 parallel_scope {
     // Multiple producers via tx.clone()
@@ -629,11 +633,11 @@ parallel_scope {
 `select` multiplexes across channels. Use recursion for event loops (no `for`/`loop`):
 
 ```spore
-let (tx1, rx1) = Channel.new[Int](buffer: 1);
-let (tx2, rx2) = Channel.new[String](buffer: 1);
+let (tx1, rx1) = Channel.new[I64](buffer: 1);
+let (tx2, rx2) = Channel.new[Str](buffer: 1);
 
 // Recursive event loop (TCO guaranteed)
-fn event_loop(rx1: Channel.Receiver[Int], rx2: Channel.Receiver[String]) {
+fn event_loop(rx1: Channel.Receiver[I64], rx2: Channel.Receiver[Str]) {
     select {
         value from rx1 => {
             print(f"Got integer: {value}");
@@ -654,8 +658,8 @@ fn event_loop(rx1: Channel.Receiver[Int], rx2: Channel.Receiver[String]) {
 
 ```spore
 // src/math.sp
-pub fn add(a: Int, b: Int) -> Int { a + b }
-fn helper() -> Int { 42 }  // private by default
+pub fn add(a: I64, b: I64) -> I64 { a + b }
+fn helper() -> I64 { 42 }  // private by default
 
 import std.collections as collections;
 import std.math as math;
@@ -665,9 +669,11 @@ import std.math as math;
 
 ### Lexical structure
 
-#### Character set
+#### Source text encoding
 
 Spore source files are UTF-8 encoded. Identifiers may contain Unicode letters, ASCII digits, and underscores. Identifiers must begin with a letter or underscore.
+
+**Character literals.** Single-quoted `'_'` syntax is **not** part of the language. The reference compiler rejects it at lex time with `character literals are not supported` (see `spore` PR #113). Use a normal string literal for a single scalar (for example `"a"`, `"世"`); character-oriented helpers in `stdlib/char.sp` take `Str` values of length 1.
 
 #### Keywords
 
@@ -692,7 +698,7 @@ The complete reserved keyword table:
 | `alias` | Type alias |
 | `where` | Generic type constraints |
 | `uses` | Effect requirement declaration |
-| `cost` | Cost bound clause |
+| `cost` | Four-slot cost vector clause |
 | `spec` | Behavioral specification block in function declarations and `impl` methods |
 | `example` | Concrete labeled example item inside a `spec` block |
 | `property` | Universally quantified assertion inside a `spec` block |
@@ -779,9 +785,11 @@ The assignment operator `=` appears only in `let` bindings and is not an express
 0xFF        // hexadecimal
 0o755       // octal
 0b1010_1100 // binary
-42i32       // typed suffix
-100u64      // typed suffix
+42i32       // typed suffix (reserved — not accepted by the reference lexer yet)
+100u64      // typed suffix (reserved — not accepted by the reference lexer yet)
 ```
+
+**Implementation note:** The reference lexer parses integer literals without suffixes and the type checker gives them a default numeric type (**`I64`** in `sporec-typeck`). Float literals default to **`F64`**.
 
 **Floats:**
 
@@ -791,14 +799,14 @@ The assignment operator `=` appears only in `let` bindings and is not an express
 1.0e-10
 2.5e+3
 1_000.5
-3.14f32
+3.14f32     // typed suffix (reserved — not accepted by the reference lexer yet)
 ```
+
+**Implementation note:** Unsuffixed floats become `F64` in `sporec-typeck`.
 
 **Booleans:** `true`, `false`
 
-**Characters:** `'a'`, `'世'`, `'\n'`, `'\u{1F600}'`
-
-**Strings:**
+**Strings** (including “single character” text as length-1 `Str` values):
 
 ```text
 "Hello, World!"                    // regular string
@@ -1132,7 +1140,7 @@ HoleExpr        = "?"
 (* ─── Literals ────────────────────────────────────── *)
 
 Literal         = IntLiteral | FloatLiteral | BoolLiteral
-                | StringLiteral | CharLiteral ;
+                | StringLiteral ;
 
 IntLiteral      = DecimalInt | HexInt | OctalInt | BinaryInt ;
 DecimalInt      = [ "-" ] Digit { Digit | "_" } [ IntSuffix ] ;
@@ -1156,8 +1164,7 @@ StringLiteral   = '"' { StringChar } '"'
 FStringPart     = StringChar | "{" Expr "}" ;
 TStringPart     = StringChar | "{" Ident "}" ;
 
-CharLiteral     = "'" ( Char | EscapeSeq ) "'" ;
-EscapeSeq       = "\\" ( "n" | "t" | "r" | "\\" | "'" | '"' | "0"
+EscapeSeq       = "\\" ( "n" | "t" | "r" | "\\" | '"' | "0"
                 | "u{" HexDigit { HexDigit } "}" ) ;
 
 (* ─── Identifier ──────────────────────────────────── *)
@@ -1178,7 +1185,7 @@ The function signature system is the heart of Spore's design. The clauses appear
 fn <name>[<generics>](<params>) -> <ReturnType> [! <ErrorTypes>]
 [where <GenericName>: <Constraint>, ...]
 [uses [<Effect>, ...]]
-[cost ≤ <N>]
+[cost [<compute_expr>, <alloc_expr>, <io_expr>, <parallel_expr>]]
 [spec { <examples and properties> }]
 {
     <body>
@@ -1189,7 +1196,13 @@ fn <name>[<generics>](<params>) -> <ReturnType> [! <ErrorTypes>]
 
 1. **`-> ReturnType`** — The return type. Omitted for functions returning `Unit`.
 
-2. **`! ErrorTypes`** — The error set. A function with `! E1 | E2` may produce errors of type `E1` or `E2`. Absence of `!` means the function cannot fail.
+2. **`! ErrorTypes`** — The error set. A function with `! E1 | E2` may produce
+   errors of type `E1` or `E2`. Absence of `!` means the function cannot fail.
+   Compatibility and `?` propagation use **canonicalized** error-set comparison:
+   resolve each written item to its canonical nominal identity, drop duplicates,
+   and compare by canonical subset/equivalence. Duplicate or canonically
+   equivalent items are redundant and should be diagnosed, even though signature
+   hashing remains conservative over the written surface form.
 
 3. **`where T: Bound, U: Bound`** — Generic constraints. The canonical form is a single `where` clause with comma-separated constraints. Spore does not use `+` multi-bound syntax.
 
@@ -1218,12 +1231,12 @@ fn <name>[<generics>](<params>) -> <ReturnType> [! <ErrorTypes>]
 
 ```spore
 trait Display {
-    fn to_string(self) -> String;
+    fn to_string(self) -> Str;
 }
 
 trait Collection {
     type Item;
-    fn len(self) -> Int;
+    fn len(self) -> I64;
     fn is_empty(self) -> Bool {
         self.len() == 0
     }
@@ -1249,7 +1262,13 @@ All control flow constructs are expressions that produce values.
 - `x |> f(_, y)` → `f(x, y)`
 - `x |> .method()` → `x.method()`
 
-**Error propagation (`?`)**: `expr?` evaluates `expr`. If the result is `Ok(v)`, yields `v`. If `Err(e)`, immediately returns `Err(e)` from the enclosing function. The error type must be in the function's declared error set.
+**Error propagation (`?`)**: `expr?` evaluates `expr`. If the result is `Ok(v)`,
+yields `v`. If `Err(e)`, immediately returns `Err(e)` from the enclosing
+function. This check is performed by canonical subset comparison: the callee's
+canonical error set must be a subset of the enclosing function's canonical
+declared error set. The first slice keeps the current call/pipeline-oriented
+checker architecture; it does not require a richer expression-local `Try` model
+to land first.
 
 ### Pattern matching details
 
@@ -1271,9 +1290,9 @@ Supported pattern forms:
 
 ### Type system
 
-**Primitive types:** `Int` (arbitrary-precision integer), `Float` (arbitrary-precision float), `Bool`, `String`, `Char`. Specific fixed-width types (`I32`, `U64`, `F32`, etc.) are obtained via refinement types (e.g., `type I32 = Int if |n| n >= -2147483648 && n <= 2147483647`).
+**Primitive types:** Fixed-width numerics `I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `U64`, `F32`, and `F64`; `Bool`; UTF-8 text as `Str`. There is **no** separate `Char` type. **Implementation note:** The reference compiler’s `Ty` enum in `sporec-typeck` uses exactly those numeric widths (plus `Str`, `Bool`, `Unit`, `Never`, tuples, refinements, …); **unsuffixed integer literals default to `I64`** and float literals to **`F64`**. Many narrative examples in SEPs still say `Int` or `Float` for readability — treat them as informal shorthands for **`I64` / `F64`** until the examples are fully normalized. Narrower ranges are expressed with **refinement types** on a fixed-width base (for example `alias Port = I64 when self >= 1 && self <= 65535`).
 
-**Collection types:** `List[T]`, `Map[K, V]`, `Set[T]`, `Array[T, N]`
+**Collection types:** **`List[T]`** (default—always unbounded); **`Vec[T, max: N]`** (bounded, **rarely needed**—only when `N` belongs in the type; see SEP-0002); **`Map[K, V]`**, **`Set[T]`**, **`Array[T, N]`**
 
 **Special types:** `Option[T]`, `Result[T, E]`, `Ref[T]`, `Channel[T]`, `Unit`
 
@@ -1281,18 +1300,18 @@ Supported pattern forms:
 
 ```spore
 // Fixed-size array
-struct Array[T, const N: Int] {
+struct Array[T, const N: I64] {
     data: List[T],  // length guaranteed to be N
 }
 
 // Fixed-size matrix
-struct Matrix[T, const ROWS: Int, const COLS: Int] {
+struct Matrix[T, const ROWS: I64, const COLS: I64] {
     data: Array[Array[T, COLS], ROWS],
 }
 
 // Usage
-let vec3: Array[Float, 3] = Array.new([1.0, 2.0, 3.0]);
-let identity: Matrix[Float, 3, 3] = Matrix.identity();
+let vec3: Array[F64, 3] = Array.new([1.0, 2.0, 3.0]);
+let identity: Matrix[F64, 3, 3] = Matrix.identity();
 ```
 
 **Refinement types:** `type PositiveInt = Int if |n| n > 0;`
@@ -1319,16 +1338,16 @@ The `@allows` annotation constrains which functions the compiler (or an AI agent
 
 ```spore
 @allows[validate, sanitize, format]
-fn process_input(raw: String) -> String ! ValidationError {
+fn process_input(raw: Str) -> Str ! ValidationError {
     let validated = validate(raw)?;
     let sanitized = sanitize(validated);
     ?final_step  // this hole can only call validate/sanitize/format
 }
 
 @allows[add, multiply, negate]
-fn arithmetic(a: Int, b: Int) -> Int {
-    let x = ?step1 : Int;  // only add/multiply/negate
-    let y = ?step2 : Int;  // same constraint
+fn arithmetic(a: I64, b: I64) -> I64 {
+    let x = ?step1 : I64;  // only add/multiply/negate
+    let y = ?step2 : I64;  // same constraint
     x + y
 }
 ```
@@ -1341,9 +1360,9 @@ The compiler infers hole types through pipeline chains:
 fn example() {
     let list = [1, 2, 3, 4, 5];
     let result = list
-        |> filter(?)        // hole: fn(Int) -> Bool
-        |> map(?)           // hole: fn(Int) -> ?R
-        |> fold(0, ?);     // hole: fn(Int, ?R) -> Int
+        |> filter(?)        // hole: fn(I64) -> Bool
+        |> map(?)           // hole: fn(I64) -> ?R
+        |> fold(0, ?);     // hole: fn(I64, ?R) -> I64
 }
 ```
 
@@ -1367,31 +1386,31 @@ When a function has both a `spec` block and a hole body, that shared hole object
 
 ### Expression parser and evaluator
 
-This example demonstrates algebraic data types, pattern matching, recursion, error handling, and cost bounds working together:
+This example demonstrates algebraic data types, pattern matching, recursion, error handling, and four-slot cost clauses working together:
 
 ```spore
 // Expression AST
 type Expr =
-    | Literal(Int)
-    | Variable(name: String)
+    Literal(I64)
+    | Variable(name: Str)
     | BinOp(op: Op, left: Expr, right: Expr)
     | UnaryOp(op: UnaryOp, expr: Expr)
-    | Let(name: String, value: Expr, body: Expr)
+    | Let(name: Str, value: Expr, body: Expr)
     | If(condition: Expr, then_branch: Expr, else_branch: Expr);
 
 type Op = Add | Sub | Mul | Div | Equal | LessThan;
 type UnaryOp = Negate | Not;
 
-type Env = Map[String, Int];
+type Env = Map[Str, I64];
 
 type EvalError =
-    | UndefinedVariable(name: String)
+    UndefinedVariable(name: Str)
     | DivisionByZero
-    | TypeError(message: String);
+    | TypeError(message: Str);
 
 // Evaluator — pure recursion, no loops
-fn eval(expr: Expr, env: Env) -> Int ! EvalError
-cost ≤ expr_size(expr) * 10
+fn eval(expr: Expr, env: Env) -> I64 ! EvalError
+cost [expr_size(expr) * 10, expr_size(expr), 0, 1]
 {
     match expr {
         Literal(n) => n,
@@ -1432,7 +1451,7 @@ cost ≤ expr_size(expr) * 10
     }
 }
 
-fn eval_binop(op: Op, left: Int, right: Int) -> Int ! EvalError {
+fn eval_binop(op: Op, left: I64, right: I64) -> I64 ! EvalError {
     match op {
         Add => left + right,
         Sub => left - right,
@@ -1473,11 +1492,11 @@ This example demonstrates channels, structured concurrency, tail-recursive messa
 
 ```spore
 type Task =
-    | Process(id: Int, data: String)
+    Process(id: I64, data: Str)
     | Stop;
 
 // Producer generates tasks and sends them to a channel
-fn producer(tx: Channel.Sender[Task], task_count: Int) {
+fn producer(tx: Channel.Sender[Task], task_count: I64) {
     (1..=task_count)
         .map(|i| Task.Process(i, f"Task data {i}"))
         .for_each(|task| tx.send(task));
@@ -1485,8 +1504,8 @@ fn producer(tx: Channel.Sender[Task], task_count: Int) {
 }
 
 // Consumer processes tasks via tail recursion
-fn consumer(id: Int, rx: Channel.Receiver[Task], result_tx: Channel.Sender[String]) {
-    fn process(id: Int, rx: Channel.Receiver[Task], result_tx: Channel.Sender[String]) {
+fn consumer(id: I64, rx: Channel.Receiver[Task], result_tx: Channel.Sender[Str]) {
+    fn process(id: I64, rx: Channel.Receiver[Task], result_tx: Channel.Sender[Str]) {
         match rx.recv() {
             Task.Process(task_id, data) => {
                 let result = f"Consumer {id} processed task {task_id}: {data}";
@@ -1500,8 +1519,8 @@ fn consumer(id: Int, rx: Channel.Receiver[Task], result_tx: Channel.Sender[Strin
 }
 
 // Result collector using tail recursion
-fn collector(rx: Channel.Receiver[String], expected: Int) {
-    fn collect(rx: Channel.Receiver[String], remaining: Int) {
+fn collector(rx: Channel.Receiver[Str], expected: I64) {
+    fn collect(rx: Channel.Receiver[Str], remaining: I64) {
         if remaining <= 0 { return }
         let result = rx.recv();
         print(result);
@@ -1514,7 +1533,7 @@ fn main() {
     let task_count = 10;
     let consumer_count = 3;
     let (task_tx, task_rx) = Channel.new[Task](buffer: 5);
-    let (result_tx, result_rx) = Channel.new[String](buffer: 10);
+    let (result_tx, result_rx) = Channel.new[Str](buffer: 10);
 
     parallel_scope {
         spawn { producer(task_tx, task_count) };
@@ -1546,7 +1565,7 @@ Spore's syntax prioritizes scannability. The fixed operator set means readers ne
 
 ### Progressive disclosure
 
-Simple functions require zero ceremony — `fn add(a: Int, b: Int) -> Int { a + b }` has no clauses to learn. Effects, error sets, and cost bounds are introduced only when the code actually needs them.
+Simple functions require zero ceremony — `fn add(a: Int, b: Int) -> Int { a + b }` has no clauses to learn. Effects, error sets, and the `cost [...]` clause are introduced only when the code actually needs them.
 
 ## Agent experience impact
 
@@ -1565,7 +1584,7 @@ Function signatures are machine-readable contracts. An agent can extract:
 - **Input/output types** from the parameter list and return type
 - **Failure modes** from the `! ErrorSet`
 - **Side effect profile** from `uses [...]`
-- **Performance budget** from `cost ≤ N`
+- **Performance budget** from the `cost [compute, alloc, io, parallel]` clause
 - **Generic requirements** from `where` clauses
 
 This enables agents to:
@@ -1588,10 +1607,10 @@ Any change to the following signature components produces a new snapshot hash an
 | Function name | `parse_config` → `load_config` |
 | Parameter names | `raw` → `input` |
 | Parameter order | `(a, b)` → `(b, a)` |
-| Parameter types | `String` → `Bytes` |
+| Parameter types | `Str` → `Bytes` |
 | Return type | `Config` → `Settings` |
-| Error type set | add/remove any error type |
-| Cost bound | `≤ 200` → `≤ 300` |
+| Error clause surface | add/remove/reorder/rename/duplicate any written error item |
+| Cost slots | e.g. `[200, 20, 0, 1]` → `[300, 40, 50, 2]` |
 | Effect set | add/remove any effect |
 | Generic constraints | `T: Eq` → `T: Eq + Hash` |
 
@@ -1604,6 +1623,12 @@ The `spec` block is tracked via a separate **spec hash**, independent of the sna
 | Any signature clause change (types, effects, cost, etc.) | changed | unchanged | `--permit` |
 
 The lighter `--permit-spec` approval reflects that spec changes clarify behavioral contracts without altering calling conventions. Downstream callers need only re-run their own tests, not update call sites.
+
+For error clauses, this policy is intentionally **conservative**. Canonically
+equivalent declarations such as reordered items or duplicate spellings are
+treated as the same semantic error set for checking and diagnostics, but they
+still change the snapshot hash until a later compatibility policy explicitly
+relaxes that rule.
 
 ## Structured representation / protocol impact
 
@@ -1632,10 +1657,10 @@ Program
     ├── cost?
     ├── spec?
     │   ├── examples[]
-    │   │   ├── label: String
+    │   │   ├── label: Str
     │   │   └── body: Expr
     │   └── properties[]
-    │       ├── label: String
+    │       ├── label: Str
     │       └── predicate: LambdaExpr
     └── body: Block
 
@@ -1729,7 +1754,7 @@ error[E0501]: `spec` must appear after all other signature clauses
   --> src/lib.sp:5:1
    |
  5 | spec { ... }
- 6 | cost ≤ 500
+ 6 | cost [500, 30, 50, 2]
    |
    = help: move `cost` before `spec`
 ```
@@ -1765,7 +1790,7 @@ spec counterexample: `parse_date` — property "round-trip"
 warning[W0501]: public function `parse_date` has no `spec` block
   --> src/dates.sp:3:1
    |
- 3 | pub fn parse_date(s: String) -> Result[Date, ParseError] ! ParseError {
+ 3 | pub fn parse_date(s: Str) -> Result[Date, ParseError] ! ParseError {
    |        ^^^^^^^^^^ no behavioral contract declared
    |
    = help: add a `spec { example "...": ... }` block before the function body
@@ -1934,7 +1959,10 @@ As this is the initial v0.1 specification, there are no backward compatibility c
 
 11. **Standard effect taxonomy evolution**: SEP-0003 now defines the initial built-in effect vocabulary (`Console`, `FileRead`, `FileWrite`, `NetConnect`, `NetListen`, `Env`, `Spawn`, `Clock`, `Random`, `Exit`). Future SEPs may extend it, but changes should preserve the intent-oriented classification.
 
-12. **Error type subtyping**: If function `f` declares `! NetworkError` and function `g` declares `! NetworkError | ParseError`, can `g` call `f` directly? How does error set subtyping work?
+12. **Error-set surface aliases**: This slice standardizes canonicalized error-set
+equivalence and subset checks without introducing a dedicated `error Alias = ...`
+surface. Should a later SEP add user-declared error-set aliases, or should Spore
+continue relying on existing nominal type names plus canonicalization?
 
 13. **`property` with `uses`**: If a property calls a function that has side effects, what effect scope applies? Current proposal: property items inherit the enclosing function's `uses` set.
 

--- a/seps/SEP-0001-core-syntax.md
+++ b/seps/SEP-0001-core-syntax.md
@@ -18,7 +18,7 @@ superseded_by: null
 
 ## Summary
 
-This proposal defines the complete core syntax and function signature system for the Spore programming language v0.1. Spore is an expression-based, statically typed language with effect tracking, explicit resource cost tracking, and guaranteed tail-call optimization. The language draws from Rust, OCaml, Roc, Gleam, and Elm, combining curly-brace block scoping with Rust-style semicolon semantics, algebraic data types, exhaustive pattern matching, and a novel function signature system that encodes generic constraints (`where`), effect requirements (`uses`), error sets (`!`), and a four-slot **`cost [compute, alloc, io, parallel]`** clause as composable signature metadata. Spore deliberately eliminates loops in favor of recursion and higher-order functions, uses square brackets for generics (`List[Int]`), auto-infers effect properties from the `uses` set, and provides a pipe operator (`|>`) for readable data-flow composition.
+This proposal defines the complete core syntax and function signature system for the Spore programming language v0.1. Spore is an expression-based, statically typed language with effect tracking, explicit resource cost tracking, and guaranteed tail-call optimization. The language draws from Rust, OCaml, Roc, Gleam, and Elm, combining curly-brace block scoping with Rust-style semicolon semantics, algebraic data types, exhaustive pattern matching, and a novel function signature system that encodes generic constraints (`where`), effect requirements (`uses`), error sets (`!`), and a four-slot **`cost [compute, alloc, io, parallel]`** clause as composable signature metadata. Spore deliberately eliminates loops in favor of recursion and higher-order functions, uses square brackets for generics (`List[I64]`), auto-infers effect properties from the `uses` set, and provides a pipe operator (`|>`) for readable data-flow composition.
 
 ## Motivation
 
@@ -34,7 +34,7 @@ Spore aims to occupy a unique design point:
 
 4. **No loops — recursion with TCO guarantee**: By removing `for`, `while`, `loop`, `break`, and `continue`, Spore encourages a purely functional iteration style via recursion and higher-order functions (`map`, `fold`, `filter`). The compiler guarantees tail-call optimization, making recursion safe and efficient.
 
-5. **Incremental elaboration**: The signature system is designed so that a simple pure function has zero overhead (`fn add(x: Int, y: Int) -> Int`), while complex functions progressively add clauses only as needed. This avoids the "all or nothing" annotation burden seen in many effect systems.
+5. **Incremental elaboration**: The signature system is designed so that a simple pure function has zero overhead (`fn add(x: I64, y: I64) -> I64`), while complex functions progressively add clauses only as needed. This avoids the "all or nothing" annotation burden seen in many effect systems.
 
 6. **Cost transparency**: The `cost` clause enables compile-time reasoning about resource consumption, supporting smart-contract use cases and agent-driven cost optimization.
 
@@ -789,7 +789,7 @@ The assignment operator `=` appears only in `let` bindings and is not an express
 100u64      // typed suffix (reserved — not accepted by the reference lexer yet)
 ```
 
-**Implementation note:** The reference lexer parses integer literals without suffixes and the type checker gives them a default numeric type (**`I64`** in `sporec-typeck`). Float literals default to **`F64`**.
+**Implementation note:** The reference lexer parses integer literals without suffixes and the type checker gives them a default numeric type (**`I64`** in `sporec-typeck`). F64 literals default to **`F64`**.
 
 **Floats:**
 
@@ -1290,13 +1290,13 @@ Supported pattern forms:
 
 ### Type system
 
-**Primitive types:** Fixed-width numerics `I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `U64`, `F32`, and `F64`; `Bool`; UTF-8 text as `Str`. There is **no** separate `Char` type. **Implementation note:** The reference compiler’s `Ty` enum in `sporec-typeck` uses exactly those numeric widths (plus `Str`, `Bool`, `Unit`, `Never`, tuples, refinements, …); **unsuffixed integer literals default to `I64`** and float literals to **`F64`**. Many narrative examples in SEPs still say `Int` or `Float` for readability — treat them as informal shorthands for **`I64` / `F64`** until the examples are fully normalized. Narrower ranges are expressed with **refinement types** on a fixed-width base (for example `alias Port = I64 when self >= 1 && self <= 65535`).
+**Primitive types:** Fixed-width numerics `I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `U64`, `F32`, and `F64`; `Bool`; UTF-8 text as `Str`. There is **no** separate `Char` type. **Implementation note:** The reference compiler’s `Ty` enum in `sporec-typeck` uses exactly those numeric widths (plus `Str`, `Bool`, `Unit`, `Never`, tuples, refinements, …); **unsuffixed integer literals default to `I64`** and float literals to **`F64`**. `Int` and `Float` are not primitive names or authoritative shorthand in the language docs. Narrower ranges are expressed with **refinement types** on a fixed-width base (for example `alias Port = I64 when self >= 1 && self <= 65535`).
 
 **Collection types:** **`List[T]`** (default—always unbounded); **`Vec[T, max: N]`** (bounded, **rarely needed**—only when `N` belongs in the type; see SEP-0002); **`Map[K, V]`**, **`Set[T]`**, **`Array[T, N]`**
 
 **Special types:** `Option[T]`, `Result[T, E]`, `Ref[T]`, `Channel[T]`, `Unit`
 
-**Const generics:** `struct Array[T, const N: Int] { ... }`
+**Const generics:** `struct Array[T, const N: I64] { ... }`
 
 ```spore
 // Fixed-size array
@@ -1314,9 +1314,9 @@ let vec3: Array[F64, 3] = Array.new([1.0, 2.0, 3.0]);
 let identity: Matrix[F64, 3, 3] = Matrix.identity();
 ```
 
-**Refinement types:** `type PositiveInt = Int if |n| n > 0;`
+**Refinement types:** `type PositiveInt = I64 if |n| n > 0;`
 
-**Function types:** `fn(Int, Int) -> Int`
+**Function types:** `fn(I64, I64) -> I64`
 
 ### Concurrency primitives
 
@@ -1565,7 +1565,7 @@ Spore's syntax prioritizes scannability. The fixed operator set means readers ne
 
 ### Progressive disclosure
 
-Simple functions require zero ceremony — `fn add(a: Int, b: Int) -> Int { a + b }` has no clauses to learn. Effects, error sets, and the `cost [...]` clause are introduced only when the code actually needs them.
+Simple functions require zero ceremony — `fn add(a: I64, b: I64) -> I64 { a + b }` has no clauses to learn. Effects, error sets, and the `cost [...]` clause are introduced only when the code actually needs them.
 
 ## Agent experience impact
 
@@ -1804,7 +1804,7 @@ The parser can recover from common errors:
 1. **Missing semicolon**: Insert one after a statement and continue parsing.
 2. **Missing closing brace**: Match indentation heuristics to suggest where the brace should go.
 3. **Unknown keyword**: Suggest the closest valid keyword (e.g., `func` → `fn`, `for` → `map`/`fold`).
-4. **Angle brackets for generics**: Detect `List<Int>` and suggest `List[Int]`.
+4. **Angle brackets for generics**: Detect `List<I64>` and suggest `List[I64]`.
 5. **Missing `!` clause**: When a function body calls a failable function without `?`, suggest adding the error type to the signature.
 
 ## Drawbacks
@@ -1834,7 +1834,7 @@ We considered including a minimal loop construct (e.g., Rust's `loop` or a `fore
 - HOFs (`map`, `fold`, `filter`) cover the vast majority of iteration patterns.
 - A single iteration paradigm reduces cognitive load once learned.
 
-### Angle brackets for generics (`List<Int>`)
+### Angle brackets for generics (`List<I64>`)
 
 Rejected because:
 
@@ -1941,7 +1941,7 @@ As this is the initial v0.1 specification, there are no backward compatibility c
 
 2. **Effect composition rules**: When a function calls two sub-functions with different `uses` sets, is the resulting set the union? How are effect aliases expanded for comparison?
 
-3. **Refinement type checking**: How deeply does the compiler verify refinement predicates (`type Positive = Int if |n| n > 0`)? Is this compile-time only, or does it generate runtime checks?
+3. **Refinement type checking**: How deeply does the compiler verify refinement predicates (`type Positive = I64 if |n| n > 0`)? Is this compile-time only, or does it generate runtime checks?
 
 4. **`throw` semantics**: Is `throw` syntactic sugar for `return Err(...)`, or does it have distinct unwinding semantics? The current spec treats it as sugar but this needs formalization.
 

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -130,6 +130,19 @@ Platform code generation maps these types to machine representations; refinement
 
 **No informal scalar aliases.** Examples and normative text must write fixed-width scalar names (`I64`, `F64`, `U8`, and so on). A project may define its own `alias Int = I64`, but that is ordinary user code and not part of the language prelude.
 
+**Index kind.** `Index` is a compile-time non-negative size kind, not a runtime
+type. Index parameters such as `N: Index` may appear in indexed types and in
+`cost [...]` clauses. Ordinary runtime values (`I64`, `Str`, `List[T]`, records,
+and so on) do not become cost variables merely because they are in scope.
+
+```spore
+type Count[N: Index] = I64 when self >= 0
+```
+
+`Count[N]` is the bridge type for APIs that carry a runtime non-negative count
+while also exposing the compile-time index `N` to cost analysis. The runtime
+representation is still an integer; the verifier sees only the index parameter.
+
 ### 3.2 Type annotations on functions
 
 Function signatures **must** be fully annotated. Parameters, return type, error set, effect set, and `cost [c, a, i, p]` clause are all declared:
@@ -141,7 +154,7 @@ fn add(a: I64, b: I64) -> I64 {
 
 fn fetch_page(url: Str) -> Str ! NetworkError
 uses [NetConnect]
-cost [5000, 200, 5000, 2]
+cost [5000, 200, 5000, 0]
 {
     http_get(url)
 }
@@ -244,7 +257,7 @@ fn identity[T](x: T) -> T {
     x
 }
 
-fn map[A, B](list: List[A], f: Fn(item: A) -> B) -> List[B] {
+fn pair[A, B](left: A, right: B) -> (A, B) {
     // implementation
 }
 
@@ -260,7 +273,7 @@ At call sites, type arguments are inferred from the actual argument types:
 ```spore
 let nums: List[I64] = [1, 2, 3]
 let result = identity(42)          // T inferred as I64
-let strings = map(nums, show)      // A=I64, B=Str inferred
+let strings = nums.map(show)       // A=I64, B=Str inferred
 ```
 
 ### 3.7 Generic type application
@@ -341,7 +354,7 @@ trait Display {
 
 trait Serialize {
     fn serialize(self) -> Bytes ! SerializeError
-        cost [100, 20, 0, 1]
+        cost [100, 20, 0, 0]
 }
 ```
 
@@ -386,6 +399,12 @@ trait Collection {
 }
 ```
 
+Shared method names are resolved through trait and inherent impl lookup, not
+through free-function overloading. A call such as `xs.map(f)` first uses the
+receiver type of `xs`; if several imported traits still provide applicable
+methods with the same name, the call must use trait-qualified syntax. Spore does
+not use signature unions such as `List[T] | Str` to model these operations.
+
 #### Trait bounds
 
 Trait bounds constrain generic type parameters in `where` clauses:
@@ -393,7 +412,7 @@ Trait bounds constrain generic type parameters in `where` clauses:
 ```spore
 fn sort[T](list: List[T]) -> List[T]
 where T: Ord
-cost [500, 100, 0, 1]
+cost [500, 100, 0, 0]
 {
     // implementation
 }
@@ -401,7 +420,7 @@ cost [500, 100, 0, 1]
 fn serialize_all[T](items: List[T]) -> List[Bytes] ! SerializeError
 where T: Serialize + Display
 {
-    items |> map(|item| item.serialize())
+    items.map(|item| item.serialize())
 }
 ```
 
@@ -411,7 +430,7 @@ Multiple bounds use `+`:
 fn dedup_and_display[T](items: List[T]) -> Str
 where T: Eq + Hash + Display
 {
-    items |> unique() |> map(|x| x.display()) |> join(", ")
+    items.unique().map(|x| x.display()).join(", ")
 }
 ```
 
@@ -451,7 +470,7 @@ Traits may declare associated types — types determined by the implementing typ
 trait Iterator {
     type Item
     fn next(self) -> Option[Self.Item]
-        cost [10, 80, 0, 1]
+        cost [10, 80, 0, 0]
 }
 
 impl Iterator for LineReader {
@@ -480,7 +499,7 @@ where
     C: Collection,
     C.Item: Add[Output = I64]
 {
-    collection.iter() |> fold(0, |acc, item| acc + item)
+    collection.iter().fold(0, |acc, item| acc + item)
 }
 ```
 
@@ -571,80 +590,91 @@ where adapter: ExternalType as Printable
 
 Adapters are always scoped and explicit — they cannot cause global coherence violations.
 
-### 3.10 Const generics
+### 3.10 Index generics
 
-#### Const generic parameters
+#### Index parameters
 
-### List vs `Vec`
+`Index` parameters are compile-time non-negative size symbols. They are the
+only user-visible variables that may flow directly into `cost [...]`. This keeps
+cost checking parametric and compile-time: the verifier proves formulas over
+symbols such as `N`, not over arbitrary runtime values.
 
-**Naming invariant:** **`List[T]` is always unbounded** — the `List` constructor never carries a `max:` parameter. **`Vec[T, max: N]` is always bounded** — every `Vec` declares a compile-time cap `N` (const-generic), useful when the **type system** must know a fixed capacity (e.g. small matrices, SIMD lanes, rare “cap in the type” APIs).
+### Dynamic `List` vs indexed containers
 
-**Style rule:** **`List[T]` is the default** for almost all APIs, examples, and iteration. Model sizes and budgets with `cost [...]`, refinements, and runtime checks on `len` as usual—**do not** sprinkle `Vec[..., max: N]` unless you genuinely need `N` in the type.
+**Naming invariant:** **`List[T]` is always dynamic** — the `List` constructor
+never carries a length or capacity parameter. If an API needs predictable cost
+from a static size, use an indexed type:
 
-**`Vec`** is for const-generic layouts (see below)—not for everyday collections.
+- **`Count[N]`** for a runtime count value carrying index `N`.
+- **`Array[T, N]`** for fixed-length arrays.
+- **`Vec[T, max: N]`** for buffers with a static capacity upper bound.
 
-Const generics allow value-level parameters in type position. Spore commonly uses them for **`Matrix`**, **`Array[T, N]`**, and the optional **`Vec[T, max: N]`** packed buffer type:
+`List[T]` remains the default sequence type for ordinary programs. A `List[T]`
+can still be inspected at runtime, but its runtime length is not a CostExpr
+variable. APIs that need verified size-parametric cost should accept or return
+`Count`, `Array`, or `Vec`.
 
 ```spore
-struct Vec[T, max: I64] {
-    data: Array[T],
+struct Array[T, N: Index] {
+    data: <compiler representation>
+}
+
+struct Vec[T, max: N] {
+    data: Array[T, N],
     len: I64,
 }
 
-// Typical slicing stays on List — no Vec required:
-fn take[T](list: List[T], n: I64) -> List[T]
-{
-    // prefix of length ≤ n (empty if n ≤ 0); cost keyed off n and list.len()
-}
-
-struct Matrix[T, rows: I64, cols: I64] {
-    data: Array[Array[T]],
+struct Matrix[T, rows: R, cols: C]
+where R: Index, C: Index {
+    data: Array[Array[T, C], R],
 }
 ```
 
-#### Type-level arithmetic
+#### Index expressions
 
-Const generic parameters support arithmetic in type-level expressions, enabling compile-time dimensional checking (mostly for **`Matrix`** / **`Array`**, not for ordinary `List` code):
+Index parameters support a deliberately small expression language:
 
-```spore
-fn transpose[T, R: I64, C: I64](
-    matrix: Matrix[T, rows: R, cols: C],
-) -> Matrix[T, rows: C, cols: R] {
-    // implementation
-}
-
-// Optional: only when Vec's max must appear in the type (buffers with static M+N):
-fn concat_vec[T, M: I64, N: I64](
-    a: Vec[T, max: M],
-    b: Vec[T, max: N],
-) -> Vec[T, max: M + N] {
-    // implementation
-}
+```text
+IndexExpr ::= 0 | 1 | N
+            | IndexExpr + IndexExpr
+            | IndexExpr * IndexExpr
+            | max(IndexExpr, IndexExpr)
+            | min(IndexExpr, IndexExpr)
+            | log(IndexExpr)
+            | span(IndexExpr, IndexExpr)
 ```
 
-Supported arithmetic operations in type position: `+`, `-`, `*`, `/`, `%`, `min`, `max`. All arithmetic is evaluated at compile time. Division by zero and overflow are compile-time errors.
+`span(hi, lo)` is saturating difference: `max(hi - lo, 0)`. Ordinary subtraction
+and division are not IndexExpr operators. This keeps the cost verifier in a
+non-negative, monotone fragment while still supporting interval-length APIs.
 
 #### Interaction with cost
 
-Cost clauses usually refer to **runtime** sizes (`items.len`, parameters, refinements). **`List[T]`** is enough for those budgets—**no `Vec` required**:
+Cost clauses refer to Index parameters, not ordinary runtime values:
 
 ```spore
-fn linear_search[T](items: List[T], target: T) -> Option[I64]
+fn vec_linear_search[T, N: Index](
+    items: Vec[T, max: N],
+    target: T,
+) -> Option[I64]
 where T: Eq
-cost [items.len * 5, items.len, 0, 1]
+cost [N * 5, 0, 0, 0]
 {
-    // O(n) search; n = items.len
+    // Verified against the static capacity bound N.
 }
 
-fn sort_list[T](items: List[T]) -> List[T]
-where T: Ord
-cost [items.len * items.len * 2, items.len, 0, 1]
+fn vec_concat[T, M: Index, N: Index](
+    a: Vec[T, max: M],
+    b: Vec[T, max: N],
+) -> Vec[T, max: M + N]
+cost [M + N, M + N, 0, 0]
 {
-    // worst-case O(n²); n = items.len
+    // implementation
 }
 ```
 
-When you **do** use `Vec[T, max: N]`, the declared `N` can appear directly in `cost [...]` (parametric verification). That pattern is specialized; prefer `List` + len-indexed cost for most functions.
+For dynamic collections, write complexity prose or use runtime metering; do not
+write a runtime-length expression as a verified compile-time CostExpr.
 
 ### 3.11 Pattern matching
 
@@ -796,7 +826,7 @@ fn handle_result(result: Invoice ! TaxError | ValidationError) -> Str {
 ```spore
 fn process_payment(amount: Money, card: Card) -> Receipt ! PaymentFailed
 uses [PaymentGateway, AuditLog]
-cost [2000, 400, 200, 2]
+cost [2000, 400, 200, 0]
 {
     let validated = validate_card(card)
     @allows[charge, charge_with_retry]
@@ -816,7 +846,7 @@ cost [2000, 400, 200, 2]
 ```spore
 fn build_dashboard(org: Org) -> Dashboard ! DataError
 uses [Database, Cache, Analytics]
-cost [20000, 2000, 1000, 8]
+cost [20000, 2000, 1000, 0]
 {
     @allows[fetch_cached_metrics, compute_summary]
     let metrics = ?gather_metrics
@@ -1006,7 +1036,7 @@ struct Tree[T] {
 | Public constants | **Yes** | API surface |
 | Local variable types | No | Inferred from RHS: `let x = compute(...)` |
 | Generic type params at call sites | No | Inferred from arguments: `sort(my_list)` — T inferred from `my_list` |
-| Closure parameter types (in context) | No | Inferred: `.map(\|x\| x + 1)` — x inferred from Iterator.Item |
+| Closure parameter types (in context) | No | Inferred: `xs.map(\|x\| x + 1)` — x inferred from the receiver item type |
 | Intermediate expression types | No | Standard local inference |
 
 ### 3.18 Typed holes
@@ -1726,26 +1756,33 @@ match is exhaustive
 
 Guards weaken exhaustiveness: when guards are present, the compiler conservatively requires a catch-all arm.
 
-### 4.14 Const generic evaluation
+### 4.14 Index generic evaluation
 
-Const generic arithmetic is evaluated at compile time during type checking. The compiler maintains a simple evaluator for type-level integer expressions:
+Index expressions are evaluated or normalized during type checking. The
+compiler keeps them symbolic when a parameter is unknown and reduces them when
+all arguments are concrete:
 
 ```text
-eval(N)           = N                    (literal)
-eval(A + B)       = eval(A) + eval(B)    (addition)
-eval(A * B)       = eval(A) * eval(B)    (multiplication)
-eval(A - B)       = eval(A) - eval(B)    (subtraction)
-eval(A / B)       = eval(A) / eval(B)    (division, B ≠ 0)
-eval(min(A, B))   = min(eval(A), eval(B))
-eval(max(A, B))   = max(eval(A), eval(B))
+eval(0)             = 0
+eval(1)             = 1
+eval(N)             = N
+eval(A + B)         = eval(A) + eval(B)
+eval(A * B)         = eval(A) * eval(B)
+eval(min(A, B))     = min(eval(A), eval(B))
+eval(max(A, B))     = max(eval(A), eval(B))
+eval(log(A))        = ceil(log2(max(1, eval(A))))
+eval(span(A, B))    = max(eval(A) - eval(B), 0)
 ```
 
-Division by zero and integer overflow in type-level arithmetic are compile-time errors.
+Overflow in concrete Index arithmetic is a compile-time error. Ordinary
+subtraction and division are intentionally absent; `span` is the only
+saturating difference operator.
 
-When a const generic function is instantiated, the compiler substitutes concrete values and evaluates:
+When an indexed function is instantiated, the compiler substitutes concrete
+Index arguments where available:
 
 ```text
-concat_vec[I64, 3, 5](a, b) → Vec[I64, max: eval(3 + 5)] = Vec[I64, max: 8]
+vec_concat[I64, 3, 5](a, b) -> Vec[I64, max: eval(3 + 5)] = Vec[I64, max: 8]
 ```
 
 ### 4.15 Error set typing
@@ -2079,7 +2116,7 @@ Since this is the first formal type system specification (implemented by `sporec
 | Feature | Migration strategy |
 |---|---|
 | Refinement types (L0) | `Ty::Refined` exists in `sporec-typeck`; extend semantics/predicate classes as needed |
-| Const generics | Add `Ty::Const(value)` variant; extend `App` to accept const args |
+| Index generics | Add an `Index` kind and extend `App` to accept Index arguments |
 | Row-polymorphic effects | Extend EffectSet with effect variables alongside concrete strings |
 
 ## Unresolved questions

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -33,13 +33,13 @@ Ty ::= I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | F32 | F64
       | Named(name)
       | App(name, [Ty])
       | Record([(name, Ty)])
-      | Fn([Ty], Ty, EffectSet)
+      | Fn([Ty], Ty, EffectSet, ErrorSet)
       | Var(u32)
       | Hole(name)
       | Error
 ```
 
-**Reference compiler:** This matches the `Ty` enum shipped in `sporec-typeck` (see `crates/sporec-typeck/src/types.rs`): fixed-width numerics, no `Char`, plus `Tuple` and `Refined`. Single-quoted character literals are rejected in the lexer (**no `Char` type or literals**, `spore` PR #113). **Unsuffixed integer literals infer as `I64` and float literals as `F64`** unless a context forces another fixed width. Many examples in this SEP still write `Int` / `Float`; treat them as informal names for those defaults (`I64` / `F64`) until rewritten.
+**Reference compiler:** This matches the `Ty` enum shipped in `sporec-typeck` (see `crates/sporec-typeck/src/types.rs`): fixed-width numerics, no `Char`, plus `Tuple` and `Refined`. Single-quoted character literals are rejected in the lexer (**no `Char` type or literals**, `spore` PR #113). **Unsuffixed integer literals infer as `I64` and float literals as `F64`** unless a context forces another fixed width. `Int` and `Float` are not primitive names or informal aliases.
 
 **Platform-specific integers (e.g. process exit status).** The core type system does **not** fix a single machine type for exit codes or other host ABI surfaces. Those contracts live in the **Platform package** metadata and startup/exit specifications (see SEP-0008); this SEP only requires that the Spore signature matches whatever that Platform declares.
 
@@ -128,7 +128,7 @@ alias Port = I64 when self >= 1 && self <= 65535
 
 Platform code generation maps these types to machine representations; refinements are checked in the decidable fragment described later in this SEP.
 
-**Informal `Int` / `Float` in examples.** Older text may still write `Int` or `Float` for ergonomics. Until those examples are rewritten, read them as referring to the default scalar widths **`I64` / `F64`** in the reference toolchain.
+**No informal scalar aliases.** Examples and normative text must write fixed-width scalar names (`I64`, `F64`, `U8`, and so on). A project may define its own `alias Int = I64`, but that is ordinary user code and not part of the language prelude.
 
 ### 3.2 Type annotations on functions
 
@@ -220,7 +220,7 @@ summarize(data: { count: named.count, total: named.total })   // OK
 
 ### 3.5 Function types with effects
 
-Function types carry a **EffectSet** — the set of effects the function requires:
+Function types carry an **EffectSet** and an **ErrorSet** — the effects they require and the errors they may propagate:
 
 ```spore
 type Logger = Fn(msg: Str) -> () uses [FileWrite]
@@ -1049,7 +1049,7 @@ The internal type representation is the `Ty` enum, defined in `crates/sporec-typ
     | Named(n)                     // named type / type parameter
     | App(n, [τ₁, …, τₖ])         // generic type application
     | Record([(f₁, τ₁), …])       // anonymous record (structural)
-    | Fn([τ₁, …, τₙ], τᵣ, C)     // function type with effect set
+    | Fn([τ₁, …, τₙ], τᵣ, C, E)  // function type with effect and error sets
     | Var(id)                      // unification variable
     | Hole(name)                   // typed hole placeholder
     | Error                        // error sentinel (recovery)
@@ -1059,7 +1059,8 @@ Where:
 
 - `n` ranges over identifiers (strings).
 - `id` ranges over `u32` (unique unification variable IDs).
-- `C` is a **EffectSet** = `BTreeSet<String>`, the set of effect names the function requires.
+- `C` is an **EffectSet** = `BTreeSet<String>`, the set of effect names the function requires.
+- `E` is an **ErrorSet**, the closed union of error types declared with `!`.
 - `f` ranges over field names (strings) in anonymous records.
 
 **Never type.** `Ty::Never` is the bottom type — a subtype of all types. It is produced by diverging expressions (`panic`, non-terminating recursion). During unification, `unify(τ, Never) = ok` for all `τ`.
@@ -1076,10 +1077,10 @@ Where:
 pub type EffectSet = BTreeSet<String>;
 ```
 
-A `EffectSet` is a sorted set of effect names. It appears as the third component of `Ty::Fn`:
+An `EffectSet` is a sorted set of effect names. It appears as the third component of `Ty::Fn`; the fourth component is the function's `ErrorSet`:
 
 ```text
-Fn([τ₁, …, τₙ], τᵣ, { cap₁, cap₂, … })
+Fn([τ₁, …, τₙ], τᵣ, { cap₁, cap₂, … }, { err₁, err₂, … })
 ```
 
 **EffectSet rules:**
@@ -1092,10 +1093,11 @@ Fn([τ₁, …, τₙ], τᵣ, { cap₁, cap₂, … })
 **Formal effect checking rule:**
 
 ```text
-Γ ⊢ f : Fn([σ₁, …, σₙ], τᵣ, C_f)
+Γ ⊢ f : Fn([σ₁, …, σₙ], τᵣ, C_f, E_f)
 C_caller ⊇ C_f
-─────────────────────────────────────────
-Γ; C_caller ⊢ f(e₁, …, eₙ) : τᵣ
+canonicalize(E_f) ⊆ canonicalize(E_caller)
+────────────────────────────────────────────────────────────
+Γ; C_caller; E_caller ⊢ f(e₁, …, eₙ) : τᵣ
 ```
 
 If `C_f ⊄ C_caller`, the checker emits:
@@ -1281,11 +1283,12 @@ x : τ ∈ Γ
 **Function application (synthesis):**
 
 ```text
-Γ ⊢ f ⇒ Fn([σ₁, …, σₙ], τᵣ, C)
+Γ ⊢ f ⇒ Fn([σ₁, …, σₙ], τᵣ, C, E)
 Γ ⊢ eᵢ ⇐ σᵢ   for i ∈ 1..n
 C ⊆ C_current
-──────────────────────────────────
-Γ; C_current ⊢ f(e₁, …, eₙ) ⇒ τᵣ
+canonicalize(E) ⊆ canonicalize(E_current)
+────────────────────────────────────────────────────
+Γ; C_current; E_current ⊢ f(e₁, …, eₙ) ⇒ τᵣ
 ```
 
 **Let binding (synthesis):**
@@ -1484,10 +1487,10 @@ Record(fields₁) <: Record(fields₂)
 
 ### 4.8 Function types
 
-Function types are `Ty::Fn(params, ret, EffectSet)`:
+Function types are `Ty::Fn(params, ret, EffectSet, ErrorSet)`:
 
 ```text
-Fn([σ₁, …, σₙ], τᵣ, C)
+Fn([σ₁, …, σₙ], τᵣ, C, E)
 ```
 
 A function value is a first-class value. Looking up a function name in the registry when it appears as a bare expression produces its function type:
@@ -1496,8 +1499,8 @@ A function value is a first-class value. Looking up a function name in the regis
 Expr::Var(name) => {
     if let Some(ty) = self.env.lookup(name) {
         ty.clone()
-    } else if let Some((params, ret, caps)) = self.registry.functions.get(name) {
-        Ty::Fn(params.clone(), Box::new(ret.clone()), caps.clone())
+    } else if let Some((params, ret, caps, errs)) = self.registry.functions.get(name) {
+        Ty::Fn(params.clone(), Box::new(ret.clone()), caps.clone(), errs.clone())
     } else {
         self.err(format!("undefined variable `{name}`"));
         Ty::Error
@@ -1551,7 +1554,7 @@ Spore primarily uses **equality-based** type compatibility via unification, with
 
 (Both operands unify to the **same** `Ty`; there is no implicit widening between widths—see §4.9.)
 
-**String concatenation** (`+` only):
+**`Str` concatenation** (`+` only):
 
 ```text
 Γ ⊢ e₁ ⇒ Str    Γ ⊢ e₂ ⇒ Str
@@ -1676,7 +1679,7 @@ Traits are registered in a `TraitRegistry` alongside the `TypeRegistry`. Each tr
 
 - Trait name
 - Supertrait requirements (e.g., `Ord: Eq`)
-- Method signatures (name, parameter types, return type, EffectSet)
+- Method signatures (name, parameter types, return type, EffectSet, ErrorSet)
 - Associated type declarations
 - Default method implementations (if any)
 
@@ -1870,8 +1873,8 @@ All types implement `Display` with a canonical format:
 | `Ty::Named("Foo")` | `Foo` |
 | `Ty::App("List", [I64])` | `List[I64]` |
 | `Ty::Record([(x, I64), (y, F64)])` | `{ x: I64, y: F64 }` |
-| `Ty::Fn([I64], Bool, {})` | `(I64) -> Bool` |
-| `Ty::Fn([I64], Bool, {"Net"})` | `(I64) -> Bool uses [Net]` |
+| `Ty::Fn([I64], Bool, {}, {})` | `(I64) -> Bool` |
+| `Ty::Fn([I64], Bool, {"Net"}, {})` | `(I64) -> Bool uses [Net]` |
 | `Ty::Var(3)` | `?T3` |
 | `Ty::Hole("h1")` | `?h1` |
 | `Ty::Error` | `<error>` |
@@ -2081,7 +2084,7 @@ Since this is the first formal type system specification (implemented by `sporec
 
 ## Unresolved questions
 
-1. **EffectSet in unification.** Currently, function type unification ignores EffectSets (the `_` in `Fn(p1, r1, _), Fn(p2, r2, _)`). Should EffectSets participate in unification, or remain checked separately? Separate checking is simpler but could miss effect mismatches in higher-order function arguments.
+1. **EffectSet in unification.** Currently, function type unification ignores EffectSets and ErrorSets (the `_` placeholders in `Fn(p1, r1, _, _), Fn(p2, r2, _, _)`). Should those sets participate in unification, or remain checked separately? Separate checking is simpler but could miss higher-order mismatches unless call-site validation stays strict.
 
 2. **Generic syntax: square brackets vs angle brackets.** The implemented `Ty::App` uses parenthesized syntax in the AST (`List[I64]`), but some spec examples use angle brackets (`List<T>`). This SEP uses square brackets as the intended syntax; a separate SEP should finalize the concrete syntax.
 

--- a/seps/SEP-0002-type-system.md
+++ b/seps/SEP-0002-type-system.md
@@ -23,8 +23,13 @@ This SEP specifies the type system for the Spore programming language. Spore's t
 
 The concrete type representation is the `Ty` enum:
 
+Implementation note: **`EffectSet`** stores effect names as strings in current compiler internals (`BTreeSet<String>` in Rust). Surface syntax references those names as literal identifiers.
+
 ```text
-Ty ::= Int | Float | Bool | Str | Char | Unit | Never
+Ty ::= I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | F32 | F64
+      | Bool | Str | Unit | Never
+      | Tuple([Ty, …])
+      | Refined(Ty, var, predicate)
       | Named(name)
       | App(name, [Ty])
       | Record([(name, Ty)])
@@ -34,15 +39,25 @@ Ty ::= Int | Float | Bool | Str | Char | Unit | Never
       | Error
 ```
 
+**Reference compiler:** This matches the `Ty` enum shipped in `sporec-typeck` (see `crates/sporec-typeck/src/types.rs`): fixed-width numerics, no `Char`, plus `Tuple` and `Refined`. Single-quoted character literals are rejected in the lexer (**no `Char` type or literals**, `spore` PR #113). **Unsuffixed integer literals infer as `I64` and float literals as `F64`** unless a context forces another fixed width. Many examples in this SEP still write `Int` / `Float`; treat them as informal names for those defaults (`I64` / `F64`) until rewritten.
+
+**Platform-specific integers (e.g. process exit status).** The core type system does **not** fix a single machine type for exit codes or other host ABI surfaces. Those contracts live in the **Platform package** metadata and startup/exit specifications (see SEP-0008); this SEP only requires that the Spore signature matches whatever that Platform declares.
+
+**Formal judgments (mixed style).** Core rules in §4 use concrete `I64` / `F64` where they describe default scalar behavior. Where a rule must range over **all** integer or float widths, this SEP uses **ι** ∈ {`I8`, …, `U64`} and **φ** ∈ {`F32`, `F64`} as metavariables, with the default literal case still **ι = `I64`**, **φ = `F64`** unless stated otherwise.
+
 Key design decisions:
 
 - **Signatures are gravity centers** — function signatures must be richly typed and fully explicit; bodies are inferred.
-- **EffectSet = BTreeSet\<String\>** is encoded directly in function types, making effect tracking a first-class part of the type.
+- **EffectSet** is encoded directly in function types (see implementation note above), making effect tracking a first-class part of the type.
+- **Current implementation note**: the checker currently carries error sets with a
+  similarly plain set-backed internal representation. This wave specifies the
+  target canonicalization-first semantics layered on top of that representation,
+  without requiring a new dedicated `error` declaration surface.
 - **Bidirectional type inference** — top-down checking from signatures, bottom-up synthesis from expressions.
 - **Two-pass module checking** — `register_item` (collect all signatures) then `check_fn` (verify bodies).
-- **Generics via square-bracket application** — `List[Int]`, `Result[T, E]`.
+- **Generics via square-bracket application** — `List[I64]`, `Result[T, E]`.
 - **Type unification** with `Var` binding and substitution maps.
-- **Refinement types (future)** — L0 decidable predicates + L1 abstract interpretation without an SMT solver.
+- **Refinement types** — L0 decidable predicates ship in `sporec-typeck` (`Ty::Refined`); richer L1 abstract interpretation without an SMT solver remains future work.
 
 ## Motivation
 
@@ -51,7 +66,7 @@ Key design decisions:
 Spore is being co-developed by humans and AI Agents. Both audiences need precise, unambiguous rules for:
 
 1. **What programs are well-typed.** Agents generate code that must type-check. Vague rules produce vague code.
-2. **What information flows through signatures.** Signatures are the primary communication channel between components, between humans and Agents, and between Agents. They must encode types, effects, cost bounds, and error sets.
+2. **What information flows through signatures.** Signatures are the primary communication channel between components, between humans and Agents, and between Agents. They must encode types, effects, the four-slot cost clause, and error sets.
 3. **What the compiler guarantees.** Typed holes, structured diagnostics, and fill-suggestions all depend on a well-defined type lattice.
 4. **Where inference ends and annotation begins.** Signatures explicit, bodies inferred — but the boundary must be razor-sharp.
 
@@ -81,51 +96,52 @@ This section introduces Spore's type system from a user's perspective, with code
 
 ### 3.1 Primitive types
 
-Spore provides a small, fixed set of built-in primitive types:
+Spore provides a small, fixed set of built-in **numeric widths**, text, and logical primitives:
 
-| Type | Description | Default Literal |
+| Type | Description | Notes |
 |---|---|---|
-| `Int` | Arbitrary-precision integer | `42` |
-| `Float` | 64-bit IEEE 754 floating point | `3.14` |
+| `I8`, `I16`, `I32`, `I64` | Signed integers | Unsuffixed literals default to **`I64`** in `sporec-typeck` |
+| `U8`, `U16`, `U32`, `U64` | Unsigned integers | |
+| `F32`, `F64` | IEEE-754 binary floats | Literals default to `F64` in the reference checker |
 | `Bool` | Boolean | `true`, `false` |
-| `String` | UTF-8 string | `"hello"` |
-| `Char` | Unicode scalar value | `'a'` |
+| `Str` | UTF-8 string | Use `"x"` even for a single Unicode scalar; there is **no** `Char` type |
 | `Unit` | Zero-information type (like Rust `()`) | `()` |
 | `Never` | Bottom type — uninhabited, no values exist | (no literal) |
 
 ```spore
-let x: Int = 42              // arbitrary-precision integer
-let y: Float = 3.14          // 64-bit IEEE 754
+let x: I64 = 42              // default integer literal type (I64)
+let y: F64 = 3.14            // default float literal type (F64)
 let b: Bool = true           // boolean
-let s: String = "hello"      // UTF-8 string
-let c: Char = 'a'            // Unicode scalar value
+let s: Str = "hello"         // UTF-8 string
+let grapheme: Str = "世"     // still `Str`, not a separate character type
 let u: () = ()               // unit (zero-information type)
 ```
 
-All primitives are nominal — `Int` ≠ `Float` even when their bit patterns coincide.
+Distinct numeric widths are **not** interchangeable without an explicit conversion story (still evolving). `Str` is unrelated to any numeric width.
 
-**Numeric sub-types via refinement.** Rather than proliferating primitive numeric types (i8, u16, f32, …), Spore uses refinement types on `Int` and `Float`:
+**Narrower domains via refinement.** Bounds and lightweight predicates attach to a fixed-width base type (the reference compiler supports this for aliases such as `alias Port = I64 when …`):
 
 ```spore
-type U8  = Int when 0 <= self <= 255
-type I32 = Int when -2147483648 <= self <= 2147483647
-type F32 = Float when self.precision == 32
+alias NonNegativeI64 = I64 when self >= 0
+alias Port = I64 when self >= 1 && self <= 65535
 ```
 
-Platform effects determine the runtime representation; the type system reasons about logical constraints, and the codegen layer maps to machine types.
+Platform code generation maps these types to machine representations; refinements are checked in the decidable fragment described later in this SEP.
+
+**Informal `Int` / `Float` in examples.** Older text may still write `Int` or `Float` for ergonomics. Until those examples are rewritten, read them as referring to the default scalar widths **`I64` / `F64`** in the reference toolchain.
 
 ### 3.2 Type annotations on functions
 
-Function signatures **must** be fully annotated. Parameters, return type, error set, effect set, and cost bound are all declared:
+Function signatures **must** be fully annotated. Parameters, return type, error set, effect set, and `cost [c, a, i, p]` clause are all declared:
 
 ```spore
-fn add(a: Int, b: Int) -> Int {
+fn add(a: I64, b: I64) -> I64 {
     a + b
 }
 
-fn fetch_page(url: String) -> String ! NetworkError
+fn fetch_page(url: Str) -> Str ! NetworkError
 uses [NetConnect]
-cost <= 5000
+cost [5000, 200, 5000, 2]
 {
     http_get(url)
 }
@@ -134,40 +150,39 @@ cost <= 5000
 Local variables inside bodies do **not** need annotations — they are inferred:
 
 ```spore
-fn process(x: Int) -> Int {
-    let doubled = x * 2          // inferred: Int
-    let message = "result"       // inferred: String
-    doubled + 1                  // inferred: Int, checked against return type
+fn process(x: I64) -> I64 {
+    let doubled = x * 2          // inferred: I64
+    let message = "result"       // inferred: Str
+    doubled + 1                  // inferred: I64, checked against return type
 }
 ```
 
 ### 3.3 Struct and enum types
 
-> **Note (N7):** Product types use the `struct` keyword: `struct Point { x: Float, y: Float }`. The `type` keyword is reserved for sum types/ADTs. The examples below use `type` with record syntax for historical reasons; canonical Spore uses `struct` for product types.
-
-Structs are nominal product types:
+**Structs** (`struct`) are nominal product types. **`type`** with variants defines sealed sums (ADTs).
 
 ```spore
-type Point = {
-    x: Float,
-    y: Float,
+struct Point {
+    x: F64,
+    y: F64,
 }
 
 let p = Point { x: 1.0, y: 2.0 }
 let dist = sqrt(p.x * p.x + p.y * p.y)
-```
 
-Enums are sealed sum types with exhaustive pattern matching:
-
-```spore
 type Shape =
-    | Circle { radius: Float }
-    | Rectangle { width: Float, height: Float }
+    Circle { radius: F64 }
+    | Rectangle { width: F64, height: F64 }
+    | Triangle { a: F64, b: F64, c: F64 }
 
-fn area(shape: Shape) -> Float {
+fn area(shape: Shape) -> F64 {
     match shape {
         Circle { radius }           => 3.14159 * radius * radius,
         Rectangle { width, height } => width * height,
+        Triangle { a, b, c } => {
+            let sper = (a + b + c) / 2.0;
+            sqrt(sper * (sper - a) * (sper - b) * (sper - c))
+        },
     }
 }
 ```
@@ -177,13 +192,13 @@ fn area(shape: Shape) -> Float {
 Anonymous records are the structural escape hatch. They have no declared name and are compatible by field shape, not by declaration site.
 
 ```spore
-fn greet(person: { name: String, age: Int }) -> String {
+fn greet(person: { name: Str, age: I64 }) -> Str {
     "Hello, " ++ person.name ++ " (age " ++ show(person.age) ++ ")"
 }
 
 // Any value with matching fields satisfies this:
 let alice = { name: "Alice", age: 30, role: "Engineer" }
-greet(alice)   // OK: alice has name: String and age: Int (extra fields ignored)
+greet(alice)   // OK: alice has name: Str and age: I64 (extra fields ignored)
 ```
 
 **Rules for anonymous records**:
@@ -191,13 +206,13 @@ greet(alice)   // OK: alice has name: String and age: Int (extra fields ignored)
 1. **Width subtyping**: A record with extra fields satisfies a type expecting fewer fields.
 2. **Exact field matching**: Field names and types must match exactly (no implicit conversion).
 3. **No trait implementation**: Anonymous records cannot implement traits or effects — nominal types are required for that.
-4. **Nominal types do NOT satisfy anonymous record types**: `type Stats = { count: Int }` is nominal and is NOT compatible with `{ count: Int }`.
+4. **Nominal types do NOT satisfy anonymous record types**: `struct Stats { count: I64 }` is nominal and is NOT compatible with `{ count: I64 }`.
 
 ```spore
 // Named types do NOT satisfy anonymous record types:
-type Stats = { count: Int, total: Float }
+struct Stats { count: I64, total: F64 }
 let named = Stats { count: 10, total: 95.5 }
-// summarize(data: named)  // ERROR: Stats is nominal, not { count: Int, total: Float }
+// summarize(data: named)  // ERROR: Stats is nominal, not { count: I64, total: F64 }
 
 // Explicit conversion required:
 summarize(data: { count: named.count, total: named.total })   // OK
@@ -208,9 +223,9 @@ summarize(data: { count: named.count, total: named.total })   // OK
 Function types carry a **EffectSet** — the set of effects the function requires:
 
 ```spore
-type Logger = Fn(msg: String) -> () uses [FileWrite]
+type Logger = Fn(msg: Str) -> () uses [FileWrite]
 
-fn with_logging(f: Fn(x: Int) -> Int, x: Int) -> Int
+fn with_logging(f: Fn(x: I64) -> I64, x: I64) -> I64
 uses [FileWrite]
 {
     log("calling f")
@@ -243,9 +258,9 @@ where T: Ord
 At call sites, type arguments are inferred from the actual argument types:
 
 ```spore
-let nums: List[Int] = [1, 2, 3]
-let result = identity(42)          // T inferred as Int
-let strings = map(nums, show)      // A=Int, B=String inferred
+let nums: List[I64] = [1, 2, 3]
+let result = identity(42)          // T inferred as I64
+let strings = map(nums, show)      // A=I64, B=Str inferred
 ```
 
 ### 3.7 Generic type application
@@ -253,15 +268,15 @@ let strings = map(nums, show)      // A=Int, B=String inferred
 Named generic types use square-bracket application in type position:
 
 ```spore
-type Pair[A, B] = {
+struct Pair[A, B] {
     first: A,
     second: B,
 }
 
-let p: Pair[Int, String] = Pair { first: 1, second: "hello" }
+let p: Pair[I64, Str] = Pair { first: 1, second: "hello" }
 
 type Result[T, E] =
-    | Ok { value: T }
+    Ok { value: T }
     | Err { error: E }
 ```
 
@@ -270,12 +285,12 @@ type Result[T, E] =
 **Newtypes** create zero-cost nominal wrappers. The new type is distinct from its underlying type:
 
 ```spore
-type UserId = String       // nominal wrapper: UserId ≠ String
-type Email = String        // nominal: Email ≠ UserId ≠ String
-type Celsius = Float       // nominal: Celsius ≠ Fahrenheit
-type Fahrenheit = Float
+type UserId = Str       // nominal wrapper: UserId ≠ Str
+type Email = Str        // nominal: Email ≠ UserId ≠ Str
+type Celsius = F64       // nominal: Celsius ≠ Fahrenheit
+type Fahrenheit = F64
 
-fn format_temp(temp: Celsius) -> String {
+fn format_temp(temp: Celsius) -> Str {
     show(temp) ++ "°C"
 }
 
@@ -283,26 +298,26 @@ let c: Celsius = 100.0
 let f: Fahrenheit = 212.0
 format_temp(temp: c)    // OK
 format_temp(temp: f)    // ERROR: expected Celsius, got Fahrenheit
-format_temp(temp: 98.6) // ERROR: expected Celsius, got Float
+format_temp(temp: 98.6) // ERROR: expected Celsius, got F64
 ```
 
 Newtypes may have refinements:
 
 ```spore
-type Port = Int when 1 <= self <= 65535
-type NonEmptyString = String when self.len() > 0
-type Latitude = Float when -90.0 <= self <= 90.0
+type Port = I64 when 1 <= self <= 65535
+type NonEmptyStr = Str when self.len() > 0
+type Latitude = F64 when -90.0 <= self <= 90.0
 ```
 
 **Type aliases** are transparent — interchangeable with their definition:
 
 ```spore
-alias StringList = List[String]
+alias TextList = List[Str]
 alias Callback[T] = Fn(event: T) -> Unit
 alias Result[T] = T ! GenericError
 
-type UserId = String       // newtype: UserId ≠ String (nominal)
-alias UserName = String    // alias: UserName == String (transparent)
+type SessionId = Str       // newtype: SessionId ≠ Str (nominal)
+alias Label = Str    // alias: Label == Str (transparent)
 ```
 
 ### 3.9 Trait system
@@ -321,12 +336,12 @@ trait Ord: Eq {
 }
 
 trait Display {
-    fn display(self) -> String
+    fn display(self) -> Str
 }
 
 trait Serialize {
     fn serialize(self) -> Bytes ! SerializeError
-    cost serialize <= 100
+        cost [100, 20, 0, 1]
 }
 ```
 
@@ -351,7 +366,7 @@ impl Ord for Point {
 }
 
 impl Display for Shape {
-    fn display(self) -> String {
+    fn display(self) -> Str {
         match self {
             Circle { radius }           => "Circle(r=" ++ show(radius) ++ ")",
             Rectangle { width, height } => "Rect(" ++ show(width) ++ "x" ++ show(height) ++ ")",
@@ -366,7 +381,7 @@ Default method implementations are supported:
 ```spore
 trait Collection {
     type Item
-    fn len(self) -> Int
+    fn len(self) -> I64
     fn is_empty(self) -> Bool { self.len() == 0 }   // default method
 }
 ```
@@ -378,7 +393,7 @@ Trait bounds constrain generic type parameters in `where` clauses:
 ```spore
 fn sort[T](list: List[T]) -> List[T]
 where T: Ord
-cost <= 500
+cost [500, 100, 0, 1]
 {
     // implementation
 }
@@ -393,7 +408,7 @@ where T: Serialize + Display
 Multiple bounds use `+`:
 
 ```spore
-fn dedup_and_display[T](items: List[T]) -> String
+fn dedup_and_display[T](items: List[T]) -> Str
 where T: Eq + Hash + Display
 {
     items |> unique() |> map(|x| x.display()) |> join(", ")
@@ -436,12 +451,12 @@ Traits may declare associated types — types determined by the implementing typ
 trait Iterator {
     type Item
     fn next(self) -> Option[Self.Item]
-    cost next <= 10
+        cost [10, 80, 0, 1]
 }
 
 impl Iterator for LineReader {
-    type Item = String
-    fn next(self) -> Option[String] {
+    type Item = Str
+    fn next(self) -> Option[Str] {
         self.read_line()
     }
 }
@@ -451,7 +466,7 @@ trait Collection {
     type Iter: Iterator where Iter.Item == Self.Item
 
     fn iter(self) -> Self.Iter
-    fn len(self) -> Int
+    fn len(self) -> I64
     fn is_empty(self) -> Bool { self.len() == 0 }
 }
 ```
@@ -460,10 +475,10 @@ Associated types eliminate extra type parameters on trait users:
 
 ```spore
 // Clean — associated types:
-fn sum_all[C](collection: C) -> Int
+fn sum_all[C](collection: C) -> I64
 where
     C: Collection,
-    C.Item: Add[Output = Int]
+    C.Item: Add[Output = I64]
 {
     collection.iter() |> fold(0, |acc, item| acc + item)
 }
@@ -519,9 +534,9 @@ Spore provides compiler-known traits for common operations:
 Derivable traits can be auto-implemented by the compiler for types whose fields all implement the trait:
 
 ```spore
-type Point = {
-    x: Float,
-    y: Float,
+struct Point {
+    x: F64,
+    y: F64,
 } deriving [Eq, Clone, Debug, Hash]
 ```
 
@@ -534,20 +549,20 @@ You can only implement a trait for a type if you own either the trait or the typ
 impl Display for Point { ... }
 
 // OK: you own MyTrait, so you can implement it for any type
-impl MyTrait for String { ... }
+impl MyTrait for Str { ... }
 
-// ERROR: you own neither Display nor String
-impl Display for String { ... }   // orphan rule violation
+// ERROR: you own neither Display nor Str
+impl Display for Str { ... }   // orphan rule violation
 ```
 
 **Adapter escape mechanism** for implementing foreign traits on foreign types:
 
 ```spore
 adapter ExternalType as Printable {
-    fn display(self) -> String { ... }
+    fn display(self) -> Str { ... }
 }
 
-fn use_external(x: ExternalType) -> String
+fn use_external(x: ExternalType) -> Str
 where adapter: ExternalType as Printable
 {
     x.display()
@@ -560,46 +575,49 @@ Adapters are always scoped and explicit — they cannot cause global coherence v
 
 #### Const generic parameters
 
-Const generics allow value-level parameters in type position, central to Spore's bounded collections and cost-aware types:
+### List vs `Vec`
+
+**Naming invariant:** **`List[T]` is always unbounded** — the `List` constructor never carries a `max:` parameter. **`Vec[T, max: N]` is always bounded** — every `Vec` declares a compile-time cap `N` (const-generic), useful when the **type system** must know a fixed capacity (e.g. small matrices, SIMD lanes, rare “cap in the type” APIs).
+
+**Style rule:** **`List[T]` is the default** for almost all APIs, examples, and iteration. Model sizes and budgets with `cost [...]`, refinements, and runtime checks on `len` as usual—**do not** sprinkle `Vec[..., max: N]` unless you genuinely need `N` in the type.
+
+**`Vec`** is for const-generic layouts (see below)—not for everyday collections.
+
+Const generics allow value-level parameters in type position. Spore commonly uses them for **`Matrix`**, **`Array[T, N]`**, and the optional **`Vec[T, max: N]`** packed buffer type:
 
 ```spore
-type Vec[T, max: Int] = {
+struct Vec[T, max: I64] {
     data: Array[T],
-    len: Int,
+    len: I64,
 }
 
-fn take[T, N: Int](list: List[T], count: N) -> Vec[T, max: N]
-where N <= list.max
+// Typical slicing stays on List — no Vec required:
+fn take[T](list: List[T], n: I64) -> List[T]
 {
-    // implementation
+    // prefix of length ≤ n (empty if n ≤ 0); cost keyed off n and list.len()
 }
 
-type Matrix[T, rows: Int, cols: Int] = {
+struct Matrix[T, rows: I64, cols: I64] {
     data: Array[Array[T]],
 }
 ```
 
 #### Type-level arithmetic
 
-Const generic parameters support arithmetic in type-level expressions, enabling compile-time dimensional checking:
+Const generic parameters support arithmetic in type-level expressions, enabling compile-time dimensional checking (mostly for **`Matrix`** / **`Array`**, not for ordinary `List` code):
 
 ```spore
-fn concat[T, M: Int, N: Int](
-    a: Vec[T, max: M],
-    b: Vec[T, max: N],
-) -> Vec[T, max: M + N] {
-    // implementation
-}
-
-fn transpose[T, R: Int, C: Int](
+fn transpose[T, R: I64, C: I64](
     matrix: Matrix[T, rows: R, cols: C],
 ) -> Matrix[T, rows: C, cols: R] {
     // implementation
 }
 
-fn flatten[T, N: Int, M: Int](
-    nested: Vec[Vec[T, max: M], max: N],
-) -> Vec[T, max: N * M] {
+// Optional: only when Vec's max must appear in the type (buffers with static M+N):
+fn concat_vec[T, M: I64, N: I64](
+    a: Vec[T, max: M],
+    b: Vec[T, max: N],
+) -> Vec[T, max: M + N] {
     // implementation
 }
 ```
@@ -608,25 +626,25 @@ Supported arithmetic operations in type position: `+`, `-`, `*`, `/`, `%`, `min`
 
 #### Interaction with cost
 
-Const generics interact naturally with the cost system. A function's cost may depend on its const generic parameters:
+Cost clauses usually refer to **runtime** sizes (`items.len`, parameters, refinements). **`List[T]`** is enough for those budgets—**no `Vec` required**:
 
 ```spore
-fn linear_search[T, N: Int](items: Vec[T, max: N], target: T) -> Option[Int]
+fn linear_search[T](items: List[T], target: T) -> Option[I64]
 where T: Eq
-cost <= N * 5
+cost [items.len * 5, items.len, 0, 1]
 {
-    // O(N) search, cost scales linearly
+    // O(n) search; n = items.len
 }
 
-fn sort_bounded[T, N: Int](items: Vec[T, max: N]) -> Vec[T, max: N]
+fn sort_list[T](items: List[T]) -> List[T]
 where T: Ord
-cost <= N * N * 2
+cost [items.len * items.len * 2, items.len, 0, 1]
 {
-    // O(N²) worst case
+    // worst-case O(n²); n = items.len
 }
 ```
 
-Calling `sort_bounded` on a `Vec[T, max: 100]` implies cost ≤ 20000 — the compiler verifies this parametrically.
+When you **do** use `Vec[T, max: N]`, the declared `N` can appear directly in `cost [...]` (parametric verification). That pattern is specialized; prefer `List` + len-indexed cost for most functions.
 
 ### 3.11 Pattern matching
 
@@ -635,7 +653,7 @@ Spore requires **full, exhaustive pattern matching** on all enums. The compiler 
 #### Exhaustiveness checking
 
 ```spore
-fn describe(shape: Shape) -> String {
+fn describe(shape: Shape) -> Str {
     match shape {
         Circle { radius }           => "circle with radius " ++ show(radius),
         Rectangle { width, height } => show(width) ++ "x" ++ show(height) ++ " rectangle",
@@ -662,7 +680,7 @@ Patterns can be nested to match deeply into data structures:
 
 ```spore
 type Expr =
-    | Literal { value: Int }
+    Literal { value: I64 }
     | BinOp { op: Op, left: Expr, right: Expr }
     | UnaryOp { op: Op, operand: Expr }
 
@@ -684,7 +702,7 @@ fn simplify(expr: Expr) -> Expr {
 Nested Option/Result matching:
 
 ```spore
-fn handle(value: Option[Result[Int, String]]) -> Int {
+fn handle(value: Option[Result[I64, Str]]) -> I64 {
     match value {
         Some(Ok(n))    => n,
         Some(Err(msg)) => panic("error: " ++ msg),
@@ -698,7 +716,7 @@ fn handle(value: Option[Result[Int, String]]) -> Int {
 Guards add boolean conditions to pattern branches:
 
 ```spore
-fn classify_temperature(temp: Float) -> String {
+fn classify_temperature(temp: F64) -> Str {
     match temp {
         t if t < -40.0  => "extreme cold",
         t if t < 0.0    => "freezing",
@@ -737,7 +755,7 @@ fn is_simple_shape(shape: Shape) -> Bool {
 Pattern matching works in `let` bindings:
 
 ```spore
-fn distance(a: Point, b: Point) -> Float {
+fn distance(a: Point, b: Point) -> F64 {
     let Point { x: x1, y: y1 } = a
     let Point { x: x2, y: y2 } = b
     sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1))
@@ -750,7 +768,7 @@ fn distance(a: Point, b: Point) -> Float {
 - `..` in struct patterns matches remaining fields.
 
 ```spore
-fn get_name(person: Person) -> String {
+fn get_name(person: Person) -> Str {
     let Person { name, .. } = person
     name
 }
@@ -758,10 +776,11 @@ fn get_name(person: Person) -> String {
 
 #### Pattern matching on error types
 
-Pattern matching integrates with Spore's row-typed error sets for exhaustive error handling:
+Pattern matching integrates with Spore's closed error sets for exhaustive error
+handling:
 
 ```spore
-fn handle_result(result: Invoice ! TaxError | ValidationError) -> String {
+fn handle_result(result: Invoice ! TaxError | ValidationError) -> Str {
     match result {
         Ok(invoice) => "Invoice #" ++ show(invoice.id),
         Err(TaxError { region, reason }) => "Tax error in " ++ show(region) ++ ": " ++ reason,
@@ -777,7 +796,7 @@ fn handle_result(result: Invoice ! TaxError | ValidationError) -> String {
 ```spore
 fn process_payment(amount: Money, card: Card) -> Receipt ! PaymentFailed
 uses [PaymentGateway, AuditLog]
-cost <= 2000
+cost [2000, 400, 200, 2]
 {
     let validated = validate_card(card)
     @allows[charge, charge_with_retry]
@@ -797,7 +816,7 @@ cost <= 2000
 ```spore
 fn build_dashboard(org: Org) -> Dashboard ! DataError
 uses [Database, Cache, Analytics]
-cost <= 20000
+cost [20000, 2000, 1000, 8]
 {
     @allows[fetch_cached_metrics, compute_summary]
     let metrics = ?gather_metrics
@@ -823,13 +842,13 @@ Error: @allows violation
 `Never` is the bottom type — it has no values and is a subtype of every type. It is the return type of functions that do not return (diverging functions).
 
 ```spore
-fn abort(msg: String) -> Never {
+fn abort(msg: Str) -> Never {
     panic(msg)
 }
 
-fn safe_divide(a: Int, b: Int) -> Int {
+fn safe_divide(a: I64, b: I64) -> I64 {
     if b == 0 {
-        abort("division by zero")   // Never coerces to Int
+        abort("division by zero")   // Never coerces to I64
     } else {
         a / b
     }
@@ -854,16 +873,48 @@ fn safe_unwrap[T](opt: Option[T]) -> T {
 - Exhaustive match arms that provably never execute
 - Error-only functions that always raise
 
-### 3.14 Row-type error sets
+### 3.14 Canonicalized error sets
 
-Spore's `! Err1 | Err2` is a **closed, row-typed error union**. Error types are themselves enum variants (ADTs), and the `!` syntax computes unions automatically across call chains:
+Spore's `! Err1 | Err2` is a **closed error set** written in surface form but
+checked with **canonicalization-first semantics**. Error types are nominal ADTs;
+the checker resolves each written item to a canonical identity, removes
+duplicates, and compares sets using that canonical form across call chains.
+
+Current implementation note: the shipping checker already supports the
+`! E1 | E2` surface and stores propagated error requirements in a plain set-like
+internal form. This section defines the **target behavior of this wave**:
+canonical subset/equivalence checks, redundancy diagnostics, and conservative
+hashing. It does **not** require a new top-level `error Alias = ...` syntax.
+
+```text
+canonicalize(E_written):
+  1. resolve each written error item to its canonical nominal identity
+  2. drop duplicates and canonically equivalent spellings
+  3. order the result by a stable canonical key for comparison / diagnostics
+```
+
+Two written error clauses are **equivalent** when their canonicalized sets are
+equal, even if their source spelling differs. A caller is **compatible** with a
+callee when `canonicalize(E_callee) ⊆ canonicalize(E_caller)`.
 
 ```spore
-fn parse(input: String) -> Ast ! SyntaxError | EncodingError
+alias ParseFailure = config.errors.ParseError
+
+fn parse(input: Str) -> Ast ! config.errors.ParseError
+fn parse_again(input: Str) -> Ast ! ParseFailure | config.errors.ParseError
+```
+
+`parse_again` is semantically equivalent to `! config.errors.ParseError`; the
+second item is redundant and should be diagnosed as such.
+
+Error sets still compose automatically via `?` propagation:
+
+```spore
+fn parse(input: Str) -> Ast ! SyntaxError | EncodingError
 fn validate(ast: Ast) -> ValidAst ! TypeError | RangeError
 
 // Error sets union automatically via `?` propagation:
-fn compile(input: String) -> ValidAst ! SyntaxError | EncodingError | TypeError | RangeError {
+fn compile(input: Str) -> ValidAst ! SyntaxError | EncodingError | TypeError | RangeError {
     let ast = parse(input)?
     validate(ast)?
 }
@@ -872,17 +923,27 @@ fn compile(input: String) -> ValidAst ! SyntaxError | EncodingError | TypeError 
 Each error type carries structured data:
 
 ```spore
-type SyntaxError = {
-    line: Int,
-    column: Int,
-    message: String,
-    snippet: String,
+struct SyntaxError {
+    line: I64,
+    column: I64,
+    message: Str,
+    snippet: Str,
 }
 ```
 
-**Error set subtyping**: A function with error set `! A` can be called where `! A | B` is expected — the caller's error set is a superset.
+**Canonical subset rule**: A function with error set `! A` can be called where
+`! A | B` is expected when `canonicalize({A}) ⊆ canonicalize({A, B})`.
 
-**`?` operator**: Propagates errors, automatically widening the error set. If `f()` returns `T ! E1` and `g()` returns `T ! E2`, calling both with `?` in the same function requires the enclosing function to declare `! E1 | E2` (or a superset).
+**`?` operator**: Propagates errors by canonical subset check. If `f()` returns
+`T ! E1` and `g()` returns `T ! E2`, calling both with `?` in the same function
+requires the enclosing function to declare a canonical superset of
+`canonicalize({E1, E2})`.
+
+**Redundancy diagnostics**: If a declaration writes duplicate or canonically
+equivalent error items, the compiler should keep checking against the
+canonicalized set but emit a structured redundancy diagnostic. User-facing text
+should stay engineering-oriented, e.g. "redundant error item `ParseFailure`:
+already covered by `config.errors.ParseError`".
 
 ### 3.15 Recursive types
 
@@ -890,30 +951,30 @@ Enums and structs may be recursive. The compiler detects and supports this:
 
 ```spore
 type Expr =
-    | Literal { value: Int }
+    Literal { value: I64 }
     | BinOp { op: Op, left: Expr, right: Expr }
     | UnaryOp { op: Op, operand: Expr }
     | IfExpr { cond: Expr, then_branch: Expr, else_branch: Expr }
 
 type JsonValue =
-    | JsonNull
+    JsonNull
     | JsonBool { value: Bool }
-    | JsonNumber { value: Float }
-    | JsonString { value: String }
+    | JsonNumber { value: F64 }
+    | JsonString { value: Str }
     | JsonArray { elements: List[JsonValue] }
-    | JsonObject { fields: List[{ key: String, value: JsonValue }] }
+    | JsonObject { fields: List[{ key: Str, value: JsonValue }] }
 ```
 
 **Infinite-size check**: The compiler rejects types that would require infinite memory without indirection:
 
 ```spore
 // ERROR: infinite-size type (struct directly contains itself)
-type Bad = {
+struct Bad {
     next: Bad,   // Bad contains Bad with no indirection
 }
 
 // OK: indirection via List breaks the cycle
-type Tree[T] = {
+struct Tree[T] {
     value: T,
     children: List[Tree[T]],   // List provides indirection
 }
@@ -923,7 +984,7 @@ type Tree[T] = {
 
 | Context | Typing Discipline | Rationale |
 |---|---|---|
-| Named types (`type X = ...`) | **Nominal** | `UserId ≠ String` even if same shape |
+| Named types (`struct` / `type` with variants) | **Nominal** | `UserId ≠ Str` even if same representation |
 | Enums | **Nominal** | Sealed, exhaustiveness-checked |
 | Traits / effects | **Nominal** | Explicit `impl` required |
 | Effects | **Nominal** (always) | Security boundary — no structural coincidence |
@@ -939,7 +1000,7 @@ type Tree[T] = {
 | Function return type | **Yes** | Agent reads signatures for synthesis; human reads for understanding |
 | Error sets (`! ...`) | **Yes** | Error contract — must be visible |
 | Effect sets (`uses [...]`) | **Yes** | Security boundary — must be visible |
-| Cost bounds (`cost <=`) | **Yes** | Performance contract — must be visible |
+| Cost clause (`cost [c, a, i, p]`) | **Yes** | Performance contract — must be visible |
 | Struct/type field types | **Yes** | Data definition — must be explicit |
 | Trait method signatures | **Yes** | Interface contract |
 | Public constants | **Yes** | API surface |
@@ -953,8 +1014,8 @@ type Tree[T] = {
 Holes are unfilled positions in code. The type checker infers their expected type from context and reports it:
 
 ```spore
-fn example(x: Int, y: String) -> Bool {
-    let a: Int = ?h1          // hole ?h1 must produce Int
+fn example(x: I64, y: Str) -> Bool {
+    let a: I64 = ?h1          // hole ?h1 must produce I64
     let b = if a > 0 {
         ?h2                   // hole ?h2 must produce Bool (from return type)
     } else {
@@ -967,7 +1028,7 @@ fn example(x: Int, y: String) -> Bool {
 The compiler reports:
 
 ```text
-Hole ?h1: expected type Int
+Hole ?h1: expected type I64
 Hole ?h2: expected type Bool
 ```
 
@@ -975,16 +1036,16 @@ Hole ?h2: expected type Bool
 
 ### 4.1 Type grammar
 
-The internal type representation is the `Ty` enum, defined in `spore-typeck/src/types.rs`:
+The internal type representation is the `Ty` enum, defined in `crates/sporec-typeck/src/types.rs`:
 
 ```text
-τ ::= Int                          // integer primitive
-    | Float                        // floating-point primitive
+τ ::= I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 | F32 | F64
     | Bool                         // boolean primitive
-    | Str                          // string primitive (displays as String)
-    | Char                         // Unicode scalar value
-    | Unit                         // unit type
+    | Str                          // UTF-8 string (`Str` in surface syntax)
+    | Unit                         // unit type (also `()`); empty tuple syntax normalizes here
     | Never                        // bottom type (uninhabited)
+    | Tuple([τ₁, …, τₙ])          // tuple type (n ≥ 2; empty tuple is Unit)
+    | Refined(τ, var, predicate) // refinement (decidable fragment)
     | Named(n)                     // named type / type parameter
     | App(n, [τ₁, …, τₖ])         // generic type application
     | Record([(f₁, τ₁), …])       // anonymous record (structural)
@@ -1003,7 +1064,7 @@ Where:
 
 **Never type.** `Ty::Never` is the bottom type — a subtype of all types. It is produced by diverging expressions (`panic`, non-terminating recursion). During unification, `unify(τ, Never) = ok` for all `τ`.
 
-**Record type.** `Ty::Record` represents anonymous structural records. Width subtyping applies: `Record([(a, Int), (b, String), (c, Bool)])` is a subtype of `Record([(a, Int), (b, String)])`.
+**Record type.** `Ty::Record` represents anonymous structural records. Width subtyping applies: `Record([(a, I64), (b, Str), (c, Bool)])` is a subtype of `Record([(a, I64), (b, Str)])`.
 
 **Error sentinel.** `Ty::Error` is produced when type resolution fails (e.g., unknown type name). It unifies with anything, allowing the checker to continue after errors and report multiple diagnostics.
 
@@ -1072,13 +1133,21 @@ The core type system uses bidirectional typing with effect context.
   ─────────────────
   Γ; S ⊢ x ⇒ T
 
-[Literal-Int]
+[Literal-I64]
   ─────────────────
-  Γ; S ⊢ n ⇒ Int
+  Γ; S ⊢ n ⇒ I64
+
+  (Default unsuffixed integer literal per §3.1; a checking context may instead fix another **ι** ∈ {`I8`, …, `U64`}.)
+
+[Literal-F64]
+  ─────────────────
+  Γ; S ⊢ c ⇒ F64
+
+  (Default unsuffixed float literal per §3.1; a checking context may instead fix another **φ** ∈ {`F32`, `F64`}.)
 
 [Literal-Str]
   ─────────────────
-  Γ; S ⊢ s ⇒ String
+  Γ; S ⊢ s ⇒ Str
 
 [Literal-Bool]
   ─────────────────
@@ -1185,14 +1254,14 @@ Spore uses **bidirectional type checking** with two modes:
 
 #### Inference rules (core subset)
 
-**Literals (synthesis):**
+**Literals (synthesis):** default widths are §3.1 (`I64`, `F64`). For a non-default fixed width, read those conclusions as **ι** / **φ** when a context, annotation, or suffix fixes another member of the same families.
 
 ```text
 ─────────────────
-Γ ⊢ n ⇒ Int          (integer literal)
+Γ ⊢ n ⇒ I64          (integer literal)
 
 ─────────────────
-Γ ⊢ f ⇒ Float        (float literal)
+Γ ⊢ c ⇒ F64        (float literal)
 
 ─────────────────
 Γ ⊢ s ⇒ Str          (string literal)
@@ -1385,7 +1454,7 @@ S.fields = [(f₁, τ₁), …, (fₙ, τₙ)]
 
 ### 4.7 Anonymous record types
 
-Anonymous records are represented as `Ty::Record(Vec<(String, Ty)>)`. Record construction synthesizes the type from field expressions:
+Anonymous records are represented as `Ty::Record(Vec<(InternedFieldName, Ty)>)` (field labels stored as interned UTF-8 identifiers in the implementation). Record construction synthesizes the type from field expressions:
 
 ```text
 Γ ⊢ e₁ ⇒ τ₁  …  Γ ⊢ eₖ ⇒ τₖ
@@ -1411,7 +1480,7 @@ fields₁ ⊇ fields₂  (by field name)
 Record(fields₁) <: Record(fields₂)
 ```
 
-**Nominal types do NOT satisfy anonymous record types.** `Named("Point")` and `Record([(x, Float), (y, Float)])` are distinct types even if `Point` has the same fields.
+**Nominal types do NOT satisfy anonymous record types.** `Named("Point")` and `Record([(x, F64), (y, F64)])` are distinct types even if `Point` has the same fields.
 
 ### 4.8 Function types
 
@@ -1439,31 +1508,55 @@ Expr::Var(name) => {
 **Display format for function types:**
 
 ```text
-(Int, String) -> Bool
-(Int) -> Int uses [FileRead, NetConnect]
+(I64, Str) -> Bool
+(I64) -> I64 uses [FileRead, NetConnect]
 ```
 
 ### 4.9 Subtyping
 
 Spore primarily uses **equality-based** type compatibility via unification, with targeted subtyping for specific cases:
 
-- `Int ≠ Float` — no implicit numeric widening.
-- `Named("UserId") ≠ Named("String")` — newtypes are distinct.
+- `I64 ≠ F64` — no implicit numeric widening.
+- `Named("UserId") ≠ Named("Str")` — newtypes are distinct.
 - `Ty::Error` unifies with anything (error recovery only).
 - `Ty::Hole(name)` unifies with anything (hole placeholder only).
 - `Ty::Never` unifies with anything (`Never <: τ` for all `τ`).
-- Width subtyping for anonymous records: `{ a: Int, b: String, c: Bool } <: { a: Int, b: String }`.
+- Width subtyping for anonymous records: `{ a: I64, b: Str, c: Bool } <: { a: I64, b: Str }`.
 - Effect set subtyping: `C₁ ⊆ C₂ ⟹ Fn(ps, r, C₁) <: Fn(ps, r, C₂)` (a function needing fewer effects is more general).
 
 ### 4.10 Binary and unary operator typing
 
-**Arithmetic operators** (`+`, `-`, `*`, `/`):
+**Reading guide.** §3.1 fixes **default** literal widths (**`I64`**, **`F64`**). The first rules below state operator typing for those defaults explicitly. **Width metavariables** reuse the Summary: **ι** ∈ {`I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `U64`} and **φ** ∈ {`F32`, `F64`}. Family rules apply to every fixed width; defaults remain the special case **ι = `I64`**, **φ = `F64`** when no other constraint fixes a width.
+
+**Arithmetic operators** (`+`, `-`, `*`, `/`, `%`) — default scalar widths (§3.1):
 
 ```text
 Γ ⊢ e₁ ⇒ τ    Γ ⊢ e₂ ⇒ τ
-τ ∈ {Int, Float}
+τ ∈ {I64, F64}
 ────────────────────────────
 Γ ⊢ e₁ ⊕ e₂ ⇒ τ
+```
+
+**Arithmetic — all fixed integer and float widths:**
+
+```text
+Γ ⊢ e₁ ⇒ ι    Γ ⊢ e₂ ⇒ ι    ⊕ ∈ {+, -, *, /, %}
+────────────────────────────
+Γ ⊢ e₁ ⊕ e₂ ⇒ ι
+
+Γ ⊢ e₁ ⇒ φ    Γ ⊢ e₂ ⇒ φ    ⊕ ∈ {+, -, *, /, %}
+────────────────────────────
+Γ ⊢ e₁ ⊕ e₂ ⇒ φ
+```
+
+(Both operands unify to the **same** `Ty`; there is no implicit widening between widths—see §4.9.)
+
+**String concatenation** (`+` only):
+
+```text
+Γ ⊢ e₁ ⇒ Str    Γ ⊢ e₂ ⇒ Str
+────────────────────────────
+Γ ⊢ e₁ + e₂ ⇒ Str
 ```
 
 **Comparison operators** (`==`, `!=`, `<`, `<=`, `>`, `>=`):
@@ -1474,6 +1567,8 @@ Spore primarily uses **equality-based** type compatibility via unification, with
 Γ ⊢ e₁ ⊗ e₂ ⇒ Bool
 ```
 
+(Relational operators require comparable operands; the reference checker unifies the two operand types. For documentation-only emphasis, **numeric** comparisons are exactly the instances where `τ = ι` or `τ = φ`.)
+
 **Boolean operators** (`&&`, `||`):
 
 ```text
@@ -1482,12 +1577,32 @@ Spore primarily uses **equality-based** type compatibility via unification, with
 Γ ⊢ e₁ ∧∨ e₂ ⇒ Bool
 ```
 
-**Unary negation** (`-`):
+**Unary negation** (`-`) — default scalars:
 
 ```text
-Γ ⊢ e ⇒ τ    τ ∈ {Int, Float}
+Γ ⊢ e ⇒ τ    τ ∈ {I64, F64}
 ───────────────────────────────
 Γ ⊢ -e ⇒ τ
+```
+
+**Unary negation — all numeric widths:**
+
+```text
+Γ ⊢ e ⇒ τ    τ = ι  or  τ = φ
+───────────────────────────────
+Γ ⊢ -e ⇒ τ
+```
+
+**Bitwise operators** (surface: `&`, `|`, `^`, `<<`, `>>`, and unary `~`; integers only):
+
+```text
+Γ ⊢ e₁ ⇒ ι    Γ ⊢ e₂ ⇒ ι    ⊙ ∈ {&, |, ^, <<, >>}
+────────────────────────────
+Γ ⊢ e₁ ⊙ e₂ ⇒ ι
+
+Γ ⊢ e ⇒ ι
+──────────────
+Γ ⊢ ~e ⇒ ι
 ```
 
 **Logical not** (`!`):
@@ -1507,16 +1622,16 @@ Refinement types are not yet implemented but are a planned extension organized i
 L0 refinements are predicates the compiler can fully evaluate at compile time:
 
 ```spore
-type Port = Int when 1 <= self <= 65535
-type Percentage = Float when 0.0 <= self <= 100.0
-type NonEmptyString = String when self.len() > 0
+type Port = I64 when 1 <= self <= 65535
+type Percentage = F64 when 0.0 <= self <= 100.0
+type NonEmptyString = Str when self.len() > 0
 ```
 
 The decidable predicate language includes:
 
 - Numeric comparisons: `<`, `<=`, `==`, `!=`, `>=`, `>`
 - Arithmetic on constants: `self + 1 <= 100`
-- String / collection length: `self.len() > 0`
+- **Str** / collection length: `self.len() > 0`
 - Boolean connectives: `&&`, `||`, `!`
 - Const equality: `self == "production" || self == "staging"`
 
@@ -1536,7 +1651,7 @@ When the compiler cannot statically evaluate the predicate (e.g., value comes fr
 L1 uses flow-sensitive abstract interpretation to propagate refinement information:
 
 ```spore
-fn process_port(raw: Int) -> Port ! InvalidPort {
+fn process_port(raw: I64) -> Port ! InvalidPort {
     if raw < 1 || raw > 65535 {
         raise InvalidPort { value: raw }
     }
@@ -1627,7 +1742,7 @@ Division by zero and integer overflow in type-level arithmetic are compile-time 
 When a const generic function is instantiated, the compiler substitutes concrete values and evaluates:
 
 ```text
-concat[Int, 3, 5](a, b) → Vec[Int, max: eval(3 + 5)] = Vec[Int, max: 8]
+concat_vec[I64, 3, 5](a, b) → Vec[I64, max: eval(3 + 5)] = Vec[I64, max: 8]
 ```
 
 ### 4.15 Error set typing
@@ -1642,18 +1757,20 @@ Fn([σ₁, …, σₙ], τᵣ, C, E)    where E = {Err₁, …, Errₖ}
 
 ```text
 Γ ⊢ e ⇒ Fn([…], τ, C, E_callee)
-E_callee ⊆ E_caller
+canonicalize(E_callee) ⊆ canonicalize(E_caller)
 ──────────────────────────────────
 Γ; E_caller ⊢ e(…)? ⇒ τ
 ```
 
-If `E_callee ⊄ E_caller`, the checker emits:
+If `canonicalize(E_callee) ⊄ canonicalize(E_caller)`, the checker emits:
 
 ```text
 error: function may raise [Err1] which is not in the declared error set
 ```
 
-**Error set union**: When multiple `?` calls appear in a function body, the function's error set must be a superset of the union of all callees' error sets.
+**Canonical error union**: When multiple `?` calls appear in a function body,
+the function's error set must be a superset of the canonical union of all
+callees' error sets.
 
 ### 4.16 Never type in the type system
 
@@ -1680,11 +1797,11 @@ The compiler validates recursive types during registration:
 3. If a cycle has no indirection, emit an infinite-size error.
 
 ```text
-type A = { field: B }
-type B = { field: A }    // ERROR: infinite size (A → B → A with no indirection)
+struct A { field: B }
+struct B { field: A }    // ERROR: infinite size (A → B → A with no indirection)
 
-type A = { field: List[B] }
-type B = { field: A }    // OK: List provides indirection
+struct A { field: List[B] }
+struct B { field: A }    // OK: List provides indirection
 ```
 
 ## Human experience impact
@@ -1694,12 +1811,12 @@ type B = { field: A }    // OK: List provides indirection
 - **Clear error messages.** Because types are nominal and simple, error messages can say "expected `Celsius`, got `Fahrenheit`" rather than showing structural type dumps.
 - **Minimal annotation burden.** Only function signatures require full annotation; local variables and closures are inferred. Humans write types where they matter (API boundaries) and skip them where they don't (implementation details).
 - **Predictable behavior.** No implicit conversions, no SFINAE, no surprising type-level computation. If it compiles, the types mean what they say.
-- **Refinement types (future) catch bugs early.** `Port` being `Int if 1 <= self <= 65535` means invalid values are caught at compile time, not at runtime.
+- **Refinement types (future) catch bugs early.** `Port` being `I64 if 1 <= self <= 65535` means invalid values are caught at compile time, not at runtime.
 
 ### Negative
 
 - **Explicit annotation requirement.** Requiring full function signatures is more annotation than TypeScript or Python. However, this is a deliberate trade-off — signatures are the gravity center for both humans and Agents.
-- **Nominal strictness.** Newtypes like `Celsius ≠ Float` require explicit conversions. This prevents accidental misuse but adds ceremony for simple cases.
+- **Nominal strictness.** Newtypes like `Celsius ≠ F64` require explicit conversions. This prevents accidental misuse but adds ceremony for simple cases.
 
 ### Cognitive model
 
@@ -1742,25 +1859,30 @@ All types implement `Display` with a canonical format:
 
 | Type | Display |
 |---|---|
-| `Ty::Int` | `Int` |
-| `Ty::Float` | `Float` |
+| `Ty::I32` (etc.) | `I32`, `I64`, … |
+| `Ty::F64` (etc.) | `F64`, `F32`, … |
 | `Ty::Bool` | `Bool` |
-| `Ty::Str` | `String` |
-| `Ty::Char` | `Char` |
+| `Ty::Str` | `Str` |
 | `Ty::Unit` | `()` |
 | `Ty::Never` | `Never` |
+| `Ty::Tuple([τ₁, τ₂])` | `(...)` / tuple spelling used by printer |
+| `Ty::Refined(τ, …)` | surface refinement form |
 | `Ty::Named("Foo")` | `Foo` |
-| `Ty::App("List", [Int])` | `List[Int]` |
-| `Ty::Record([(x, Int), (y, Float)])` | `{ x: Int, y: Float }` |
-| `Ty::Fn([Int], Bool, {})` | `(Int) -> Bool` |
-| `Ty::Fn([Int], Bool, {"Net"})` | `(Int) -> Bool uses [Net]` |
+| `Ty::App("List", [I64])` | `List[I64]` |
+| `Ty::Record([(x, I64), (y, F64)])` | `{ x: I64, y: F64 }` |
+| `Ty::Fn([I64], Bool, {})` | `(I64) -> Bool` |
+| `Ty::Fn([I64], Bool, {"Net"})` | `(I64) -> Bool uses [Net]` |
 | `Ty::Var(3)` | `?T3` |
 | `Ty::Hole("h1")` | `?h1` |
 | `Ty::Error` | `<error>` |
 
 ### Snapshot hashes
 
-Function signatures (parameter types, return type, error set, EffectSet, cost bound, generic constraints) are included in snapshot hashes. Body changes and `@allows` annotations are excluded. This ensures:
+Function signatures (parameter types, return type, error set, EffectSet, cost
+bound, generic constraints) are included in snapshot hashes. Body changes and
+`@allows` annotations are excluded. For error sets, the hash policy is
+intentionally conservative: written surface spelling still participates even when
+two clauses are canonically equivalent. This ensures:
 
 - API-breaking changes require explicit `--permit`.
 - Implementation refactoring does not break downstream consumers.
@@ -1773,7 +1895,7 @@ Type diagnostics participate in the shared diagnostics protocol described in SEP
 {
   "code": "E0301",
   "severity": "error",
-  "message": "type mismatch: expected `Int`, found `String`",
+  "message": "type mismatch: expected `I64`, found `Str`",
   "primary_span": {
     "file": "main.sp",
     "range": {
@@ -1790,13 +1912,15 @@ Type diagnostics participate in the shared diagnostics protocol described in SEP
 
 | Category | Example message |
 |---|---|
-| Type mismatch | `type mismatch in function 'add': expected 'Int', got 'String'` |
+| Type mismatch | `type mismatch in function 'add': expected 'I64', got 'Str'` |
 | Undefined variable | `undefined variable 'x'` |
 | Arity mismatch | `function 'add' expects 2 arguments, got 3` |
 | Missing effect | `missing effects [NetConnect]: caller does not declare them` |
+| Missing propagated error | `function may raise [ParseError] which is not in the declared error set` |
+| Redundant error item | `redundant error item 'ParseFailure': already covered by 'config.errors.ParseError'` |
 | Non-exhaustive match | `non-exhaustive match: missing variant 'Triangle'` |
-| Cannot negate type | `cannot negate type 'String'` |
-| Cannot apply `!` | `cannot apply '!' to type 'Int'` |
+| Cannot negate type | `cannot negate type 'Str'` |
+| Cannot apply `!` | `cannot apply '!' to type 'I64'` |
 | Unknown field | `struct 'Point' has no field 'z'` |
 
 ### Dual-channel diagnostics
@@ -1814,8 +1938,8 @@ For each hole, the checker reports the type-system facts that feed the shared SE
 
 ```text
 Hole ?h1 in function `example`:
-  expected type: Int
-  available bindings: x: Int, y: String
+  expected type: I64
+  available bindings: x: I64, y: Str
   suggested fills: compute_value, default_int
 ```
 
@@ -1827,7 +1951,7 @@ Hole ?h1 in function `example`:
 
 3. **No higher-kinded types.** GATs + associated types cover most use cases, but abstracting over container kinds generically (functor-map over any container) requires either code generation or per-container implementations.
 
-4. **Refinement types are unimplemented.** The L0 + L1 refinement vision is specified but not yet in the compiler. Users cannot currently express bounded numeric types or flow-sensitive narrowing.
+4. **Refinement types are only partially implemented.** L0-style aliases (`alias Port = I64 when …`) work in the reference compiler, but the full refinement vision in later sections (flow-sensitive narrowing, transitive proof obligations) is not complete.
 
 5. **Annotation overhead.** Requiring full function signatures is more annotation than TypeScript or Python. This is a deliberate trade-off — signatures are the gravity center for both humans and Agents.
 
@@ -1885,7 +2009,7 @@ Hole ?h1 in function `example`:
 **Considered for future.** Making EffectSets row-polymorphic would allow:
 
 ```spore
-fn apply[C](f: Fn(x: Int) -> Int uses C, x: Int) -> Int uses C
+fn apply[C](f: Fn(x: I64) -> I64 uses C, x: I64) -> I64 uses C
 ```
 
 This is compatible with the current design but not yet implemented. The string-based `BTreeSet` representation would need to be extended with effect variables.
@@ -1912,7 +2036,7 @@ Spore's type system is most directly influenced by Rust:
 ### Liquid Haskell
 
 - Refinement types attached to base types.
-- Spore adopts the refinement syntax (`type Port = Int when ...`) but replaces the SMT backend with decidable predicates (L0) and abstract interpretation (L1).
+- Spore adopts the refinement syntax (`alias Port = I64 when ...` / `type Port = I64 when ...`) but replaces the SMT backend with decidable predicates (L0) and abstract interpretation (L1).
 
 ### TypeScript
 
@@ -1935,23 +2059,23 @@ Spore implements a simplified version: no higher-rank polymorphism, no impredica
 
 ### This is the initial type system specification
 
-Since this is the first formal type system specification (v0.1 → SEP), there is no prior specification to be backward-compatible with. The implemented `Ty` enum and checker in `spore-typeck` serve as the de facto baseline.
+Since this is the first formal type system specification (implemented by `sporec-typeck`), there is no older SEP to be backward-compatible with. The `Ty` enum in the reference compiler is the de facto baseline documented in §§3.1–4.1 above.
 
 ### Compatibility commitments
 
-1. **Ty enum stability.** The variants `Int`, `Float`, `Bool`, `Str`, `Char`, `Unit`, `Never`, `Named`, `App`, `Record`, `Fn`, `Var`, `Hole`, `Error` are stable. New variants may be added but existing variants will not be removed or renamed without a new SEP.
+1. **Ty enum stability.** The variants `I8`…`U64`, `F32`, `F64`, `Bool`, `Str`, `Unit`, `Never`, `Tuple`, `Refined`, `Named`, `App`, `Record`, `Fn`, `Var`, `Hole`, `Error` are stable in the reference implementation. New variants may be added but existing variants will not be removed or renamed without a new SEP. (`Char` was removed from the language and toolchain in `spore` PR #113.)
 
 2. **EffectSet representation.** `BTreeSet<String>` is the current representation. Future SEPs may introduce effect variables for row-polymorphic effects, but the concrete string-based API will remain supported.
 
 3. **Two-pass checking.** The `register_item` → `check_fn` architecture is stable. Future passes (e.g., trait resolution, cost checking) will be added after these two, not replace them.
 
-4. **Display format.** The canonical type display format (`Int`, `List[Int]`, `(Int) -> Bool uses [Net]`, `{ x: Int, y: Float }`) is stable and may be relied upon by tools and diagnostics.
+4. **Display format.** The canonical type display format (`I64`, `List[I64]`, `(I64) -> Bool uses [Net]`, `{ x: I64, y: F64 }`, etc.) is stable and may be relied upon by tools and diagnostics.
 
 ### Migration path for future features
 
 | Feature | Migration strategy |
 |---|---|
-| Refinement types (L0) | Add `Ty::Refined(Box<Ty>, Predicate)` variant; extend `resolve_type` |
+| Refinement types (L0) | `Ty::Refined` exists in `sporec-typeck`; extend semantics/predicate classes as needed |
 | Const generics | Add `Ty::Const(value)` variant; extend `App` to accept const args |
 | Row-polymorphic effects | Extend EffectSet with effect variables alongside concrete strings |
 
@@ -1959,7 +2083,7 @@ Since this is the first formal type system specification (v0.1 → SEP), there i
 
 1. **EffectSet in unification.** Currently, function type unification ignores EffectSets (the `_` in `Fn(p1, r1, _), Fn(p2, r2, _)`). Should EffectSets participate in unification, or remain checked separately? Separate checking is simpler but could miss effect mismatches in higher-order function arguments.
 
-2. **Generic syntax: square brackets vs angle brackets.** The implemented `Ty::App` uses parenthesized syntax in the AST (`List[Int]`), but some spec examples use angle brackets (`List<T>`). This SEP uses square brackets as the intended syntax; a separate SEP should finalize the concrete syntax.
+2. **Generic syntax: square brackets vs angle brackets.** The implemented `Ty::App` uses parenthesized syntax in the AST (`List[I64]`), but some spec examples use angle brackets (`List<T>`). This SEP uses square brackets as the intended syntax; a separate SEP should finalize the concrete syntax.
 
 3. **Refinement type representation.** Where do refinement predicates live in the `Ty` enum? Options:
    - (a) `Ty::Refined(Box<Ty>, Predicate)` — a wrapper around any base type.
@@ -1980,4 +2104,7 @@ The following questions from earlier drafts are now resolved by this specificati
 
 2. **Never type semantics.** ✅ Resolved — `unify(τ, Never) = ok` for all `τ` (§4.16). Never is handled as a bottom type directly within the unifier.
 
-3. **Error type representation.** ✅ Resolved — error sets are a component of `Ty::Fn`, making it `Fn(params, ret, EffectSet, ErrorSet)` (§4.15). Error set unions are computed during `?` propagation.
+3. **Error type representation.** ✅ Resolved — error sets are a component of
+`Ty::Fn`, making it `Fn(params, ret, EffectSet, ErrorSet)` (§4.15). `?`
+propagation uses canonical subset/union semantics, while signature hashing stays
+conservative over the written error clause.

--- a/seps/SEP-0003-effect-system.md
+++ b/seps/SEP-0003-effect-system.md
@@ -15,7 +15,7 @@ superseded_by: null
 
 # SEP-0003: Effect System
 
-> **Executive Summary**: Defines Spore's effect system as a flat effect-set model with 10 built-in intent-oriented atomic effects (Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit) plus user-defined effects. The canonical surface syntax uses explicit `effect` declarations, `perform Effect.op(...)`, top-level `handler`, and `handle { ... } with { ... }`, while semantic checking remains a subset test over effect sets. Concrete grammar is centralized in SEP-0001; this SEP specifies effect algebra, handler semantics, narrowing rules, and diagnostics.
+> **Executive Summary**: Defines Spore's effect system as a flat effect-set model with 10 built-in intent-oriented atomic effects (Console, FileRead, FileWrite, NetConnect, NetListen, Env, Spawn, Clock, Random, Exit) plus user-defined effects. The compositional model treats handlers as explicit discharge points: normal handlers, mock handlers, and Platform handlers are the same semantic object, with handled effects removed from a local residual set and handler implementation effects added back to the outer requirement. Concrete grammar is centralized in SEP-0001; this SEP specifies effect algebra, unified handler semantics, discharge rules, narrowing rules, and diagnostics.
 
 ## Summary
 
@@ -26,6 +26,12 @@ The built-in effect vocabulary is **intent-oriented**: each built-in effect answ
 The design is intentionally **flat and monomorphic**: effect sets are finite sets of atomic identifiers with no effect variables, no row types, and no effect polymorphism. Named aliases (`effect X = A | B`) provide ergonomics without adding expressiveness. Higher-order functions such as `map` accept only pure (`uses []`) closures; effectful iteration is expressed through `parallel_scope` + `spawn`.
 
 Concrete surface syntax for `effect`, `handler`, `perform`, and `handle ... with` is defined in SEP-0001. This SEP focuses on semantics, algebra, typing, protocol fields, and diagnostics.
+
+> **Release-safety note**: Handler discharge and the unified declaration form in
+> this SEP describe the target behavior of the current compositional-semantics
+> wave. The shipping implementation already checks explicit `perform` usage and
+> effect sets, but parser/runtime support for the full unified handler surface is
+> still being completed.
 
 ---
 
@@ -606,6 +612,63 @@ Spawn ∈ S_scope    S_body ⊆ S_scope
 
 > **Note on spawn purity.** The `spawn` expression itself is **pure** — it merely creates a task descriptor (of type `Task[T]`). No side effect is executed at the point of `spawn`; the effect occurs when the task is later scheduled. This is why a closure containing only `spawn { ... }` satisfies `uses []` when passed to `map` or other pure-closure-requiring combinators.
 
+### 8.1 Handler discharge semantics
+
+Handlers are the effect-system's **discharge operator**. A handler declaration
+names the effects it covers and the implementation effects it may itself use:
+
+```spore
+handler Name(params?) handles [EffectA, EffectB] uses [ImplEffects] {
+    impl EffectA { ... }
+    impl EffectB { ... }
+}
+```
+
+This is the preferred surface shape for the current wave. Normal handlers,
+mock handlers used in tests, and Platform-installed handlers are all instances
+of this same semantic form; "Platform handler" is a deployment role, not a
+distinct language feature.
+
+Let:
+
+- `S_body` be the effect set collected from the handled block before discharge
+- `H` be the union of effects listed in active handler declarations
+- `S_impl` be the union of all handler implementation effect sets
+
+Then the enclosing residual effect set is:
+
+```text
+residual(handle e with h̄) = (S_body \ H) ∪ S_impl
+```
+
+Intuition:
+
+1. effects covered by the active handlers stop leaking outward;
+2. any effects required to *run the handlers themselves* still count; and
+3. unhandled effects remain visible to the outer scope.
+
+This rule is purely semantic. Users still declare ordinary `uses [...]`
+signatures; there is no separate user-facing "effect subtraction" syntax.
+
+#### Coverage and duplicate-match rules
+
+A handler scope is well-formed only if all of the following hold:
+
+1. **Interface completeness.** For every `Effect` listed in `handles [...]`,
+   the handler provides an `impl Effect { ... }` block covering the declared
+   operations of that effect interface.
+2. **Unique local match.** Within one `with` block, the same `Effect.op`
+   cannot be matched by two sibling handlers or two sibling inline arms.
+3. **Innermost wins.** If nested handler scopes both cover an operation, the
+   innermost matching handler is chosen.
+4. **Explicit leakage.** A `perform Effect.op(...)` not covered by the active
+   handler stack remains in the residual effect set and must still be justified
+   by the enclosing `uses [...]`.
+
+Inline `on Effect.op(...) => ...` arms are semantic sugar for anonymous
+single-scope handlers and therefore obey the same discharge and duplicate-match
+rules.
+
 ### 9. Effect checking algorithm
 
 The compiler performs effect checking during type-checking as a single pass:
@@ -757,44 +820,67 @@ This expands semantically to the union of the two effects and does not define a 
 
 ### 14. Effect handlers
 
-Effect handlers provide concrete implementations for effect operations, enabling testability, mockability, and platform abstraction:
+Effect handlers provide concrete implementations for effect operations,
+enabling testability, mockability, and platform abstraction. Spore uses a
+**unified handler model**: ordinary handlers, mock handlers, and Platform
+handlers all use the same declaration shape and discharge rules.
 
 #### Handler definition
 
 ```spore
-handler Console as MockConsole(output: List[Str]) {
-    fn println(msg: Str) -> () { self.output.push(msg) }
-    fn read_line() -> Str ! IoError { "mock input" }
+handler MockConsole(output: List[Str]) handles [Console] uses [] {
+    impl Console {
+        fn println(msg: Str) -> () { self.output.push(msg) }
+        fn read_line() -> Str ! IoError { "mock input" }
+    }
 }
 
-handler FileRead as RealFileRead(root: Str) {
-    fn read_file(path: Str) -> Str ! IoError {
-        platform.fs.read(self.root + "/" + path)
-    }
-    fn list_dir(path: Str) -> List[Str] ! IoError {
-        platform.fs.list(self.root + "/" + path)
+handler FixtureFiles(files: Map[Str, Str])
+handles [FileRead]
+uses []
+{
+    impl FileRead {
+        fn read_file(path: Str) -> Str ! IoError {
+            self.files.get(path).unwrap_or("")
+        }
+
+        fn list_dir(path: Str) -> List[Str] ! IoError {
+            []
+        }
     }
 }
 ```
 
+The first example is a mock handler. The second shows the same declaration
+shape applied to a different effect family. A Platform package installs
+handlers using the same model; the difference is only *where* the handler
+instance comes from (project startup / adapter wiring) rather than any special
+Platform-only semantics.
+
 #### Handler binding
 
-The canonical handler form is `handle { ... } with { ... }`. The `with` block may contain inline effect arms via `on Effect.op(...) => ...` and/or named handler installations via `use HandlerName { ... }`. The `use` payload initializes the handler instance fields declared in `handler <Effect> as <HandlerName>(...)`, and duplicate matches for the same `Effect.op` inside one `with` block are errors.
+The canonical handler form is `handle { ... } with { ... }`. The `with` block
+may contain named handler installations via `use HandlerName(...)` and/or
+inline effect arms via `on Effect.op(...) => ...`. Installing a named handler
+discharges the effects listed in that handler's `handles [...]` clause and
+re-exports the handler's own `uses [...]` as residual obligations of the outer
+scope. Duplicate matches for the same `Effect.op` inside one `with` block are
+errors.
 
 ```spore
 // Bind a single named handler
 handle {
     greet("world")
 } with {
-    use MockConsole { output: [] }
+    use MockConsole(output: [])
 }
 
 // Bind multiple named handlers
 handle {
     app.run()
 } with {
-    use RealFileRead { root: "/srv/app" }
-    use MockConsole { output: [] }
+    use FixtureFiles(files: fixture_files)
+    use MockConsole(output: [])
 }
 
 // Inline handler arms remain available
@@ -814,9 +900,11 @@ effect RateLimit {
     fn check_limit(key: Str) -> Bool
 }
 
-handler RateLimit as FixedDecisionRateLimit(allowed: Bool) {
-    fn check_limit(key: Str) -> Bool {
-        self.allowed
+handler FixedDecisionRateLimit(allowed: Bool) handles [RateLimit] uses [] {
+    impl RateLimit {
+        fn check_limit(key: Str) -> Bool {
+            self.allowed
+        }
     }
 }
 ```
@@ -1013,7 +1101,13 @@ Algebraic effect handlers (as in Koka or OCaml 5) allow effects to be intercepte
 3. **Platform abstraction** — The same user code runs on different platforms by swapping handlers (e.g., browser vs. server filesystem).
 4. **Colorless functions** — Unlike async/await, effect handlers do not bifurcate the function space.
 
-Spore's handler model is intentionally simpler than full algebraic effects: handlers are lexical, non-resumable, and one-shot. A matching handler arm computes the value of the corresponding `perform` expression directly; there is no continuation capture or `resume()` path in canonical v0.1 semantics.
+Spore's handler model is intentionally simpler than full algebraic effects:
+handlers are lexical, non-resumable, and one-shot. A matching handler arm
+computes the value of the corresponding `perform` expression directly; there is
+no continuation capture or `resume()` path in canonical v0.1 semantics.
+Discharge is explicit: handled effects are removed from the local residual set,
+while handler implementation effects remain visible to the enclosing scope.
+Normal, mock, and Platform handlers all follow this same rule.
 
 Syntax: `effect` defines operations, `handler` provides implementations, `handle ... with` binds handlers at call sites. See §13-14 for full details.
 

--- a/seps/SEP-0003-effect-system.md
+++ b/seps/SEP-0003-effect-system.md
@@ -224,20 +224,29 @@ uses [FileWrite]
 
 ### Effectful iteration with `parallel_scope` + `spawn`
 
-When you need side effects during iteration, use the structured concurrency pattern:
+When you need side effects during iteration, keep the effectful work explicit rather than hiding it inside a pure combinator closure:
 
 ```spore
 fn fetch_all(urls: List[Url]) -> List[Response] ! NetworkError
 uses [NetConnect, Spawn]
 {
     parallel_scope {
-        let tasks = urls.map(|url| {
-            spawn {
-                // spawn body uses [NetConnect], ⊆ parent {NetConnect, Spawn}  ✓
-                http.get(url)
+        fn spawn_all(remaining: List[Url]) -> List[Task[Response]]
+        uses [NetConnect, Spawn]
+        {
+            match remaining {
+                [] => [],
+                [url, ..rest] => [
+                    spawn {
+                        // spawn body uses [NetConnect], ⊆ parent {NetConnect, Spawn}  ✓
+                        http.get(url)
+                    },
+                    ..spawn_all(rest),
+                ],
             }
-        })
-        tasks.collect_results()
+        }
+
+        spawn_all(urls).collect_results()
     }
 }
 ```
@@ -245,9 +254,9 @@ uses [NetConnect, Spawn]
 Why does this type-check?
 
 1. `fetch_all` declares `uses [NetConnect, Spawn]`.
-2. `spawn { ... }` requires `Spawn ∈ {NetConnect, Spawn}` — satisfied.
-3. Inside the spawn body, `http.get` requires `NetConnect`; `{NetConnect} ⊆ {NetConnect, Spawn}` — satisfied.
-4. The closure passed to `map` returns `Task[Response]`. The `spawn` expression itself is pure (it merely creates a task handle), so the closure satisfies `uses []`.
+2. The local helper `spawn_all` is also declared with `uses [NetConnect, Spawn]`, so its recursive body may both spawn tasks and perform network requests inside those tasks.
+3. `spawn { ... }` requires `Spawn ∈ {NetConnect, Spawn}` — satisfied.
+4. Inside the spawn body, `http.get` requires `NetConnect`; `{NetConnect} ⊆ {NetConnect, Spawn}` — satisfied.
 
 ### Auto-inferred properties
 
@@ -469,7 +478,7 @@ $$(T_1, T_2) \to R \equiv (T_1, T_2) \to R \ \textbf{uses}\ \{\}$$
 
 The compiler derives semantic properties from the `uses` set via the property-inference function **𝒫**:
 
-$$\mathcal{P}(\text{pure}, S) = \begin{cases} \text{true} & \text{if } S = \emptyset \\ \text{true} & \text{if } S \subseteq \{\text{Spawn}\} \\ \text{false} & \text{otherwise} \end{cases}$$
+$$\mathcal{P}(\text{pure}, S) = \begin{cases} \text{true} & \text{if } S = \emptyset \\ \text{false} & \text{otherwise} \end{cases}$$
 
 $$\mathcal{P}(\text{deterministic}, S) = \begin{cases} \text{true} & \text{if } S \cap \{\text{Clock, Random}\} = \emptyset \\ \text{false} & \text{otherwise} \end{cases}$$
 
@@ -477,12 +486,12 @@ $$\mathcal{P}(\text{total}, S) = \text{determined by a separate termination anal
 
 #### 5.0 Edge cases in the `pure` formula
 
-The complete rule: `𝒫(pure, S) = true` iff `S ⊆ {Spawn}`. Pure computation requires no declared effect — it is the default. `Spawn` is pure-compatible because `spawn` merely creates a task descriptor; the effect is deferred. All other built-in effects represent interactions with the external world and therefore make a function impure.
+The complete rule: `𝒫(pure, S) = true` iff `S = ∅`. Pure computation requires no declared effect — it is the default. `Spawn` is not pure-compatible: creating schedulable work has observable concurrency and scheduling consequences even when the spawned body is deterministic. Determinism remains a separate property.
 
 | Effect set S | pure? | Rationale |
 |---|---|---|
 | `{}` | true | No effects at all |
-| `{Spawn}` | true | `spawn` merely creates a task descriptor (pure); the effect is deferred |
+| `{Spawn}` | false | `spawn` introduces observable concurrency/scheduling behavior |
 | `{Console}` | false | Console interacts with the terminal — an external I/O channel |
 | `{Clock}` | false | Clock reads the external world (system time) |
 | `{Random}` | false | Random reads external entropy |
@@ -571,7 +580,7 @@ Read: "Under type context Γ and effect set S, expression e has type T."
 
 
 ────────────────────────────  [PURE-LITERAL]
-Γ; S ⊢ 42 : Int      ∀ S
+Γ; S ⊢ 42 : I64      ∀ S
 ```
 
 ### 8. Effect composition rules
@@ -610,7 +619,7 @@ Spawn ∈ S_scope    S_body ⊆ S_scope
 Γ; S_scope ⊢ spawn { body } : Task[T]
 ```
 
-> **Note on spawn purity.** The `spawn` expression itself is **pure** — it merely creates a task descriptor (of type `Task[T]`). No side effect is executed at the point of `spawn`; the effect occurs when the task is later scheduled. This is why a closure containing only `spawn { ... }` satisfies `uses []` when passed to `map` or other pure-closure-requiring combinators.
+> **Note on `spawn`.** A `spawn { ... }` expression still requires `Spawn` in the surrounding `uses` set even though the child body may run later. Creating schedulable work is therefore **not** pure and cannot be smuggled through APIs that require `uses []` closures such as `map`.
 
 ### 8.1 Handler discharge semantics
 
@@ -965,8 +974,8 @@ The canonical serialised form of a function type includes the EffectSet:
 ```json
 {
   "kind": "Fn",
-  "params": ["Int", "Int"],
-  "return": "Int",
+  "params": ["I64", "I64"],
+  "return": "I64",
   "effects": [],
   "errors": []
 }
@@ -1148,9 +1157,9 @@ This SEP depends on SEP-0002 (Type System). The `EffectSet` is integrated into t
 
 ```rust
 enum Ty {
-    Int,
+    I64,
     Bool,
-    String,
+    Str,
     Fn(Vec<Ty>, Box<Ty>, EffectSet),  // params, return, effects
     // ...
 }

--- a/seps/SEP-0003-effect-system.md
+++ b/seps/SEP-0003-effect-system.md
@@ -98,10 +98,10 @@ fn greet(name: Str) uses [Console] {
 If a function needs no effects it is *pure* and the `uses` clause may be omitted entirely:
 
 ```spore
-fn add(a: Int, b: Int) -> Int {
+fn add(a: I64, b: I64) -> I64 {
     a + b
 }
-// equivalent to: fn add(a: Int, b: Int) -> Int uses [] { a + b }
+// equivalent to: fn add(a: I64, b: I64) -> I64 uses [] { a + b }
 ```
 
 ### Built-in atomic effects
@@ -204,17 +204,17 @@ but `perform Alias.println(...)` is not the canonical surface.
 Higher-order combinators such as `map`, `filter`, and `fold` accept **only pure closures** — closures whose effect set is empty:
 
 ```spore
-fn process_scores(scores: List[Int]) -> List[String] {
+fn process_scores(scores: List[I64]) -> List[Str] {
     scores
-        .filter(|s| s >= 60)              // pure: (Int) -> Bool
-        .map(|s| format("Pass: {}", s))   // pure: (Int) -> String
+        .filter(|s| s >= 60)              // pure: (I64) -> Bool
+        .map(|s| format("Pass: {}", s))   // pure: (I64) -> Str
 }
 ```
 
 Attempting to pass an effectful closure is a compile error:
 
 ```spore
-fn bad_example(scores: List[Int]) -> List[Unit]
+fn bad_example(scores: List[I64]) -> List[Unit]
 uses [FileWrite]
 {
     // ❌ ERROR: map requires a pure closure, but this closure uses [FileWrite]
@@ -308,7 +308,7 @@ Diagnostics and tooling should therefore not synthesize or rely on `module X use
 The `@allows` annotation constrains which functions an AI agent (or developer) may use to fill a Hole. In the shared SEP-0005 hole protocol, this shows up as a filtered `candidates` list rather than as a separate bespoke schema.
 
 ```spore
-fn process_input(raw: String) -> SafeInput ! ValidationError {
+fn process_input(raw: Str) -> SafeInput ! ValidationError {
     @allows[validate, sanitize]
     ?clean_input
 }
@@ -345,7 +345,7 @@ Without `@allows`, all functions matching the type and effect constraints may ap
 A pure recursive function requires no annotations:
 
 ```spore
-fn fibonacci(n: Int) -> Int {
+fn fibonacci(n: I64) -> I64 {
     match n {
         0 => 0,
         1 => 1,
@@ -360,7 +360,7 @@ Compiler inference output:
 uses []
 // auto-inferred: pure, deterministic
 // total: structural recursion on n (decreasing) — provable
-cost ≤ O(2^n)
+// cost: non-structural; compute ~ O(2^n) (SEP-0004)
 ```
 
 ---
@@ -695,10 +695,10 @@ A closure defined within a context with effect set *S* has an inferred effect se
 fn example() -> Unit
 uses [FileRead, NetConnect]
 {
-    // Inferred type: (String) -> Data uses [NetConnect]
+    // Inferred type: (Str) -> Data uses [NetConnect]
     let fetch_fn = |url| http.get(url)
 
-    // Inferred type: (Int) -> Int uses []  (pure)
+    // Inferred type: (I64) -> I64 uses []  (pure)
     let double = |x| x * 2
 }
 ```

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -28,7 +28,9 @@ This SEP specifies Spore's compile-time cost analysis system — a three-tier me
 > behavior and active cost syntax, start with the implementation repository's
 > `spore/README.md`, which documents the four-slot
 > `cost [compute, alloc, io, parallel]` form used by implementation-facing
-> examples.
+> examples. The checked-residual-budgeting rules added in this SEP describe the
+> target behavior of the current wave without adding any new user-facing
+> subtraction syntax.
 
 The three tiers are:
 
@@ -185,6 +187,21 @@ $ sporec --query-cost merge_sort
 }
 ```
 
+### Checked residual budgeting (target behavior of this wave)
+
+Users declare a **total** budget for a function. The checker then reasons about
+how much of that budget remains at each program point.
+
+- Source-level declarations stay aggregate: `cost [compute, alloc, io, parallel]`
+- The compiler internally tracks a **residual budget** after each checked prefix
+- Residuals may be surfaced in diagnostics, HoleReport payloads, or debugging
+  tools, but they are **not** a new source-language arithmetic feature
+
+In other words, the language does **not** expose user-facing budget subtraction
+such as `cost [n - 1, ...]` or `remaining_cost(...)`. Residual budgeting is a
+checker concept used to explain whether a call, handler installation, or hole
+still fits within the enclosing declaration.
+
 ### Summary of the three tiers
 
 ```text
@@ -273,6 +290,37 @@ Every system call (file read/write, network request, stdio, random number genera
 | Parallel `parallel { A, B }` | C, A, W: `max(cost(A), cost(B)) + sync_overhead`; P: `sum(P(A), P(B))` |
 
 > **Concurrent sync overhead.** The `sync_overhead` is a configurable constant (default: 0) representing the synchronisation cost of joining parallel branches. It can be set in `spore.toml` as `[cost] sync_overhead = 10`. When set to 0 (the default), the parallel cost reduces to a simple `max`. Projects requiring precise modelling of fork/join overhead should configure this parameter.
+
+#### Checked residual budgeting
+
+Let `C_declared` be the function's declared cost vector and `K_prefix(p)` be the
+cost accumulated by the checker before program point `p`. A subexpression `e`
+checked at `p` is valid iff:
+
+```text
+K_prefix(p) ⊕ K(e) ≤ C_declared
+```
+
+The checker may report a residual vector `R(p)` satisfying:
+
+```text
+K_prefix(p) ⊕ R(p) ≤ C_declared
+```
+
+and use the greatest such pointwise vector as the displayed "remaining budget."
+This is equivalent to internal pointwise subtraction over already-known costs,
+but that subtraction remains an implementation detail rather than a source
+construct.
+
+Consequences:
+
+1. **Holes** inherit a residual budget from the enclosing prefix, which is why
+   SEP-0005 can expose per-hole remaining cost without inventing new syntax.
+2. **Handlers** are checked the same way: the enclosing scope must have enough
+   residual budget for both the handled body and any handler implementation
+   obligations that escape via discharge (see SEP-0003).
+3. **Diagnostics stay canonical**: the user sees a declared total budget plus a
+   reported residual, not a requirement to write explicit budget arithmetic.
 
 ### Formal cost judgments
 
@@ -391,6 +439,11 @@ Var      ::= [a-z][a-z0-9_]*                       (* Lowercase identifier *)
 | Variable exponents `n^m` | Pushes comparison into the exponential polynomial domain, losing polynomial decidability |
 
 > **Note on subtraction discrepancy.** The cost-model spec (§6) includes subtraction in its symbolic cost operators (e.g., `(len(list) - 1) × cost(f)` for `reduce`). However, the decidability analysis forbids subtraction in CostExpr to maintain monotonicity and non-negativity. This SEP follows the decidability spec: **subtraction is not a valid CostExpr operator**. Where subtraction appears naturally (e.g., `n - 1`), the compiler uses the conservative upper bound (e.g., `n` instead of `n - 1`). Cost formulas in the HOF table that use subtraction (e.g., `reduce`) are computed internally by the compiler but are presented to the CostExpr verifier in their upper-bound form.
+
+Residual budgeting does not weaken this rule: the checker may compute
+"remaining budget" internally, but that is not a user-authored `CostExpr`
+surface and therefore does not reintroduce subtraction into the source
+language.
 
 #### Implementation (Rust)
 

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -16,7 +16,7 @@ superseded_by: null
 
 # SEP-0004: Cost Analysis & Decidability
 
-> **Executive Summary**: Introduces 4-dimensional cost analysis with CostVector(compute, alloc, io, parallel), where cost expressions are restricted to a decidable grammar (+, ×, ^const, log, max, min). Provides a three-tier escape mechanism (@unbounded for opt-out, @allow for local override, advisory warnings for gradual adoption) and formal cost inference rules for higher-order function propagation. Checked residual budgeting is defined over 4D vectors as an internal compiler relation (`before + candidate ≤ budget`), not as user-facing subtraction syntax. Targets O(n⁵) verification complexity.
+> **Executive Summary**: Introduces 4-dimensional cost analysis with CostVector(compute, alloc, io, parallel), where cost expressions are restricted to a decidable grammar (+, ×, ^const, log, max, min). Provides a three-tier escape mechanism (@unbounded for opt-out, @allows for local override, advisory warnings for gradual adoption) and formal cost inference rules for higher-order function propagation. Checked residual budgeting is defined over 4D vectors as an internal compiler relation (`before + candidate ≤ budget`), not as user-facing subtraction syntax. Targets O(n⁵) verification complexity.
 
 ## Summary
 
@@ -251,8 +251,8 @@ where `α` and `β` are project-configurable weights (default α = 2, β = 100).
 |-----------|----------|-------|
 | Integer `+`, `-`, `*` | 1 | |
 | Integer `/`, `%` | 2 | Division is slightly more expensive |
-| Float `+`, `-`, `*` | 2 | |
-| Float `/` | 3 | |
+| F64 `+`, `-`, `*` | 2 | |
+| F64 `/` | 3 | |
 | Comparison `==`, `!=`, `<`, `>` | 1 | |
 | Logical `&&`, `\|\|`, `!` | 1 | Max-path (short-circuit does not reduce cost) |
 | Bitwise `&`, `\|`, `^`, `<<`, `>>` | 1 | |
@@ -269,8 +269,8 @@ where `α` and `β` are project-configurable weights (default α = 2, β = 100).
 |-----------|------------|
 | Struct creation | field count |
 | List creation | element count + 1 header |
-| String creation | ⌈len / 8⌉ |
-| String concatenation | ⌈(len_a + len_b) / 8⌉ (new allocation) |
+| `Str` creation | ⌈len / 8⌉ |
+| `Str` concatenation | ⌈(len_a + len_b) / 8⌉ (new allocation) |
 | Enum / union | 1 (tag + max variant size) |
 | Deep copy | original cell count |
 | Borrow / reference | 0 |
@@ -1103,7 +1103,7 @@ WARNING [unbounded-cost] fibonacci's cost cannot be statically determined.
   Inferred complexity: O(2^n)
 
   Options:
-  (a) Add tighter refinements (`n: Int if n ≤ 30`) together with concrete `cost [...]` literals for small‑n paths
+  (a) Add tighter refinements (`n: I64 if n ≤ 30`) together with concrete `cost [...]` literals for small‑n paths
   (b) Mark as `@unbounded` (relinquish cost constraint)
   (c) Rewrite using structural recursion or tail recursion + iteration bound
 ```

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -16,26 +16,20 @@ superseded_by: null
 
 # SEP-0004: Cost Analysis & Decidability
 
-> **Executive Summary**: Introduces 4-dimensional cost analysis with CostVector(compute, alloc, io, parallel), where cost expressions are restricted to a decidable grammar (+, ×, ^const, log, max, min). Provides a three-tier escape mechanism (@unbounded for opt-out, @allow for local override, advisory warnings for gradual adoption) and formal cost inference rules for higher-order function propagation. Targets O(n⁵) verification complexity.
+> **Executive Summary**: Introduces 4-dimensional cost analysis with CostVector(compute, alloc, io, parallel), where cost expressions are restricted to a decidable grammar (+, ×, ^const, log, max, min). Provides a three-tier escape mechanism (@unbounded for opt-out, @allow for local override, advisory warnings for gradual adoption) and formal cost inference rules for higher-order function propagation. Checked residual budgeting is defined over 4D vectors as an internal compiler relation (`before + candidate ≤ budget`), not as user-facing subtraction syntax. Targets O(n⁵) verification complexity.
 
 ## Summary
 
 This SEP specifies Spore's compile-time cost analysis system — a three-tier mechanism that statically determines or verifies upper bounds on resource consumption for every function. The system operates along four cost dimensions — **compute(op)**, **alloc(cell)**, **io(call)**, **parallel(lane)** — and leverages the fact that Spore has **no loops** (all iteration is expressed via recursion and higher-order functions) to make cost analysis equivalent to recursion analysis.
 
-> **Release-safety note**: This is a `Draft` design record, not the current
-> implementation contract. Some examples below intentionally preserve older
-> proposal syntax such as `cost ≤ expr` and `@unbounded`. For current release
-> behavior and active cost syntax, start with the implementation repository's
-> `spore/README.md`, which documents the four-slot
-> `cost [compute, alloc, io, parallel]` form used by implementation-facing
-> examples. The checked-residual-budgeting rules added in this SEP describe the
-> target behavior of the current wave without adding any new user-facing
-> subtraction syntax.
+> **Note:** This SEP is `Draft`. Compiler behavior follows the implementation
+> repository (`spore/README.md`) until acceptance. Declare per-function budgets
+> with four-slot `cost [compute, alloc, io, parallel]` (SEP-0001).
 
 The three tiers are:
 
 1. **Tier 1 — Automatic structural recursion detection** (~70% of functions): the compiler detects that one argument strictly decreases along a well-founded relation on every recursive call and automatically infers a cost bound.
-2. **Tier 2 — Declarative verification** (~20%): the developer writes `cost ≤ expr` in the function signature; the compiler verifies it.
+2. **Tier 2 — Declarative verification** (~20%): the developer writes `cost [compute, alloc, io, parallel]` in the function signature; the compiler verifies each slot independently.
 3. **Tier 3 — `@unbounded` escape hatch** (~10%): the developer explicitly opts out of cost checking; the annotation is *contagious* — callers inherit `@unbounded` unless they isolate it with `with_cost_limit`.
 
 Cost expressions (`CostExpr`) are drawn from a restricted grammar — `+`, `*`, `^const`, `log`, `max`, `min` — deliberately excluding division, subtraction, and conditionals. This restriction guarantees that the verification problem "`C(n̄) ≤ B(n̄)` for all valid inputs" is **decidable in polynomial time**, specifically **O(n⁵)** where n is the combined AST size of the two expressions.
@@ -86,7 +80,7 @@ This section explains how developers interact with the cost system in daily use.
 For the vast majority of functions, the compiler infers cost automatically. You do not need to write any annotation:
 
 ```spore
-fn factorial(n: Int) -> Int {
+fn factorial(n: I64) -> I64 {
     match n {
         0 => 1,
         n => n * factorial(n - 1),
@@ -105,7 +99,7 @@ The compiler detects structural recursion on `n` (decreasing by 1 on each call) 
 Tree traversals work the same way:
 
 ```spore
-fn tree_sum(tree: Tree<Int>) -> Int {
+fn tree_sum(tree: Tree<I64>) -> I64 {
     match tree {
         Leaf(v) => v,
         Node(left, val, right) => tree_sum(left) + val + tree_sum(right),
@@ -119,7 +113,7 @@ fn tree_sum(tree: Tree<Int>) -> Int {
   → O(n)
 ```
 
-### Declaring cost — `cost ≤ expr`
+### Declaring cost — `cost [compute, alloc, io, parallel]`
 
 When the compiler cannot automatically detect structural recursion but you know the cost is bounded, declare it:
 
@@ -127,7 +121,12 @@ When the compiler cannot automatically detect structural recursion but you know 
 fn merge_sort[T](list: List[T]) -> List[T]
     where T: Ord
     decreases len(list)
-    cost ≤ len(list) * log(len(list)) * 5 + len(list)
+    cost [
+        len(list) * log(len(list)) * 5 + len(list),
+        len(list) * log(len(list)),
+        0,
+        1,
+    ]
 {
     match list {
         [] => [],
@@ -148,7 +147,7 @@ Some functions have costs that are mathematically unknown or unprovable (e.g., t
 
 ```spore
 @unbounded
-fn collatz_steps(n: Int) -> Int {
+fn collatz_steps(n: I64) -> I64 {
     match n {
         1 => 0,
         n if n % 2 == 0 => 1 + collatz_steps(n / 2),
@@ -157,11 +156,11 @@ fn collatz_steps(n: Int) -> Int {
 }
 ```
 
-`@unbounded` functions cannot be called directly from `cost ≤ K` functions. To bridge the boundary, use a runtime cost limiter:
+`@unbounded` functions cannot be called directly from ordinary four-slot cost declarations without isolation. The intended bridge is a **runtime cost limiter** (below). The reference compiler in the `spore` implementation repository does not implement this form yet; see that repo’s `docs/DESIGN.md`.
 
 ```spore
-fn safe_collatz(n: Int) -> Int ! CostExceeded
-    cost ≤ 10000
+fn safe_collatz(n: I64) -> I64 ! CostExceeded
+    cost [10000, 2000, 0, 2]
 {
     with_cost_limit(10000) {
         collatz_steps(n)
@@ -176,7 +175,7 @@ $ sporec --query-cost merge_sort
 {
   "function": "merge_sort",
   "cost_symbolic": "n * log(n) * 5 + n",
-  "cost_declared": "≤ n * log(n) * 5 + n",
+  "cost_declared": "[n*log(n)*5+n, n*log(n), 0, 1]",
   "dimensions": {
     "compute": "n * log(n) * 4 + n",
     "alloc": "n * log(n)",
@@ -187,10 +186,11 @@ $ sporec --query-cost merge_sort
 }
 ```
 
-### Checked residual budgeting (target behavior of this wave)
+### Checked residual budgeting
 
-Users declare a **total** budget for a function. The checker then reasons about
-how much of that budget remains at each program point.
+Users declare per-function budgets with the four-slot `CostVector`
+`cost [compute, alloc, io, parallel]`. The checker tracks how much of each
+dimension remains after each checked program prefix.
 
 - Source-level declarations stay aggregate: `cost [compute, alloc, io, parallel]`
 - The compiler internally tracks a **residual budget** after each checked prefix
@@ -209,7 +209,7 @@ still fits within the enclosing declaration.
   ┌────────────────────────────────────────────┐
   │  Tier 1: Structural recursion       ~70%   │  ← Fully automatic
   ├────────────────────────────────────────────┤
-  │  Tier 2: cost ≤ expr declaration    ~20%   │  ← Developer writes bound, compiler verifies
+  │  Tier 2: `cost [c,a,i,p]` declaration   ~20%   │  ← Developer writes bounds, compiler verifies
   ├────────────────────────────────────────────┤
   │  Tier 3: @unbounded escape          ~10%   │  ← Explicit opt-out
   └────────────────────────────────────────────┘
@@ -232,7 +232,8 @@ The abstract machine maintains four independent cost dimensions:
 | I/O | `W` | Side-effect / external call count | call |
 | Parallelism | `P` | Parallel execution width | lane |
 
-**Scalar reduction**: for signature-level `cost ≤ K`, dimensions are folded into a single scalar:
+**Scalar summaries (reports):** tooling may fold **C**, **A**, and **W** into one
+weighted number for display. Declarations remain the four-slot form; the fold is:
 
 ```text
 cost = C × 1 + A × α + W × β
@@ -293,18 +294,22 @@ Every system call (file read/write, network request, stdio, random number genera
 
 #### Checked residual budgeting
 
-Let `C_declared` be the function's declared cost vector and `K_prefix(p)` be the
-cost accumulated by the checker before program point `p`. A subexpression `e`
-checked at `p` is valid iff:
+Let `B_declared` be the function's declared cost vector and `K_before(p)` be the
+cost vector accumulated by the checker before program point `p`. A candidate
+subexpression `e` checked at `p` is valid iff:
 
 ```text
-K_prefix(p) ⊕ K(e) ≤ C_declared
+K_before(p) ⊕ K(e) ≤ B_declared
 ```
 
-The checker may report a residual vector `R(p)` satisfying:
+This is the intended reading of checked residuals for the current wave: the
+compiler proves **before + candidate ≤ budget** pointwise over the four cost
+dimensions.
+
+The checker may also report a residual vector `R(p)` satisfying:
 
 ```text
-K_prefix(p) ⊕ R(p) ≤ C_declared
+K_before(p) ⊕ R(p) ≤ B_declared
 ```
 
 and use the greatest such pointwise vector as the displayed "remaining budget."
@@ -447,7 +452,7 @@ language.
 
 #### Implementation (Rust)
 
-The `CostExpr` type is implemented in `spore-typeck/src/cost.rs`:
+The `CostExpr` type is implemented in `sporec-typeck/src/cost.rs`:
 
 ```rust
 pub enum CostExpr {
@@ -509,7 +514,7 @@ The compiler recognizes the following decreasing patterns:
 | Tuple projection | `(a, b) → a` or `(a, b) → b` (strictly smaller) | Structural subterm | Depends on projected component |
 | Integer halving | `n → n / 2` (with `n > 0` guard) | `<` on ℕ | O(log n) |
 
-**Detection algorithm** (implemented in `spore-typeck/src/cost.rs`):
+**Detection algorithm** (implemented in `sporec-typeck/src/cost.rs`):
 
 ```text
 algorithm detect_structural_recursion(f):
@@ -541,9 +546,9 @@ where `cost_per_step` is the four-dimensional cost of the function body excludin
 When the compiler cannot auto-detect structural recursion but the developer knows the function terminates with a bounded cost, they declare it:
 
 ```spore
-fn gcd(a: Int, b: Int) -> Int
+fn gcd(a: I64, b: I64) -> I64
     decreases a + b
-    cost ≤ log(max(a, b))
+    cost [log(max(a, b)), 0, 0, 1]
 {
     match b {
         0 => a,
@@ -570,7 +575,7 @@ fn gcd(a: Int, b: Int) -> Int
 
 ```text
 WARNING [unverified-cost-bound] gcd's cost bound cannot be automatically verified.
-  Declared: cost ≤ log(max(a, b))
+  Declared (compute slot): log(max(a, b))
   Reason: compiler cannot prove log(max(b, a % b)) < log(max(a, b))
 
   Options:
@@ -585,7 +590,7 @@ WARNING [unverified-cost-bound] gcd's cost bound cannot be automatically verifie
 
 ```spore
 @unbounded
-fn collatz_steps(n: Int) -> Int {
+fn collatz_steps(n: I64) -> I64 {
     match n {
         1 => 0,
         n if n % 2 == 0 => 1 + collatz_steps(n / 2),
@@ -600,14 +605,14 @@ fn collatz_steps(n: Int) -> Int {
 |------|-------------|
 | Warning, not error | `@unbounded` produces a compiler warning, does not block compilation |
 | Contagious | Calling an `@unbounded` function makes the caller `@unbounded` too (unless wrapped in `with_cost_limit`) |
-| Context restriction | `@unbounded` functions cannot be called directly in `cost ≤ K` contexts |
+| Context restriction | `@unbounded` functions cannot be called directly inside ordinary `cost [...]` functions |
 | Hole interaction | Holes inside `@unbounded` functions report `cost_budget: unbounded` |
 
 **Impact scope tracking.** When a function is marked `@unbounded`, its unbounded status propagates through the call chain:
 
 - **Direct callers**: any function that calls an `@unbounded` function becomes `@unbounded` itself (unless the call is wrapped in `with_cost_limit`).
 - **Indirect callers**: if function A is `@unbounded` and B calls A, then B is also `@unbounded`. If C calls B, C is also `@unbounded`, and so on up the call chain.
-- **Isolation**: wrapping an `@unbounded` call in `with_cost_limit` halts the propagation. The wrapping function can declare `cost ≤ K` normally.
+- **Isolation**: wrapping an `@unbounded` call in `with_cost_limit` halts the propagation. The wrapping function can declare `cost [...]` normally.
 
 The compiler tracks this propagation and reports the full impact scope in its diagnostic:
 
@@ -641,7 +646,7 @@ Since higher-order function arguments `f` in Spore must be pure (no effect varia
 The following example demonstrates step-by-step cost derivation for nested higher-order functions:
 
 ```spore
-fn matrix_sum(matrix: List[List[Int]]) -> Int {
+fn matrix_sum(matrix: List[List[I64]]) -> I64 {
     matrix
         |> map(|row| row |> fold(0, |a, b| a + b))
         |> fold(0, |a, b| a + b)
@@ -679,14 +684,14 @@ Step 6: total cost
 Detected via **strongly connected components** (SCC) of the call graph (Tarjan's algorithm, O(V + E)):
 
 ```spore
-fn is_even(n: Int) -> Bool {
+fn is_even(n: I64) -> Bool {
     match n {
         0 => true,
         n => is_odd(n - 1),
     }
 }
 
-fn is_odd(n: Int) -> Bool {
+fn is_odd(n: I64) -> Bool {
     match n {
         0 => false,
         n => is_even(n - 1),
@@ -699,7 +704,7 @@ Analysis: SCC = {is_even, is_odd}. Combined call pattern: `is_even(n) → is_odd
 | Scenario | Handling |
 |----------|----------|
 | SCC satisfies structural recursion | Automatic cost derivation |
-| SCC does not satisfy structural recursion | All functions in SCC need `cost ≤` or `@unbounded` |
+| SCC does not satisfy structural recursion | All functions in SCC need explicit `cost [...]` or `@unbounded` |
 | Any function in SCC is `@unbounded` | Entire SCC treated as `@unbounded` |
 
 ### 4.9 Decidability proof sketch
@@ -820,14 +825,12 @@ These fallback steps only convert FAIL → PASS, never the reverse.
 Four-dimensional cost declarations are verified **independently per dimension**:
 
 ```spore
-fn sort[T](items: List[T, max: n]) -> List[T, max: n]
+fn sort[T](items: List[T]) -> List[T]
     where T: Ord
-    cost ≤ {compute: n * log(n) * 3, alloc: n, io: 0, parallel: 1}
+    cost [items.len * log(items.len) * 3, items.len, 0, 1]
 ```
 
 This is equivalent to four independent verification problems, each using the same asymptotic comparison algorithm.
-
-When using scalar `cost ≤ K`, the compiler first computes symbolic cost per dimension, then forms the scalar expression `C(n̄) + α × A(n̄) + β × W(n̄)`. Since α and β are constants, the result is still a valid CostExpr.
 
 ### 4.13 Interaction with the Hole system
 
@@ -835,7 +838,7 @@ Partially-defined functions participate in cost analysis:
 
 ```spore
 fn process(data: Data) -> Result ! ProcessError
-    cost ≤ 1000
+    cost [1000, 400, 0, 1]
 {
     parsed = parser.parse(data)     // cost: 600
     ?process_logic                  // hole: remaining budget 400
@@ -874,7 +877,7 @@ Source Code
     └── Generate symbolic CostExpr per function
   ↓
 [4] Cost Verification
-    ├── Compare inferred CostExpr against declared `cost ≤ expr`
+    ├── Compare inferred CostExpr per dimension against declared `cost [c,a,i,p]` slots
     ├── PASS → compilation succeeds
     ├── FAIL → compile error with four-dimensional breakdown
     └── UNKNOWN → warning with suggestions
@@ -887,20 +890,14 @@ Source Code
 Bounded types provide compile-time size information for cost verification:
 
 ```spore
-fn process_batch(items: List[Order, max: 500]) -> BatchResult ! TooLarge
-    cost ≤ 25000
+fn process_batch(items: List[Order]) -> BatchResult ! TooLarge
+    cost [25000, items.len * 80 + 800, items.len / 50, 16]
 {
     items |> map(|order| validate(order)) |> fold(BatchResult.empty(), merge)
 }
 ```
 
-`List[Order, max: 500]` means:
-
-1. **Compile-time**: the compiler uses 500 as the upper bound for `len(items)` in cost verification. It substitutes `n = 500` into the symbolic cost expression to verify `cost ≤ 25000`.
-2. **Runtime**: if a list exceeding 500 elements is passed, the call produces a `TooLarge` error at the call site. The function body itself never sees more than 500 elements.
-3. **Error propagation**: the `TooLarge` error must appear in the function's error set (`! TooLarge`) or in the caller's error handling.
-
-When no `max` constraint is present, the cost remains a symbolic expression in terms of `len(items)`.
+`List[Order]` here carries **runtime** length. The **`TooLarge`** path (or upstream validation) rejects oversize batches; verification substitutes a conservative `n` (derived from refinements / policy constants) into the cost checker. When a **numeric cap must literally appear in the type** (`N` tied to generics), reserve **`Vec[Order, max: N]`**—that is uncommon; **`List`** should be the default API shape.
 
 ### 4.16 FFI extern function cost declarations
 
@@ -908,12 +905,12 @@ Foreign functions have no Spore body for the compiler to analyse. They **must** 
 
 ```spore
 extern fn c_sort[T](data: List[T]) -> List[T]
-    cost ≤ n * log(n)    // declared, not computed; n = len(data)
+    cost [n * log(n), n, 0, 1]        // declared, not computed; n = len(data)
 ```
 
 ```spore
 extern fn openssl_encrypt(data: Bytes, key: Key) -> Bytes ! CryptoError
-    cost ≤ len(data) * 3 + 500
+    cost [len(data) * 3 + 500, len(data), len(data), 1]
 ```
 
 **Rules for extern fn cost:**
@@ -933,7 +930,7 @@ For generic functions like `map(f, list)`, cost depends on the concrete function
 
 ```spore
 fn map[T, U](list: List[T], f: (T) -> U) -> List[U]
-    cost ≤ len(list) * cost(f) + len(list)
+    cost [len(list) * cost(f) + len(list), len(list), 0, 1]
 {
     // ...
 }
@@ -961,7 +958,7 @@ let result = map(items, |x| x * 2)
 ### Positive
 
 - **Zero-cost annotations for most code.** ~70% of functions are structurally recursive and get cost bounds automatically. Developers write ordinary code and the compiler silently tracks cost.
-- **Performance regressions caught at compile time.** If a refactoring changes O(n) to O(n²), the `cost ≤` declaration fails immediately — not after a production outage.
+- **Performance regressions caught at compile time.** If a refactoring changes O(n) to O(n²), the `cost [...]` declaration fails immediately — not after a production outage.
 - **Precise diagnostics.** The compiler does not just say "cost exceeded"; it provides a four-dimensional breakdown showing exactly where the budget went.
 - **Gradual adoption.** The three-tier design means developers can start with `@unbounded` everywhere and progressively tighten bounds as the codebase matures.
 
@@ -969,11 +966,11 @@ let result = map(items, |x| x * 2)
 
 - **Learning curve.** Developers must understand asymptotic cost notation to write Tier 2 declarations. The `CostExpr` grammar (no subtraction, no division) requires adjustment.
 - **False positives.** Conservative analysis may reject programs whose actual cost is within bounds (e.g., amortized O(1) operations reported as O(n)).
-- **Annotation burden for non-structural recursion.** The ~20% of functions in Tier 2 require explicit `cost ≤` and possibly `decreases` clauses.
+- **Annotation burden for non-structural recursion.** The ~20% of functions in Tier 2 require explicit `cost [...]` and possibly `decreases` clauses.
 
 ### Mitigation
 
-- The compiler suggests fixes: "change `cost ≤ n` to `cost ≤ n * log(n)` to match inferred cost."
+- The compiler suggests fixes: widen the relevant `cost [...]` slots (often compute) until inferred cost fits.
 - `@trust_cost` suppresses unverified-bound warnings for cases where the developer is confident.
 - IDE integration shows cost inline as code lens annotations.
 
@@ -1078,8 +1075,8 @@ The Language Server Protocol exposes:
 | `cost-exceeded` | Error | Inferred cost exceeds declared bound |
 | `unbounded-cost` | Warning | Recursive function with no detectable cost bound and no `@unbounded` annotation |
 | `unbounded-function` | Warning | Function marked `@unbounded` |
-| `unbounded-in-bounded-context` | Error | `@unbounded` function called from `cost ≤ K` context without `with_cost_limit` |
-| `unverified-cost-bound` | Warning | `cost ≤ expr` declared but compiler cannot verify it |
+| `unbounded-in-bounded-context` | Error | `@unbounded` function called from `cost [...]` context without `with_cost_limit` |
+| `unverified-cost-bound` | Warning | `cost [...]` declared but compiler cannot verify one or more slots |
 | `cost-effect-conflict` | Error | `uses []` (pure) declared but W > 0 inferred |
 
 ### Example diagnostics
@@ -1089,11 +1086,11 @@ The Language Server Protocol exposes:
 ```text
 ERROR [cost-exceeded] bad_search's inferred cost exceeds declared bound.
   Inferred: n * log(n)
-  Declared: ≤ n
+  Declared compute slot upper bound too small vs inferred
   Excess factor: log(n)
 
   Suggestions:
-  (a) Change declaration to `cost ≤ n * log(n)` to match actual cost
+  (a) Widen the relevant `cost [...]` slots (especially compute) so the inferred bound fits
   (b) Optimize implementation to eliminate the log(n) factor
   (c) Check for unnecessary nested iteration
 ```
@@ -1106,7 +1103,7 @@ WARNING [unbounded-cost] fibonacci's cost cannot be statically determined.
   Inferred complexity: O(2^n)
 
   Options:
-  (a) Add `cost ≤ K` with parameter constraint `n: Int if n ≤ 30`
+  (a) Add tighter refinements (`n: Int if n ≤ 30`) together with concrete `cost [...]` literals for small‑n paths
   (b) Mark as `@unbounded` (relinquish cost constraint)
   (c) Rewrite using structural recursion or tail recursion + iteration bound
 ```
@@ -1217,7 +1214,7 @@ Spore's cost inference uses abstract interpretation — executing the program on
 
 ### Sized types: Hughes, Pareto, Sabry
 
-Sized types annotate data types with size information (e.g., `List[T, max: n]`) to enable termination checking and complexity analysis. Spore's bounded types are directly inspired by this line of work.
+Sized types annotate values with compile-time **size parameters** (`Vec[T, max: n]`, `Matrix[…]`) to enable sharper termination and complexity reasoning. Everyday programs should stay on **`List[T]`** (`len` routed through `cost` / refinements). Spore exposes **`Vec[T, max: N]`** mostly for layouts that genuinely need **`N` in the type**.
 
 ---
 
@@ -1246,8 +1243,9 @@ Cost analysis is introduced as a new compiler effect. No existing Spore code is 
 
 ### Interaction with existing SEPs
 
-- **SEP-0002 (Type System):** CostExpr types integrate with the type checker. Bounded types (`List[T, max: n]`) provide size information for cost analysis.
-- **SEP-0003 (Hole System):** Cost budgets are propagated to HoleReports, enriching the constraint environment for hole-filling.
+- **SEP-0002 (Type System):** CostExpr integrates with checker types. Prefer **`List[T]`** (`items.len`-indexed costs); use **`Vec[T, max: N]`** sparingly—only when **`N`** must participate in generics. **`List[T]`** stays unbounded (never `List[..., max: ...]`).
+
+- **SEP-0005 (Hole System):** Cost budgets propagate to HoleReports for hole filling.
 
 ---
 
@@ -1318,7 +1316,7 @@ WARNING [cost-drift] function merge_sort: actual cost exceeds prediction.
   Predicted: 1200 op
   Actual (sampled): 1500 op
   Drift ratio: 1.25 (threshold: 1.2)
-  Suggestion: review recent changes to merge_sort or update cost ≤ declaration
+  Suggestion: review recent changes to merge_sort or update the declared `cost [...]` slots
 ```
 
 ---
@@ -1345,15 +1343,15 @@ WARNING [cost-drift] function merge_sort: actual cost exceeds prediction.
 
 3. **Cost drift detection.** The mechanism, tolerance threshold, and CI integration are specified in the "Cost drift detection" section above. The remaining unresolved question is the design of a full runtime cost sampling framework — specifically, how to keep instrumentation overhead below 1% in production builds.
 
-4. **Probabilistic cost bounds.** Randomized algorithms (e.g., QuickSort with random pivot) have expected rather than worst-case cost. Should Spore support `cost ≤ O(n log n) expected`? Deferred to future work.
+4. **Probabilistic cost bounds.** Randomized algorithms (e.g., QuickSort with random pivot) have expected rather than worst-case cost. Should Spore support an **`expected`** cost metadata channel alongside worst-case four-slot bounds? Deferred to future work.
 
-5. **Polymorphic cost (partially resolved).** The call-site instantiation approach is now specified in §4.17: `cost(f)` is substituted at each call site where `f` is concrete. The remaining open question is whether the signature-level notation `cost ≤ N × cost(f) + N` should be a first-class part of the CostExpr grammar, or remain an informal convention that the compiler resolves during monomorphisation.
+5. **Polymorphic cost (partially resolved).** The call-site instantiation approach is now specified in §4.17: `cost(f)` is substituted at each call site where `f` is concrete. The remaining open question is whether a signature-level pattern like `cost [N × cost(f) + N, N, 0, 1]` should be a first-class part of each slot's CostExpr grammar, or remain an informal convention resolved during monomorphisation.
 
 6. **Recursion depth limits.** Should the compiler enforce a compile-time recursion depth ceiling? Current decision: only `@unbounded` functions use runtime `with_cost_limit`. Whether to add a compile-time depth annotation (e.g., `max_depth ≤ 1000`) is unresolved.
 
 7. **Interaction with concurrency.** The parallel dimension `P` (lane) is defined but its interaction with async/await and structured concurrency needs further specification. In particular, how does `with_cost_limit` behave across spawn boundaries?
 
-8. **Amortized analysis.** Operations like dynamic array append are O(1) amortized but O(n) worst-case. The current system can only express worst-case bounds. Whether to extend CostExpr with amortized semantics (potentially through a separate annotation `cost_amortized ≤ expr`) is deferred.
+8. **Amortized analysis.** Operations like dynamic array append are O(1) amortized but O(n) worst-case. The current system can only express worst-case bounds. Whether to extend CostExpr with amortized semantics (potentially through a separate `amortized [...]` metadata channel parallel to worst-case `cost [...]`) is deferred.
 
 9. **Standard library cost annotations.** The standard library must be annotated with cost bounds for the system to be useful. What is the process for auditing and annotating existing library functions? Should the compiler ship with a built-in cost database for the standard library?
 

--- a/seps/SEP-0004-cost-analysis.md
+++ b/seps/SEP-0004-cost-analysis.md
@@ -16,7 +16,7 @@ superseded_by: null
 
 # SEP-0004: Cost Analysis & Decidability
 
-> **Executive Summary**: Introduces 4-dimensional cost analysis with CostVector(compute, alloc, io, parallel), where cost expressions are restricted to a decidable grammar (+, ×, ^const, log, max, min). Provides a three-tier escape mechanism (@unbounded for opt-out, @allows for local override, advisory warnings for gradual adoption) and formal cost inference rules for higher-order function propagation. Checked residual budgeting is defined over 4D vectors as an internal compiler relation (`before + candidate ≤ budget`), not as user-facing subtraction syntax. Targets O(n⁵) verification complexity.
+> **Executive Summary**: Introduces 4-dimensional cost analysis with CostVector(compute, alloc, io, parallel), where cost expressions range over compile-time `Index` parameters and a decidable IndexExpr grammar (+, ×, log, max, min, span). Provides a three-tier escape mechanism (`@unbounded` for opt-out, `@trust_cost` for unverifiable declarations, advisory warnings for gradual adoption) and formal cost inference rules for higher-order function propagation. Checked residual budgeting is defined over 4D vectors as an internal compiler relation (`before + candidate ≤ budget`), not as user-facing subtraction syntax.
 
 ## Summary
 
@@ -32,7 +32,7 @@ The three tiers are:
 2. **Tier 2 — Declarative verification** (~20%): the developer writes `cost [compute, alloc, io, parallel]` in the function signature; the compiler verifies each slot independently.
 3. **Tier 3 — `@unbounded` escape hatch** (~10%): the developer explicitly opts out of cost checking; the annotation is *contagious* — callers inherit `@unbounded` unless they isolate it with `with_cost_limit`.
 
-Cost expressions (`CostExpr`) are drawn from a restricted grammar — `+`, `*`, `^const`, `log`, `max`, `min` — deliberately excluding division, subtraction, and conditionals. This restriction guarantees that the verification problem "`C(n̄) ≤ B(n̄)` for all valid inputs" is **decidable in polynomial time**, specifically **O(n⁵)** where n is the combined AST size of the two expressions.
+Cost expressions (`CostExpr`) are drawn from a restricted grammar over compile-time `Index` parameters — `+`, `*`, `log`, `max`, `min`, and `span(hi, lo)` — deliberately excluding arbitrary runtime values, division, ordinary subtraction, and conditionals. This restriction keeps verification decidable and makes cost a compile-time symbolic upper-bound function rather than runtime profiling.
 
 ---
 
@@ -118,26 +118,23 @@ fn tree_sum(tree: Tree<I64>) -> I64 {
 When the compiler cannot automatically detect structural recursion but you know the cost is bounded, declare it:
 
 ```spore
-fn merge_sort[T](list: List[T]) -> List[T]
+fn vec_merge_sort[T, N: Index](items: Vec[T, max: N]) -> Vec[T, max: N]
     where T: Ord
-    decreases len(list)
+    decreases N
     cost [
-        len(list) * log(len(list)) * 5 + len(list),
-        len(list) * log(len(list)),
+        N * log(N) * 5 + N,
+        N * log(N),
         0,
-        1,
+        0,
     ]
 {
-    match list {
-        [] => [],
-        [x] => [x],
-        _ => {
-            (left, right) = split_at(list, len(list) / 2)
-            merge(merge_sort(left), merge_sort(right))
-        },
-    }
+    ?sort_impl
 }
 ```
+
+Dynamic `List[T]` sorting remains available in the standard library, but its
+length is not a verified `CostExpr` variable. Publishing a verified sorting cost
+requires an indexed container such as `Vec[T, max: N]`.
 
 The compiler verifies the declared bound against the inferred cost using abstract interpretation and the asymptotic comparison algorithm defined in the reference section. The optional `decreases` clause provides a termination measure when the compiler needs help.
 
@@ -160,7 +157,7 @@ fn collatz_steps(n: I64) -> I64 {
 
 ```spore
 fn safe_collatz(n: I64) -> I64 ! CostExceeded
-    cost [10000, 2000, 0, 2]
+    cost [10000, 2000, 0, 0]
 {
     with_cost_limit(10000) {
         collatz_steps(n)
@@ -197,8 +194,8 @@ dimension remains after each checked program prefix.
 - Residuals may be surfaced in diagnostics, HoleReport payloads, or debugging
   tools, but they are **not** a new source-language arithmetic feature
 
-In other words, the language does **not** expose user-facing budget subtraction
-such as `cost [n - 1, ...]` or `remaining_cost(...)`. Residual budgeting is a
+In other words, the language does **not** expose user-facing budget arithmetic
+such as `remaining_cost(...)` or local budget variables. Residual budgeting is a
 checker concept used to explain whether a call, handler installation, or hole
 still fits within the enclosing declaration.
 
@@ -368,14 +365,17 @@ Consequences:
   K(spawn e) = (1, 1, 0, 1) ⊕ K(e) projected onto parallel dimension
   (parallel dimension tracks spawned lanes)
 
-[Cost-HOF-Map]
-  K(map(f, xs)) = |xs| ⊗ K_body(f) ⊕ (0, |xs|, 0, 0)
+[Cost-HOF-VecMap]
+  xs: Vec[T, max: N]
+  K(xs.map(f)) = N ⊗ K_body(f) ⊕ (0, N, 0, 0)
 
-[Cost-HOF-Fold]
-  K(fold(f, init, xs)) = |xs| ⊗ K_body(f)
+[Cost-HOF-VecFold]
+  xs: Vec[T, max: N]
+  K(xs.fold(init, f)) = N ⊗ K_body(f)
 
-[Cost-HOF-Filter]
-  K(filter(p, xs)) = |xs| ⊗ K_body(p) ⊕ (0, |xs|, 0, 0)
+[Cost-HOF-VecFilter]
+  xs: Vec[T, max: N]
+  K(xs.filter(p)) = N ⊗ K_body(p) ⊕ (0, N, 0, 0)
 ```
 
 **Verification judgment:**
@@ -414,40 +414,56 @@ The cost expression language is intentionally restricted to ensure decidability:
 
 ### 4.4 CostExpr grammar
 
-The cost expression language is deliberately restricted to maintain decidability.
+The cost expression language is deliberately restricted to maintain
+decidability. CostExpr may mention only compile-time Index symbols, literals,
+and function-cost summaries such as `cost(f)`. Ordinary runtime values are not
+CostExpr variables.
 
 #### BNF definition
 
 ```bnf
-CostExpr ::= Literal                              (* Positive integer constant *)
-           | Var                                   (* Variable from parameter size *)
-           | CostExpr '+' CostExpr                 (* Addition *)
-           | CostExpr '*' CostExpr                 (* Multiplication *)
-           | CostExpr '^' Literal                  (* Power — exponent must be constant *)
-           | 'log' '(' CostExpr ')'                (* Logarithm — base 2, ceiling *)
-           | 'max' '(' CostExpr ',' CostExpr ')'   (* Maximum *)
-           | 'min' '(' CostExpr ',' CostExpr ')'   (* Minimum *)
+CostExpr ::= Literal
+           | IndexExpr
+           | 'cost' '(' FnVar ')'
+           | CostExpr '+' CostExpr
+           | CostExpr '*' CostExpr
+           | 'log' '(' CostExpr ')'
+           | 'max' '(' CostExpr ',' CostExpr ')'
+           | 'min' '(' CostExpr ',' CostExpr ')'
 
-Literal  ::= [1-9][0-9]*                           (* Positive integer, no zero *)
-Var      ::= [a-z][a-z0-9_]*                       (* Lowercase identifier *)
+IndexExpr ::= Literal
+            | IndexVar
+            | IndexExpr '+' IndexExpr
+            | IndexExpr '*' IndexExpr
+            | 'log' '(' IndexExpr ')'
+            | 'max' '(' IndexExpr ',' IndexExpr ')'
+            | 'min' '(' IndexExpr ',' IndexExpr ')'
+            | 'span' '(' IndexExpr ',' IndexExpr ')'
+
+Literal  ::= '0' | [1-9][0-9]*
+IndexVar ::= [A-Z][A-Za-z0-9_]*
+FnVar    ::= [a-z][A-Za-z0-9_]*
 ```
 
 #### Explicitly forbidden constructs
 
 | Construct | Reason |
 |-----------|--------|
-| Division `/` | Avoids division-by-zero and rational expressions; keeps expressions closed over ℕ⁺ |
-| Subtraction `-` | Cost is always non-negative; subtraction may produce negative values, breaking monotonicity |
+| Ordinary runtime values | Cost must be a compile-time symbolic upper-bound function over Index parameters |
+| Division `/` | Avoids division-by-zero and rational expressions |
+| Ordinary subtraction `-` | May produce negative values and non-monotone expressions |
 | Conditionals `if...then...else` | Introduces undecidable branching — conditionals can encode arbitrary predicates |
 | Recursive cost definitions | Avoids fixpoint computation; recursion analysis is handled at a separate layer |
-| Negative numbers | Cost domain is ℕ (non-negative integers) |
+| Negative numbers | Cost domain is `N0` (non-negative integers) |
 | Variable exponents `n^m` | Pushes comparison into the exponential polynomial domain, losing polynomial decidability |
 
-> **Note on subtraction discrepancy.** The cost-model spec (§6) includes subtraction in its symbolic cost operators (e.g., `(len(list) - 1) × cost(f)` for `reduce`). However, the decidability analysis forbids subtraction in CostExpr to maintain monotonicity and non-negativity. This SEP follows the decidability spec: **subtraction is not a valid CostExpr operator**. Where subtraction appears naturally (e.g., `n - 1`), the compiler uses the conservative upper bound (e.g., `n` instead of `n - 1`). Cost formulas in the HOF table that use subtraction (e.g., `reduce`) are computed internally by the compiler but are presented to the CostExpr verifier in their upper-bound form.
+`span(hi, lo)` is the only difference-like operation. Its meaning is
+`max(hi - lo, 0)`, and it exists only in the Index layer so APIs can express
+interval lengths without admitting arbitrary subtraction into CostExpr.
 
 Residual budgeting does not weaken this rule: the checker may compute
 "remaining budget" internally, but that is not a user-authored `CostExpr`
-surface and therefore does not reintroduce subtraction into the source
+surface and therefore does not reintroduce ordinary subtraction into the source
 language.
 
 #### Implementation (Rust)
@@ -457,40 +473,48 @@ The `CostExpr` type is implemented in `sporec-typeck/src/cost.rs`:
 ```rust
 pub enum CostExpr {
     Const(u64),
-    Var(String),
+    IndexVar(String),
+    FunctionCost(String),
     Add(Box<CostExpr>, Box<CostExpr>),
     Mul(Box<CostExpr>, Box<CostExpr>),
-    Pow(Box<CostExpr>, u32),    // exponent is a constant
     Log(Box<CostExpr>),
     Max(Box<CostExpr>, Box<CostExpr>),
     Min(Box<CostExpr>, Box<CostExpr>),
+    Span(Box<CostExpr>, Box<CostExpr>),
 }
 ```
 
 ### 4.5 Semantics
 
-CostExpr evaluates over **ℕ⁺ = {1, 2, 3, ...}** (positive natural numbers).
+CostExpr evaluates over **N0 = {0, 1, 2, ...}** (non-negative integers). A
+CostVector's identity element is `[0, 0, 0, 0]`.
 
-Let σ: Var → ℕ⁺ be an assignment environment. The semantic function ⟦·⟧: CostExpr → (Var → ℕ⁺) → ℕ⁺ is defined as:
+Let σ: IndexVar → N0 be an assignment environment. The semantic function
+⟦·⟧: CostExpr → (IndexVar → N0) → N0 is defined as:
 
 ```text
-⟦ c ⟧σ           = c                              (c ∈ ℕ⁺)
-⟦ x ⟧σ           = σ(x)                           (x ∈ Var)
+⟦ c ⟧σ           = c                              (c ∈ N0)
+⟦ N ⟧σ           = σ(N)                           (N ∈ IndexVar)
 ⟦ e₁ + e₂ ⟧σ    = ⟦e₁⟧σ + ⟦e₂⟧σ
 ⟦ e₁ * e₂ ⟧σ    = ⟦e₁⟧σ × ⟦e₂⟧σ
-⟦ e ^ k ⟧σ      = (⟦e⟧σ)ᵏ                        (k ∈ ℕ⁺)
-⟦ log(e) ⟧σ     = max(⌈log₂(⟦e⟧σ)⌉, 1)          (min value 1 to avoid ×0)
+⟦ log(e) ⟧σ     = ⌈log₂(max(1, ⟦e⟧σ))⌉
 ⟦ max(e₁,e₂) ⟧σ = max(⟦e₁⟧σ, ⟦e₂⟧σ)
 ⟦ min(e₁,e₂) ⟧σ = min(⟦e₁⟧σ, ⟦e₂⟧σ)
+⟦ span(e₁,e₂) ⟧σ = max(⟦e₁⟧σ - ⟦e₂⟧σ, 0)
 ```
 
 > **Convention**: `log` always means `log₂` (binary logarithm), following standard computer science convention.
 
-**Theorem 4.1 (Monotonicity).** For any CostExpr `e`, if σ₁(x) ≤ σ₂(x) for all variables x, then ⟦e⟧σ₁ ≤ ⟦e⟧σ₂.
+**Theorem 4.1 (Monotonicity for the positive fragment).** For any CostExpr `e`
+that does not contain `span`, if σ₁(N) ≤ σ₂(N) for all variables N, then
+⟦e⟧σ₁ ≤ ⟦e⟧σ₂.
 
-*Proof.* By structural induction on `e`. All operations (`+`, `×`, `(·)ᵏ`, `⌈log₂(·)⌉`, `max`, `min`) are monotone non-decreasing on ℕ⁺. ∎
+*Proof.* By structural induction on `e`. All operations (`+`, `×`, `log`,
+`max`, `min`) are monotone non-decreasing on N0. ∎
 
-Monotonicity guarantees: **if the inequality holds for "sufficiently large" inputs, it holds for all inputs** (after adjusting constants). This is the theoretical foundation of the asymptotic comparison algorithm.
+For `span(hi, lo)`, the checker tracks variance: `hi` is covariant and `lo` is
+contravariant. This is still a compile-time Index relation, not ordinary
+runtime-value reasoning.
 
 ### 4.6 Three-tier analysis
 
@@ -546,14 +570,11 @@ where `cost_per_step` is the four-dimensional cost of the function body excludin
 When the compiler cannot auto-detect structural recursion but the developer knows the function terminates with a bounded cost, they declare it:
 
 ```spore
-fn gcd(a: I64, b: I64) -> I64
-    decreases a + b
-    cost [log(max(a, b)), 0, 0, 1]
+fn gcd_bounded[A: Index, B: Index](a: Count[A], b: Count[B]) -> Count[max(A, B)]
+    decreases A + B
+    cost [log(max(A, B)), 0, 0, 0]
 {
-    match b {
-        0 => a,
-        _ => gcd(b, a % b),
-    }
+    ?gcd_impl
 }
 ```
 
@@ -627,17 +648,16 @@ WARNING [unbounded-function] collatz_steps is marked @unbounded.
 
 ### 4.7 Higher-order function cost formulas
 
-Since Spore has no loops, higher-order functions are the *only* iteration mechanism besides recursion. The standard library has built-in cost formulas:
+Since Spore has no loops, higher-order functions are the *only* iteration mechanism besides recursion. Verified standard-library cost formulas are defined for indexed containers:
 
 | Function | Cost formula |
 |----------|-------------|
-| `map(list, f)` | `len(list) × cost(f) + len(list)` |
-| `fold(list, init, f)` | `len(list) × cost(f)` |
-| `filter(list, pred)` | `len(list) × cost(pred) + len(list)` |
-| `flat_map(list, f)` | `len(list) × cost(f) + total_output_len` |
-| `zip(a, b)` | `min(len(a), len(b))` |
-| `take(list, n)` | `n` |
-| `reduce(list, f)` | `(len(list) - 1) × cost(f)` |
+| `v.map(f)` where `v: Vec[T, max: N]` | `N × cost(f) + N` |
+| `v.fold(init, f)` where `v: Vec[T, max: N]` | `N × cost(f)` |
+| `v.filter(pred)` where `v: Vec[T, max: N]` | `N × cost(pred) + N` |
+| `a.zip(b)` where `a: Vec[A, max: M]`, `b: Vec[B, max: N]` | `min(M, N)` |
+| `v.take(count)` where `count: Count[K]` | `min(N, K)` |
+| `v.reduce(f)` where `v: Vec[T, max: N]` | `N × cost(f)` |
 
 Since higher-order function arguments `f` in Spore must be pure (no effect variables), `cost(f)` is always statically determinable. Substituting `cost(f)` into the formula yields a valid CostExpr.
 
@@ -646,37 +666,37 @@ Since higher-order function arguments `f` in Spore must be pure (no effect varia
 The following example demonstrates step-by-step cost derivation for nested higher-order functions:
 
 ```spore
-fn matrix_sum(matrix: List[List[I64]]) -> I64 {
+fn matrix_sum[M: Index, N: Index](matrix: Vec[Vec[I64, max: N], max: M]) -> I64 {
     matrix
-        |> map(|row| row |> fold(0, |a, b| a + b))
-        |> fold(0, |a, b| a + b)
+        .map(|row| row.fold(0, |a, b| a + b))
+        .fold(0, |a, b| a + b)
 }
 ```
 
-**Six-step derivation** (let `m = len(matrix)`, `n = len(row)` for a typical row):
+**Six-step derivation** (using the static bounds `M` and `N`):
 
 ```text
 Step 1: inner closure cost
   cost(|a, b| a + b) = 1 op                           // single addition
 
 Step 2: inner fold cost
-  cost(fold(row, 0, |a, b| a + b)) = n × cost(+) = n × 1 = n
+  cost(row.fold(0, |a, b| a + b)) = N × cost(+) = N × 1 = N
 
 Step 3: map step cost (applying inner fold to each row)
-  map_step_cost = cost(inner_fold) = n
+  map_step_cost = cost(inner_fold) = N
 
 Step 4: outer map cost
-  cost(map(matrix, inner_fold)) = m × map_step_cost + m
-                                = m × n + m
+  cost(matrix.map(inner_fold)) = M × map_step_cost + M
+                               = M × N + M
 
 Step 5: outer fold cost
-  cost(fold(mapped, 0, |a, b| a + b)) = m × 1 = m
+  cost(mapped.fold(0, |a, b| a + b)) = M × 1 = M
 
 Step 6: total cost
   total = cost(outer_map) + cost(outer_fold)
-        = (m × n + m) + m
-        = m × n + 2 × m
-        → O(m × n)
+        = (M × N + M) + M
+        = M × N + 2 × M
+        → O(M × N)
 ```
 
 ### 4.8 Mutual recursion
@@ -709,13 +729,16 @@ Analysis: SCC = {is_even, is_odd}. Combined call pattern: `is_even(n) → is_odd
 
 ### 4.9 Decidability proof sketch
 
-**Verification problem.** Given inferred cost C(n̄) and declared bound B(n̄) as CostExprs, and variable set V = {n₁, ..., nₖ}, determine: does there exist N₀ ∈ ℕ⁺ such that for all n̄ ∈ (ℕ⁺)ᵏ with nᵢ ≥ N₀, we have ⟦C⟧σ_n̄ ≤ ⟦B⟧σ_n̄?
+**Verification problem.** Given inferred cost C(n_bar) and declared bound
+B(n_bar) as CostExprs, and variable set V = {n1, ..., nk}, determine: does
+there exist a threshold T in N0 such that for all non-negative Index
+assignments n_bar with every ni >= T, we have ⟦C⟧σ_n_bar <= ⟦B⟧σ_n_bar?
 
 **Step 1: max/min lifting.** Lift max/min to the top level using distribution rules:
 
 ```text
 e₁ + max(e₂, e₃) → max(e₁ + e₂, e₁ + e₃)
-e₁ * max(e₂, e₃) → max(e₁ * e₂, e₁ * e₃)    (valid since e₁ ≥ 1 on ℕ⁺)
+e₁ * max(e₂, e₃) → max(e₁ * e₂, e₁ * e₃)    (valid over N0)
 ```
 
 With nesting depth d bounded by a constant (default ≤ 8), this produces at most 2^d = O(1) sub-expression pairs, each of size O(n).
@@ -735,7 +758,8 @@ Verification rules for max/min at the top level:
 t = c × n₁^a₁ × ... × nₖ^aₖ × log(n₁)^b₁ × ... × log(nₖ)^bₖ
 ```
 
-where c ∈ ℕ⁺, aᵢ ∈ ℕ, bᵢ ∈ ℕ. We write this as the triple **(c, ā, b̄)**.
+where c is a positive N0 coefficient, and each ai and bi is in N0. We write
+this as the triple **(c, a_bar, b_bar)**.
 
 The *normal form* of a CostExpr is a finite sum of poly-log monomials. Conversion algorithm NF:
 
@@ -784,7 +808,10 @@ t₁ ≼ t₂  ⟺  ā₁ < ā₂  (componentwise ≤ and ≠)
 4. Otherwise → return FAIL
 ```
 
-**Step 4: Small-input enumeration.** For inputs n̄ < N₀ (where N₀ is computed from the dominance analysis, typically ≤ 100), the compiler enumerates all values and checks C(n̄) ≤ B(n̄) directly. Enumeration space is N₀ᵏ, feasible for k ≤ 5.
+**Step 4: Small-input enumeration.** For inputs n_bar < T (where T is
+computed from the dominance analysis, typically <= 100), the compiler
+enumerates all values and checks C(n_bar) <= B(n_bar) directly. Enumeration
+space is T^k, feasible for k <= 5.
 
 ### 4.10 Verification complexity
 
@@ -803,7 +830,9 @@ This is in **P** (polynomial-time complexity class). ∎
 
 ### 4.11 Soundness
 
-**Theorem 4.3 (Soundness).** If the algorithm outputs PASS, then there exists N₀ ∈ ℕ⁺ such that for all n̄ ∈ (ℕ⁺)ᵏ with min(n̄) ≥ N₀, we have C(n̄) ≤ B(n̄).
+**Theorem 4.3 (Soundness).** If the algorithm outputs PASS, then there exists a
+threshold T in N0 such that for all non-negative Index assignments n_bar with
+min(n_bar) >= T, we have C(n_bar) <= B(n_bar).
 
 *Proof sketch.*
 
@@ -825,9 +854,9 @@ These fallback steps only convert FAIL → PASS, never the reverse.
 Four-dimensional cost declarations are verified **independently per dimension**:
 
 ```spore
-fn sort[T](items: List[T]) -> List[T]
+fn vec_sort[T, N: Index](items: Vec[T, max: N]) -> Vec[T, max: N]
     where T: Ord
-    cost [items.len * log(items.len) * 3, items.len, 0, 1]
+    cost [N * log(N) * 3, N, 0, 0]
 ```
 
 This is equivalent to four independent verification problems, each using the same asymptotic comparison algorithm.
@@ -838,7 +867,7 @@ Partially-defined functions participate in cost analysis:
 
 ```spore
 fn process(data: Data) -> Result ! ProcessError
-    cost [1000, 400, 0, 1]
+    cost [1000, 400, 0, 0]
 {
     parsed = parser.parse(data)     // cost: 600
     ?process_logic                  // hole: remaining budget 400
@@ -887,30 +916,33 @@ Source Code
 
 ### 4.15 Bounded type semantics
 
-Bounded types provide compile-time size information for cost verification:
+Indexed types provide compile-time size information for cost verification:
 
 ```spore
-fn process_batch(items: List[Order]) -> BatchResult ! TooLarge
-    cost [25000, items.len * 80 + 800, items.len / 50, 16]
+fn process_batch[N: Index](items: Vec[Order, max: N]) -> BatchResult ! TooLarge
+    cost [N * 80 + 800, N, N, 0]
 {
-    items |> map(|order| validate(order)) |> fold(BatchResult.empty(), merge)
+    items.map(|order| validate(order)).fold(BatchResult.empty(), merge)
 }
 ```
 
-`List[Order]` here carries **runtime** length. The **`TooLarge`** path (or upstream validation) rejects oversize batches; verification substitutes a conservative `n` (derived from refinements / policy constants) into the cost checker. When a **numeric cap must literally appear in the type** (`N` tied to generics), reserve **`Vec[Order, max: N]`**—that is uncommon; **`List`** should be the default API shape.
+`Vec[Order, max: N]` carries the static capacity bound `N`. Dynamic
+`List[Order]` remains useful for ordinary programs, but its runtime length is
+not a CostExpr variable. Use `Vec`, `Array`, or `Count` when a verified
+compile-time cost bound must mention size.
 
 ### 4.16 FFI extern function cost declarations
 
 Foreign functions have no Spore body for the compiler to analyse. They **must** declare their cost explicitly at the binding site:
 
 ```spore
-extern fn c_sort[T](data: List[T]) -> List[T]
-    cost [n * log(n), n, 0, 1]        // declared, not computed; n = len(data)
+extern fn c_sort[T, N: Index](data: Vec[T, max: N]) -> Vec[T, max: N]
+    cost [N * log(N), N, 0, 0]
 ```
 
 ```spore
-extern fn openssl_encrypt(data: Bytes, key: Key) -> Bytes ! CryptoError
-    cost [len(data) * 3 + 500, len(data), len(data), 1]
+extern fn openssl_encrypt[N: Index](data: Bytes[N], key: Key) -> Bytes[N] ! CryptoError
+    cost [N * 3 + 500, N, N, 0]
 ```
 
 **Rules for extern fn cost:**
@@ -920,28 +952,30 @@ extern fn openssl_encrypt(data: Bytes, key: Key) -> Bytes ! CryptoError
 | Required declaration | `extern fn` without a `cost` clause is treated as `@unbounded` |
 | No body analysis | The compiler trusts the declared cost — no verification is possible |
 | Contagious unbounded | An `@unbounded` extern fn follows the same contagion rules as any `@unbounded` function |
-| Variable binding | Cost variables (`n`, `len(data)`) bind to parameter sizes at the call site |
+| Variable binding | Cost variables are Index parameters such as `N`; ordinary runtime values do not bind into CostExpr |
 
 This ensures FFI boundaries maintain cost transparency — external code cannot silently introduce cost black holes.
 
 ### 4.17 Polymorphic function cost resolution
 
-For generic functions like `map(f, list)`, cost depends on the concrete function `f`. Spore resolves this at the **call site**:
+For generic methods like `vec.map(f)`, cost depends on the concrete function
+`f`. Spore resolves this at the **call site**:
 
 ```spore
-fn map[T, U](list: List[T], f: (T) -> U) -> List[U]
-    cost [len(list) * cost(f) + len(list), len(list), 0, 1]
-{
-    // ...
+impl[T, N: Index] Mappable for Vec[T, max: N] {
+    type Item = T
+    type Mapped[U] = Vec[U, max: N]
+    fn map[U](self, f: (T) -> U) -> Vec[U, max: N]
+        cost [N * cost(f) + N, N, 0, 0]
 }
 ```
 
 At each call site, `f` is concrete and `cost(f)` is known:
 
 ```spore
-let result = map(items, |x| x * 2)
+let result = items.map(|x| x * 2)
 // cost(|x| x * 2) = 1 op
-// total cost = len(items) * 1 + len(items) = 2 * len(items)
+// total cost = N * 1 + N = 2 * N
 ```
 
 **Resolution rules:**
@@ -1021,18 +1055,18 @@ The compiler emits structured cost information as part of the compilation artifa
 ```json
 {
   "functions": {
-    "merge_sort": {
-      "cost_declared": "n * log(n) * 5 + n",
-      "cost_inferred": "n * log(n) * 4 + n",
+    "vec_merge_sort": {
+      "cost_declared": "N * log(N) * 5 + N",
+      "cost_inferred": "N * log(N) * 4 + N",
       "cost_status": "verified",
       "cost_dimensions": {
-        "compute": "n * log(n) * 4",
-        "alloc": "n",
+        "compute": "N * log(N) * 4",
+        "alloc": "N",
         "io": "0",
-        "parallel": "1"
+        "parallel": "0"
       },
       "tier": 2,
-      "decreases": "len(list)"
+      "decreases": "N"
     },
     "factorial": {
       "cost_inferred": "n * 4",
@@ -1052,7 +1086,7 @@ CostExpr is serialized as a JSON AST for tool consumption:
 {
   "type": "Mul",
   "left": { "type": "Var", "name": "n" },
-  "right": { "type": "Log", "arg": { "type": "Var", "name": "n" } }
+      "right": { "type": "Log", "arg": { "type": "IndexVar", "name": "N" } }
 }
 ```
 
@@ -1167,7 +1201,7 @@ Skip Tier 2 — either the compiler infers the cost automatically or the functio
 - Would leave ~20% of practically-bounded functions as `@unbounded`, significantly reducing the system's value.
 - Merge sort, quicksort, GCD, and many other well-known algorithms would lack cost bounds.
 
-### Alternative 4: Allow division and subtraction in CostExpr
+### Alternative 4: Allow division and ordinary subtraction in CostExpr
 
 Extend the grammar to support `n*(n-1)/2` and similar expressions.
 
@@ -1177,6 +1211,9 @@ Extend the grammar to support `n*(n-1)/2` and similar expressions.
 - Subtraction breaks monotonicity (expressions can decrease as inputs grow).
 - The comparison problem becomes undecidable in general.
 - The conservative upper-bound approach (`n^2` instead of `n*(n-1)/2`) is acceptable in practice.
+
+`span(hi, lo)` is the accepted narrow alternative: it expresses saturating
+interval length in the Index layer without admitting general subtraction.
 
 ### Alternative 5: SMT-based verification
 
@@ -1214,7 +1251,10 @@ Spore's cost inference uses abstract interpretation — executing the program on
 
 ### Sized types: Hughes, Pareto, Sabry
 
-Sized types annotate values with compile-time **size parameters** (`Vec[T, max: n]`, `Matrix[…]`) to enable sharper termination and complexity reasoning. Everyday programs should stay on **`List[T]`** (`len` routed through `cost` / refinements). Spore exposes **`Vec[T, max: N]`** mostly for layouts that genuinely need **`N` in the type**.
+Sized types annotate values with compile-time **Index parameters** (`Count[N]`,
+`Array[T, N]`, `Vec[T, max: N]`, `Matrix[…]`) to enable sharper termination and
+complexity reasoning. Everyday dynamic programs can stay on **`List[T]`**, but
+verified CostExprs only mention Index parameters.
 
 ---
 
@@ -1243,7 +1283,7 @@ Cost analysis is introduced as a new compiler effect. No existing Spore code is 
 
 ### Interaction with existing SEPs
 
-- **SEP-0002 (Type System):** CostExpr integrates with checker types. Prefer **`List[T]`** (`items.len`-indexed costs); use **`Vec[T, max: N]`** sparingly—only when **`N`** must participate in generics. **`List[T]`** stays unbounded (never `List[..., max: ...]`).
+- **SEP-0002 (Type System):** CostExpr integrates with the `Index` kind. `List[T]` stays dynamic and unbounded; `Count[N]`, `Array[T, N]`, and `Vec[T, max: N]` expose compile-time Index parameters to cost checking.
 
 - **SEP-0005 (Hole System):** Cost budgets propagate to HoleReports for hole filling.
 
@@ -1345,7 +1385,7 @@ WARNING [cost-drift] function merge_sort: actual cost exceeds prediction.
 
 4. **Probabilistic cost bounds.** Randomized algorithms (e.g., QuickSort with random pivot) have expected rather than worst-case cost. Should Spore support an **`expected`** cost metadata channel alongside worst-case four-slot bounds? Deferred to future work.
 
-5. **Polymorphic cost (partially resolved).** The call-site instantiation approach is now specified in §4.17: `cost(f)` is substituted at each call site where `f` is concrete. The remaining open question is whether a signature-level pattern like `cost [N × cost(f) + N, N, 0, 1]` should be a first-class part of each slot's CostExpr grammar, or remain an informal convention resolved during monomorphisation.
+5. **Polymorphic cost (partially resolved).** The call-site instantiation approach is now specified in §4.17: `cost(f)` is substituted at each call site where `f` is concrete. Signature-level patterns such as `cost [N * cost(f) + N, N, 0, 0]` are first-class CostExprs when `N: Index`.
 
 6. **Recursion depth limits.** Should the compiler enforce a compile-time recursion depth ceiling? Current decision: only `@unbounded` functions use runtime `with_cost_limit`. Whether to add a compile-time depth annotation (e.g., `max_depth ≤ 1000`) is unresolved.
 

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -23,7 +23,7 @@ superseded_by: null
 
 This SEP specifies Spore's **Hole System** — a first-class language mechanism that treats unfinished code as a structured, typed, compiler-mediated collaboration interface between humans and AI Agents.
 
-A *hole* is written `?name` (optionally `?name: Type`) in any expression position within a function body. The compiler accepts programs containing holes, classifies those functions as **partial**, and produces a shared typed hole report. The stable machine protocol reuses one hole object across both batch and single-hole queries: `sporec holes FILE --json` emits `{ "holes": [...], "dependency_graph": ... }`, while `sporec query-hole FILE ?name --json` returns the matching hole object directly. That shared object now carries the fields agents actually consume today, including `name`, `display_name`, `location`, `expected_type`, `type_inferred_from`, `function`, `enclosing_signature`, `bindings`, `binding_dependencies`, `available_effects`, `errors_to_handle`, `cost_budget`, `candidates`, `dependent_holes`, `confidence`, and `error_clusters`.
+A *hole* is written `?name` (optionally `?name: Type`) in any expression position within a function body. The compiler accepts programs containing holes, classifies those functions as **partial**, and produces a shared typed hole report. The stable machine protocol reuses one hole object across both batch and single-hole queries: `sporec holes FILE --json` emits `{ "holes": [...], "dependency_graph": ... }`, while `sporec query-hole FILE ?name --json` returns the matching hole object directly. That shared object now carries the fields agents actually consume today, including `name`, `display_name`, `location`, `expected_type`, `type_inferred_from`, `function`, `enclosing_signature`, `bindings`, `binding_dependencies`, `available_effects`, `errors_to_handle`, a legacy `cost_budget`, `candidates`, `dependent_holes`, `confidence`, and `error_clusters`. That `cost_budget` field name remains on the current stable surface, but today it is still a scalar-style compatibility snapshot rather than a fully checked 4D residual context.
 
 Multiple holes still form a **Hole Dependency Graph** (DAG), enabling topological ordering and parallel filling by multiple Agents. The long-term **Agent Protocol** defines a five-state machine (DISCOVER → ANALYZE → PROPOSE → VERIFY → ACCEPT/REJECT) for autonomous filling workflows. Today, however, `spore watch --json` remains a thinner transport: it emits per-cycle `compile_result` plus a summary `hole_graph_update`, while richer per-hole watch events remain the target architecture rather than the stable contract.
 
@@ -56,7 +56,7 @@ Making holes a first-class language construct enables:
 - **Compiler-mediated collaboration**: The compiler produces HoleReports that are *information-self-sufficient* — an Agent reading a report needs zero additional context to attempt a fill.
 - **Incremental development**: Functions transition smoothly from `partial` to `complete`. Downstream callers are not invalidated because holes are body-only — they never affect signature hashes.
 - **Dependency-ordered filling**: The compiler can analyze data-flow between holes, build a DAG, and recommend an optimal filling order.
-- **Cost-bounded filling**: Each hole carries a remaining cost budget inherited from the enclosing function's declared checked budget.
+- **Cost-bounded filling (target behavior)**: each hole should eventually carry the checked residual context inherited from the enclosing function's declared budget; today the stable payload still exposes only a legacy `cost_budget` snapshot, and the compiler does not yet compute authoritative per-hole 4D residuals for candidate scoring.
 
 ### Why the Agent Protocol Matters
 
@@ -80,7 +80,7 @@ A hole is written with a `?` prefix followed by an identifier. Holes can appear 
 ```spore
 fn calculate_tax(income: Money, region: Region) -> Money ! InvalidRegion
     uses [TaxTable]
-    cost ≤ 500
+    cost [500, 100, 0, 1]
 {
     ?tax_logic
 }
@@ -91,7 +91,7 @@ The function compiles successfully. It is marked `partial` — not broken.
 Optionally, holes can carry a type annotation:
 
 ```spore
-let body: String = ?report_body : String
+let body: Str = ?report_body : Str
 ```
 
 If the annotation conflicts with the inferred type, the compiler emits a `hole-type-conflict` warning (not an error — holes are exploratory).
@@ -101,8 +101,8 @@ If the annotation conflicts with the inferred type, the compiler emits a `hole-t
 A function may contain any number of independently named holes:
 
 ```spore
-fn reconcile(ledger: Ledger, txns: Vec[Tx]) -> Ledger ! Mismatch
-    cost ≤ 5000
+fn reconcile(ledger: Ledger, txns: List[Tx]) -> Ledger ! Mismatch
+    cost [5000, txns.len * 4, 0, 1]
 {
     let grouped     = group_by_account(txns)
     let adjustments = ?compute_adjustments
@@ -116,7 +116,7 @@ Holes can also appear nested inside expressions, function arguments, and match a
 ```spore
 fn render(page: Page) -> Html ! TemplateError
     uses [Templates]
-    cost ≤ 800
+    cost [800, 400, 0, 1]
 {
     let nav = render_nav(?nav_items)                 // hole as argument
     let content = match page.kind {
@@ -153,11 +153,11 @@ A complete Human → Agent → Compiler interaction:
 ```spore
 fn generate_invoice(
     customer: Customer,
-    items: Vec[LineItem],
+    items: List[LineItem],
     tax_region: TaxRegion,
 ) -> Invoice ! TaxCalculationError | InvalidLineItem
     uses [TaxTable]
-    cost ≤ 5000
+    cost [5000, items.len * 8, 0, 1]
 {
     let validated_items = ?validate_items
     let subtotal = sum(validated_items.map(|i| i.price * i.quantity))
@@ -173,7 +173,7 @@ fn generate_invoice(
 $ sporec query-hole src/billing/invoice.sp ?validate_items --json
 ```
 
-The compiler returns a HoleReport (see §4 for the full structure) containing: expected type `Vec[LineItem]`, available bindings, candidate function `validate_line_items` with an exact type match, cost 300 within budget 5000.
+The compiler returns a HoleReport (see §4 for the full structure) containing: expected type `List[LineItem]`, available bindings, candidate function `validate_line_items` with an exact type match, cost 300 within budget 5000.
 
 **Step 3 — Agent proposes a fill:**
 
@@ -191,6 +191,10 @@ $ spore check src/billing/invoice.sp
   ?compute_tax: still open
   budget for ?compute_tax: ≤4580
 ```
+
+Until the checker publishes full CostVector residuals in HoleReport, treat the
+stable `cost_budget` field as schema-oriented metadata, not a proof of an exact
+residual.
 
 **Step 5 — Agent fills the next hole, compiler confirms completion:**
 
@@ -223,7 +227,7 @@ Empty function bodies desugar to a single hole named `{function_name}_body`.
 
 ### HoleInfo Structure
 
-The implementation (in `spore-typeck`) represents a single hole as:
+The implementation (in `sporec-typeck`) represents a single hole as:
 
 ```rust
 pub struct HoleInfo {
@@ -231,11 +235,11 @@ pub struct HoleInfo {
     pub expected_type: Ty,         // inferred/expected type
     pub function: String,          // enclosing function
     pub bindings: BTreeMap<String, Ty>,  // local bindings at hole site
-    pub suggestions: Vec[String],  // candidate functions
+    pub suggestions: List[Str],  // candidate functions (unbounded list)
 }
 ```
 
-**HoleInfo vs HoleReport:** `HoleInfo` is the **compiler-internal** representation (Rust struct in `spore-typeck`), while `HoleReport` is the **JSON output format** for machine/Agent consumption. `HoleInfo` is converted to `HoleReport` via `to_json()` with additional computed fields (scores, confidence, error clusters). They serve different purposes: HoleInfo for compiler passes, HoleReport for external tooling.
+**HoleInfo vs HoleReport:** `HoleInfo` is the **compiler-internal** representation (Rust struct in `sporec-typeck`), while `HoleReport` is the **JSON output format** for machine/Agent consumption. `HoleInfo` is converted to `HoleReport` via `to_json()` with additional computed fields (scores, confidence, error clusters). They serve different purposes: HoleInfo for compiler passes, HoleReport for external tooling.
 
 The `HoleReport` aggregates all holes in a module, with `to_json()` for machine consumption. Hand-rolled JSON serialization is used in v0.1 to minimize dependencies; serde migration is tracked as future work (see Unresolved Questions §10).
 
@@ -260,9 +264,9 @@ preserved; four new extensions are added.
 | `bindings` | Variables in scope with name, type, and simulated value (`symbolic` or `computed`) |
 | `available_effects` | The `uses` list available at the hole site |
 | `errors_to_handle` | Error types not yet handled before the hole |
-| `cost.budget_total` | The `cost ≤ N` from the enclosing function |
-| `cost.cost_before_hole` | Cumulative cost of statements before the hole |
-| `cost.budget_remaining` | `budget_total - cost_before_hole` |
+| `cost_budget.budget_total` | Legacy scalar-style compatibility field carried by today's stable payload |
+| `cost_budget.cost_before_hole` | Legacy prefix-cost snapshot; useful as schema context, not yet an authoritative checked residual |
+| `cost_budget.budget_remaining` | Legacy derived remainder; current implementations should not treat it as a precise 4D residual proof |
 | `candidates` | Functions in scope whose return type matches the hole's expected type |
 | `dependent_holes` | Holes that become reachable when this hole is filled |
 | `enclosing_function` | Full signature context of the containing function |
@@ -308,6 +312,12 @@ Replaces the coarse `match_quality: "exact" | "partial"` string with a four-dime
 | Effect fit | `required_effects_fit` | `{0, 1}` | All required effects available (boolean) |
 | Error coverage | `error_coverage` | `[0, 1]` | Fraction of candidate's declared errors covered by context |
 
+This scoring vector is still a **target** contract. In particular, `cost_fit`
+should ultimately be computed against checked residual context, but current
+implementation work has not yet connected real residual checking to candidate
+ranking. The stable `cost_budget` field should therefore be read as schema
+compatibility, not as evidence that `cost_fit` is already authoritative today.
+
 **Type match formula:**
 
 ```text
@@ -345,8 +355,11 @@ expected to be **additive** rather than schema-breaking:
 
 1. **`effect_context`** — active handler stack, already-discharged effects, and
    the visible effect aliases / interfaces at the hole site.
-2. **`residual_context`** — remaining checked budgets after the current prefix,
-   including residual cost and any still-unhandled effect / error obligations.
+2. **`residual_context`** — remaining checked obligations after the current
+   prefix, including a 4D cost vector (`budget_declared`, `cost_before`,
+   `budget_residual`) plus any still-unhandled effect / error obligations. This
+   stays on the `v0.x` line and is the planned successor to the legacy
+   scalar-style `cost_budget` snapshot once the compiler computes real residuals.
 3. **`rejection_reasons`** — structured VERIFY/REJECT feedback explaining why a
    proposed fill failed (for example: `type_mismatch`, `effect_leak`,
    `budget_exceeded`, `duplicate_handler_match`).
@@ -429,7 +442,7 @@ Example:
 ```spore
 fn fetch_and_parse(url: Url) -> Document ! NetworkError | ParseError | Timeout
     uses [Http]
-    cost ≤ 3000
+    cost [3000, 500, 100, 1]
 {
     let response = http_get(url)          // may raise NetworkError, Timeout
         |> catch Timeout => retry_once(url)  // Timeout handled here
@@ -466,7 +479,7 @@ Edges are classified into three dependency types:
 |---|---|---|
 | Type dependency | `type` | h₂'s expected type contains a type variable solvable only after h₁ is filled |
 | Value dependency | `value` | h₂'s available bindings include a value whose data-flow traces back to h₁ |
-| Cost dependency | `cost` | h₂'s remaining cost budget depends on h₁'s actual cost |
+| Cost dependency | `cost` | h₂'s target checked residual context depends on h₁'s actual cost |
 
 #### Graph Construction
 
@@ -484,7 +497,7 @@ function build_hole_graph(module: TypedAST) -> Graph:
             if trace_type_source(tv) is HoleOutput(h'):
                 edges.add(Edge(from=h', to=h, kind="type"))
 
-        if h.cost_budget depends on another hole h':
+        if h.residual_context (or legacy cost_budget compatibility data) depends on another hole h':
             edges.add(Edge(from=h', to=h, kind="cost"))
 
     return Graph(vertices=holes, edges=deduplicate(edges))
@@ -594,7 +607,7 @@ function compute_fill_order(G: Graph) -> Result[List[Set[Hole]], CycleError]:
 
 **Proof.** By induction on layer index k.
 
-**Base case (k = 0):** L₀ = { h ∈ V | in-degree(h) = 0 }. These holes have no predecessors — their types, bindings, and cost budgets are fully determined. They are fillable. Since we take *all* zero in-degree nodes, no fillable hole is missed.
+**Base case (k = 0):** L₀ = { h ∈ V | in-degree(h) = 0 }. These holes have no predecessors — their types, bindings, and any target residual dependencies are fully determined. They are fillable. In current implementations the exposed `cost_budget` payload may still be a compatibility placeholder, but the dependency statement here is about the target checked-residual model. Since we take *all* zero in-degree nodes, no fillable hole is missed.
 
 **Inductive step (k → k+1):** Assume layers L₀ through Lₖ are correctly computed and all holes in them are filled. Let G' be the subgraph remaining after removing L₀ ∪ ... ∪ Lₖ.
 
@@ -782,14 +795,14 @@ Current watch output is compile-result oriented; richer transport states such as
     "errors": [
       {
         "code": "E0301",
-        "message": "type mismatch: expected Vec[ValidItem], found Vec[RawItem]",
+        "message": "type mismatch: expected List[ValidItem], found List[RawItem]",
         "location": { "file": "src/orders.sp", "line": 18, "column": 5 },
         "suggestion": "consider using validate_items(raw_input).map(|i| i.into())"
       }
     ],
     "root_cause": "type_mismatch",
     "fix_hints": [
-      "candidate validate_items returns Vec[RawItem], not Vec[ValidItem]",
+      "candidate validate_items returns List[RawItem], not List[ValidItem]",
       "try: validate_items(raw_input).map(|i| i.into())"
     ]
   }
@@ -812,8 +825,8 @@ The Agent reads diagnostics, understands the failure, and autonomously decides t
 A hole in a recursive function is valid — `?name` is just an expression of some type. It does not call itself. The compiler detects recursive calls to partial functions and terminates simulation at depth 1:
 
 ```spore
-fn factorial(n: Int) -> Int
-    cost ≤ 1000
+fn factorial(n: I64) -> I64
+    cost [1000, 200, 0, 1]
 {
     if n <= 1 { 1 }
     else { n * ?factorial_step }
@@ -823,7 +836,7 @@ fn factorial(n: Int) -> Int
 Here `?factorial_step` has type `Int`. The function is partial. If a recursive call to `factorial` occurs:
 
 ```spore
-fn bad(n: Int) -> Int
+fn bad(n: I64) -> I64
 {
     ?self_ref + bad(n - 1)   // bad is partial; recursive call also partial
 }
@@ -879,10 +892,10 @@ Value holes:
 When a hole has contradictory type constraints from its context, the compiler reports the conflict without failing:
 
 ```spore
-fn conflicted(flag: Bool) -> Int
+fn conflicted(flag: Bool) -> I64
 {
-    let x: String = ?ambiguous   // constraint 1: String (from let binding)
-    let y: Int = x               // constraint 2: Int (from assignment)
+    let x: Str = ?ambiguous   // constraint 1: Str (from let binding)
+    let y: I64 = x               // constraint 2: I64 (from assignment)
     y
 }
 ```
@@ -933,7 +946,7 @@ A hole in a function inferred as `pure` (i.e., `uses []`) is itself pure by defi
 **Formal rule:** If function `f` has `uses []` (and is therefore inferred as `pure`), any expression that replaces a hole `?h` in `f`'s body must also be pure — it may not call functions requiring IO or State effects.
 
 ```spore
-fn pure_fn(x: Int) -> Int
+fn pure_fn(x: I64) -> I64
 {
     ?must_be_pure   // ok: hole is inert
 }
@@ -1152,6 +1165,11 @@ All hole-related commands support `--json` for machine consumption.
 
 **`sporec holes FILE --json`:** emits the batch hole report. The stable root object contains `holes` plus `dependency_graph`.
 
+The JSON example below intentionally shows today's stable `cost_budget` field
+name. Its numeric contents are illustrative compatibility data, not a claim that
+current releases already emit authoritative checked 4D residual vectors; that is
+the planned `residual_context` extension on the same `v0.x` lineage.
+
 ```json
 {
   "holes": [
@@ -1268,10 +1286,10 @@ The hole system integrates with Language Server Protocol:
 ### Cost diagnostics for partial functions
 
 ```text
-[partial] pipeline: (Vec[Int]) -> Vec[Int]
+[partial] pipeline: (List[Int]) -> List[Int]
   known cost: 200 (before hole) + ≤150 (after hole) = ≤350
   budget for ?middle_step: ≤650 (1000 - 350)
-  note: ?middle_step filling must have cost ≤ 650
+  note: ?middle_step filling must stay within the remaining compute budget (≤ 650)
 ```
 
 ### Post-fill diagnostics

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -17,7 +17,7 @@ superseded_by: null
 
 # SEP-0005: Hole System & Agent Protocol
 
-> **Executive Summary**: Defines typed holes (`?name`) as first-class language constructs that carry type, effect, and cost context. The current stable machine surface is a shared typed hole protocol: `sporec holes FILE --json` emits a root object with `holes` and `dependency_graph`, and `sporec query-hole FILE ?name --json` returns the same per-hole object directly. This SEP also keeps the richer long-term agent/watch protocol — dependency-aware fill ordering, cross-hole coordination, and the `DISCOVER → ANALYZE → PROPOSE → VERIFY → ACCEPT/REJECT` workflow — while documenting that today's `spore watch --json` still emits `compile_result` plus a summary-style `hole_graph_update`, not the full target graph payload.
+> **Executive Summary**: Defines typed holes (`?name`) as first-class language constructs that carry type, effect, and cost context. The current stable machine surface is a shared typed hole protocol: `sporec holes FILE --json` emits a root object with `holes` and `dependency_graph`, and `sporec query-hole FILE ?name --json` returns the same per-hole object directly. This SEP keeps HoleReport on the current `v0.x` lineage, documents additive target extensions such as richer effect context, residual context, and rejection reasons, and preserves the richer long-term agent/watch protocol — dependency-aware fill ordering, cross-hole coordination, and the `DISCOVER → ANALYZE → PROPOSE → VERIFY → ACCEPT/REJECT` workflow — while documenting that today's `spore watch --json` still emits `compile_result` plus a summary-style `hole_graph_update`, not the full target graph payload.
 
 ## Summary
 
@@ -30,7 +30,7 @@ Multiple holes still form a **Hole Dependency Graph** (DAG), enabling topologica
 Key components formalized in this SEP:
 
 - **Hole syntax and semantics** (`?name`, `?name: Type`, partial functions)
-- **HoleReport v0.3** with four extensions: (A) candidate scoring vector, (B) binding dependency graph, (C) confidence & ambiguity, (D) error clusters
+- **HoleReport v0.x lineage**, with v0.3 target extensions for: (A) candidate scoring vector, (B) binding dependency graph, (C) confidence & ambiguity, (D) error clusters
 - **Hole Dependency Graph** with layered topological sort and parallel fill scheduling
 - **Agent state machine protocol** for autonomous hole filling
 - **JSON output protocol** via `--json` flag and NDJSON event stream
@@ -56,13 +56,13 @@ Making holes a first-class language construct enables:
 - **Compiler-mediated collaboration**: The compiler produces HoleReports that are *information-self-sufficient* — an Agent reading a report needs zero additional context to attempt a fill.
 - **Incremental development**: Functions transition smoothly from `partial` to `complete`. Downstream callers are not invalidated because holes are body-only — they never affect signature hashes.
 - **Dependency-ordered filling**: The compiler can analyze data-flow between holes, build a DAG, and recommend an optimal filling order.
-- **Cost-bounded filling**: Each hole carries a remaining cost budget inherited from the enclosing function's `cost ≤ N` clause.
+- **Cost-bounded filling**: Each hole carries a remaining cost budget inherited from the enclosing function's declared checked budget.
 
 ### Why the Agent Protocol Matters
 
 AI Agents are not humans reading error messages. They are stateless processes that parse structured output. Spore's hole system is designed with Agents as a *primary* consumer:
 
-- **HoleReport v0.3** replaces human-readable strings (e.g., `match_quality: "partial"`) with machine-comparable scoring vectors.
+- **HoleReport v0.x** keeps evolving by additive fields rather than by a major naming reset; the current target v0.3 additions replace human-readable strings (e.g., `match_quality: "partial"`) with machine-comparable scoring vectors.
 - **Binding dependency graphs** let Agents understand data-flow without re-analyzing source code.
 - **Confidence indicators** tell Agents when to auto-fill vs. when to request human guidance.
 - **NDJSON event streams** allow Agents to consume compiler output in real-time, reacting to each incremental compilation result.
@@ -239,9 +239,14 @@ pub struct HoleInfo {
 
 The `HoleReport` aggregates all holes in a module, with `to_json()` for machine consumption. Hand-rolled JSON serialization is used in v0.1 to minimize dependencies; serde migration is tracked as future work (see Unresolved Questions §10).
 
-### HoleReport v0.3
+### HoleReport v0.3 (within the v0.x lineage)
 
-HoleReport v0.3 is a **superset** of v0.2. The schema version advances from `"spore/hole-report/v1"` to `"spore/hole-report/v2"`. All v0.2 fields are preserved; four new extensions are added.
+HoleReport v0.3 is a **superset** of v0.2 on the same `v0.x` line. The
+project should not rename this family to a detached `v3`/`v1`/`v2` scheme just
+because additive fields land. Current implementation payloads are effectively
+unversioned shared objects; if/when an explicit schema tag is emitted, it
+should remain on a `spore/hole-report/v0.x` identifier. All v0.2 fields are
+preserved; four new extensions are added.
 
 #### Base Fields (v0.2)
 
@@ -332,6 +337,22 @@ overall = 0.40 × type_match + 0.20 × cost_fit + 0.25 × required_effects_fit +
 Weights are hard-coded in the compiler. Candidates are sorted by `overall` descending, with `type_match` as tiebreaker, then `cost_fit`, then lexicographic name for stability.
 
 Each candidate also includes an `adjustments` array of human-readable notes (e.g., `"needs type conversion: Option[Card] → Card"`, `"cost near budget limit"`).
+
+#### Prospective additive extensions (not yet stable output)
+
+The next HoleReport additions should remain on the same `v0.x` lineage and are
+expected to be **additive** rather than schema-breaking:
+
+1. **`effect_context`** — active handler stack, already-discharged effects, and
+   the visible effect aliases / interfaces at the hole site.
+2. **`residual_context`** — remaining checked budgets after the current prefix,
+   including residual cost and any still-unhandled effect / error obligations.
+3. **`rejection_reasons`** — structured VERIFY/REJECT feedback explaining why a
+   proposed fill failed (for example: `type_mismatch`, `effect_leak`,
+   `budget_exceeded`, `duplicate_handler_match`).
+
+These fields are target behavior for a future v0.x slice. Today's stable output
+remains the shared hole object described above.
 
 #### Extension B: Binding Dependency Graph
 
@@ -753,7 +774,7 @@ Current watch output is compile-result oriented; richer transport states such as
 
 **ACCEPT**: Compilation succeeded. The hole is marked `filled`. The dependency graph is recalculated, possibly unlocking blocked holes. The Agent returns to DISCOVER.
 
-**REJECT**: Compilation failed. Today that appears as a watch `compile_result` with `status: "error"` plus compiler diagnostics; the richer structured rejection payload below remains the target transport shape:
+**REJECT**: Compilation failed. Today that appears as a watch `compile_result` with `status: "error"` plus compiler diagnostics; the richer structured rejection payload below remains the target transport shape. A future additive `rejection_reasons` field should capture the normalized machine causes without changing the current v0.x lineage:
 
 ```json
 {
@@ -972,7 +993,9 @@ This is the central section of SEP-0005. The hole system is designed with AI Age
 
 ### Information Self-Sufficiency
 
-A HoleReport v0.3 is **self-contained**. An Agent reading a report needs zero additional context to attempt a fill. The report includes:
+A HoleReport on the current v0.x lineage is **self-contained**. An Agent
+reading a report needs zero additional context to attempt a fill. The report
+includes:
 
 1. **What to produce**: `type.expected` with `type.inferred_from` explaining why
 2. **What is available**: `bindings` with types, simulated values, and `binding_dependencies` showing data-flow
@@ -1347,10 +1370,16 @@ These are runtime markers with no compiler support. They provide no type informa
 
 ### Schema Versioning
 
-- HoleReport v0.3 uses schema `"spore/hole-report/v2"`
+- HoleReport stays on the current `v0.x` lineage; additive extensions must not
+  force a detached `v3` naming story
+- Current implementation payloads are shared JSON objects without an explicit
+  schema tag; any future schema identifier should stay in the
+  `spore/hole-report/v0.x` family
 - All v0.2 fields are preserved with identical semantics
-- New v0.3 fields (`binding_dependencies`, `confidence`, `error_clusters`, `candidates[].scores`, `candidates[].overall`, `candidates[].adjustments`) are additive
-- Tools that do not recognize v0.3 fields can safely ignore them
+- New v0.3 fields (`binding_dependencies`, `confidence`, `error_clusters`,
+  `candidates[].scores`, `candidates[].overall`, `candidates[].adjustments`)
+  are additive
+- Tools that do not recognize newer v0.x fields can safely ignore them
 
 ### CLI Flags
 

--- a/seps/SEP-0005-hole-system.md
+++ b/seps/SEP-0005-hole-system.md
@@ -241,12 +241,17 @@ pub struct HoleInfo {
 
 **HoleInfo vs HoleReport:** `HoleInfo` is the **compiler-internal** representation (Rust struct in `sporec-typeck`), while `HoleReport` is the **JSON output format** for machine/Agent consumption. `HoleInfo` is converted to `HoleReport` via `to_json()` with additional computed fields (scores, confidence, error clusters). They serve different purposes: HoleInfo for compiler passes, HoleReport for external tooling.
 
-The `HoleReport` aggregates all holes in a module, with `to_json()` for machine consumption. Hand-rolled JSON serialization is used in v0.1 to minimize dependencies; serde migration is tracked as future work (see Unresolved Questions §10).
+The batch `sporec holes FILE --json` response aggregates all holes in a module by
+returning a root object with `holes` and `dependency_graph`; each element of
+`holes` is the same per-hole `HoleReport` object returned directly by
+`sporec query-hole FILE ?name --json`. Hand-rolled JSON serialization is used
+in v0.1 to minimize dependencies; serde migration is tracked as future work
+(see Unresolved Questions §10).
 
 ### HoleReport v0.3 (within the v0.x lineage)
 
 HoleReport v0.3 is a **superset** of v0.2 on the same `v0.x` line. The
-project should not rename this family to a detached `v3`/`v1`/`v2` scheme just
+project should not rename this family to a detached major-version scheme just
 because additive fields land. Current implementation payloads are effectively
 unversioned shared objects; if/when an explicit schema tag is emitted, it
 should remain on a `spore/hole-report/v0.x` identifier. All v0.2 fields are
@@ -279,7 +284,7 @@ A hole's type is determined by the **intersection of all constraints** imposed b
 2. **Return position:** A hole in tail position inherits the function's return type
 3. **Function arguments:** `f(?h)` constrains `?h` to the parameter type of `f`
 4. **Match arms:** A hole in a match arm must have the same type as sibling arms
-5. **Operators:** `?h + x` where `x: Int` constrains `?h` to `Int` (or a type implementing `Add<Int>`)
+5. **Operators:** `?h + x` where `x: I64` constrains `?h` to `I64` (or a type implementing `Add<I64>`)
 
 When multiple constraints agree, the intersection is the agreed-upon type. When constraints conflict, the compiler applies the **nearest constraint rule** (see Edge Cases §8.3) and emits a warning.
 
@@ -833,7 +838,7 @@ fn factorial(n: I64) -> I64
 }
 ```
 
-Here `?factorial_step` has type `Int`. The function is partial. If a recursive call to `factorial` occurs:
+Here `?factorial_step` has type `I64`. The function is partial. If a recursive call to `factorial` occurs:
 
 ```spore
 fn bad(n: I64) -> I64
@@ -845,7 +850,7 @@ fn bad(n: I64) -> I64
 The compiler reports:
 
 ```text
-[partial] bad: (Int) -> Int
+[partial] bad: (I64) -> I64
   holes: ?self_ref
   note: recursive call to partial function bad — simulation terminates at depth 1
 ```
@@ -900,14 +905,14 @@ fn conflicted(flag: Bool) -> I64
 }
 ```
 
-**Resolution rule:** The compiler uses the **nearest constraint** — the one syntactically closest to the hole. In this case, the `let x: String` annotation is nearest, so `?ambiguous` is reported with type `String`.
+**Resolution rule:** The compiler uses the **nearest constraint** — the one syntactically closest to the hole. In this case, the `let x: Str` annotation is nearest, so `?ambiguous` is reported with type `Str`.
 
 ```text
 warning[H0002]: hole ?ambiguous has conflicting type constraints
-  constraint 1: String (from let binding on line 4)
-  constraint 2: Int    (from usage on line 5)
+  constraint 1: Str (from let binding on line 4)
+  constraint 2: I64    (from usage on line 5)
   note: no type satisfies both constraints simultaneously.
-        The hole is reported with type `String` (nearest constraint).
+        The hole is reported with type `Str` (nearest constraint).
         Filling this hole will likely require restructuring the surrounding code.
 ```
 
@@ -1286,7 +1291,7 @@ The hole system integrates with Language Server Protocol:
 ### Cost diagnostics for partial functions
 
 ```text
-[partial] pipeline: (List[Int]) -> List[Int]
+[partial] pipeline: (List[I64]) -> List[I64]
   known cost: 200 (before hole) + ≤150 (after hole) = ≤350
   budget for ?middle_step: ≤650 (1000 - 350)
   note: ?middle_step filling must stay within the remaining compute budget (≤ 650)
@@ -1415,7 +1420,7 @@ These are runtime markers with no compiler support. They provide no type informa
 
 1. **Existing complete code**: Unaffected. No holes means no HoleReports, no dependency graphs, no Agent protocol activation.
 2. **New code with holes**: Opt-in by writing `?name` in function bodies.
-3. **Agent tooling**: Agents should check `schema` version and handle both `"spore/hole-report/v1"` and `"spore/hole-report/v2"`.
+3. **Agent tooling**: Agents should treat the payload as a `v0.x`-lineage schema and ignore unknown additive fields. If an explicit schema identifier is emitted, it should stay in the `"spore/hole-report/v0.x"` family.
 
 ---
 

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -1378,7 +1378,7 @@ error[K0101]: cost budget exceeded
    |
    = note: `summarize` budget is 5000 op, already used 1200 op
    = note: remaining budget: 3800 op, shortfall: 4400 op
-help: filter `records` before scanning, or increase budget to `cost ≤ 10000`
+help: filter `records` before scanning, or widen the declared `cost [..., ...]` compute (or aggregate) slots
 ```
 
 **Hole report:**
@@ -1484,27 +1484,33 @@ All diagnostics carry a categorized code. Every code is queryable: `sporec expla
 
 #### K0xxx — Cost Violations
 
-| Code | Name | Description |
-|------|------|-------------|
-| `K0101` | budget-exceeded | Concrete cost exceeds `cost ≤ K` |
-| `K0102` | symbolic-budget-exceeded | Symbolic cost may exceed bound for some inputs |
-| `K0103` | cost-underflow | Remaining budget negative after prior statements |
-| `K0201` | unbounded-call | Calling `unbounded` function without `with_cost_limit` |
-| `K0202` | unbounded-recursion | Recursive function without structural termination proof |
-| `K0301` | cost-declaration-missing | Function with cost-sensitive callees but no `cost ≤ K` |
+| Code | Name (implementation) | Short description |
+|------|----------------------|-------------------|
+| `K0101` | cost budget exceeded | Inferred cost exceeds declared bound (warning in current policy) |
+| `K0102` | cost annotation mismatch | Declared `cost [...]` does not match inferred cost |
+| `K0001` | cost budget exceeded | Legacy alias for `K0101` |
+| `K0201` | unbounded recursion detected | Recursion pattern not structurally bounded |
+| `K0202` | loop without bounded iteration | Reserved / iteration-path diagnostic |
+| `K0301` | missing cost on recursive function | Recursive function lacks `cost [...]` where required |
+| `K0302` | invalid cost expression | `cost [...]` parse or shape error |
+| `K0303` | `@unbounded` requires cost | `@unbounded` without `cost [c, a, i, p]` (hard error) |
+
+Canonical enum and messages: `spore` repo `crates/sporec-typeck/src/error.rs`.
 
 #### H0xxx — Hole Diagnostics
 
-| Code | Name | Description |
-|------|------|-------------|
-| `H0101` | hole-report | Standard hole report with type, bindings, candidates |
-| `H0102` | hole-type-conflict | Explicit annotation conflicts with inferred type |
-| `H0103` | hole-unconstrained | Hole has no type constraints from context |
-| `H0201` | partial-function | Function contains one or more unfilled holes |
-| `H0202` | hole-cost-tight | Remaining budget < 10% of total |
-| `H0301` | hole-duplicate-name | Two holes share a name in the same module |
-| `H0302` | hole-in-signature | Hole in signature position (not allowed for value holes) |
-| `H0303` | circular-hole-dependency | Circular hole dependency detected |
+| Code | Name (implementation) | Short description |
+|------|----------------------|-------------------|
+| `H0101` | typed hole found | Standard hole report entry |
+| `H0102` | hole with inferred type | Hole with type context |
+| `H0103` | hole in return position | Hole where return is expected |
+| `H0201` | hole candidates available | Ranked fills exist |
+| `H0202` | no candidates found | No suitable fill |
+| `H0203` | ambiguous candidates | Multiple close matches |
+| `H0301` | hole depends on another hole | Ordering / dependency |
+| `H0302` | circular hole dependency | Dependency cycle |
+
+Canonical enum: `spore` repo `crates/sporec-typeck/src/error.rs` (SEP tables may lag other `H` variants).
 
 #### M0xxx — Module Errors
 
@@ -1879,6 +1885,6 @@ Suppression is limited to **warnings only** — errors and notes cannot be suppr
 | **hole** | Source-code placeholder (`?name`) for unfinished implementation, carrying type information |
 | **effect** | A declared system permission (e.g., `Network`, `FileSystem`) required to perform certain operations |
 | **effect ceiling** | Project-level maximum effect set; no module may exceed it |
-| **cost annotation** | A declared upper bound on a function's computational cost (`cost ≤ K`) |
+| **cost annotation** | A declared four-slot upper bound (`cost [compute, alloc, io, parallel]`) |
 | **debounce** | Coalescing multiple rapid file-system events into a single compilation trigger |
 | **NDJSON** | Newline-Delimited JSON — each line is a complete, independent JSON object |

--- a/seps/SEP-0006-compiler-architecture.md
+++ b/seps/SEP-0006-compiler-architecture.md
@@ -19,7 +19,7 @@ superseded_by: null
 
 # SEP-0006: Compiler Architecture
 
-> **Executive Summary**: Defines a 6-phase compiler pipeline (Lex → Parse → Resolve → TypeCheck → Lower → Codegen) with SEP-aligned diagnostic codes organized by category — E0xxx (type errors), C0xxx (effect violations), K0xxx (cost budget), M0xxx (module errors), W0xxx (warnings). The architecture centers on a shared diagnostics pipeline consumed by CLI JSON, LSP, and the hole/reporting surfaces, while `spore watch --json` currently provides summary NDJSON events (`compile_result` plus `hole_graph_update`) and leaves richer watch transports as a later layer.
+> **Executive Summary**: Defines a 5-phase compiler pipeline (Lex → Parse → Resolve → TypeCheck → Codegen) with SEP-aligned diagnostic codes organized by category — E0xxx (type errors), C0xxx (effect violations), K0xxx (cost budget), M0xxx (module errors), W0xxx (warnings). The architecture centers on a shared diagnostics pipeline consumed by CLI JSON, LSP, and the hole/reporting surfaces, while `spore watch --json` currently provides summary NDJSON events (`compile_result` plus `hole_graph_update`) and leaves richer watch transports as a later layer.
 
 ## Summary
 
@@ -119,7 +119,7 @@ error[E0301]: type mismatch
   --> src/billing.sp:42:22
    |
 42 |     charge(card, "fifty dollars")
-   |                  ^^^^^^^^^^^^^^^ expected `Money`, found `String`
+   |                  ^^^^^^^^^^^^^^^ expected `Money`, found `Str`
    |
 help: try `Money.from_string("fifty dollars")`
 ```
@@ -324,7 +324,7 @@ The Desugar pass (merged into Resolve) canonicalizes all syntactic sugar:
 |-------|---------------|
 | `a \|> f(b)` | `f(a, b)` |
 | `expr?` | `match expr { Ok(v) => v, Err(e) => return Err(e.into()) }` |
-| `f"hello {name}"` | `format("hello {}", name)` |
+| `f"hello {name}"` | `InterpolatedStr([Literal("hello "), Expr(name)])` |
 | `t"hello {name}"` | `Template([Literal("hello "), Interpolation(name)])` |
 
 **sig hash is computed at this layer.** It covers:
@@ -602,8 +602,8 @@ $ spore watch src/main.sp
 [watch] ✓ Initial compilation complete, 0 errors, 3 holes
 
   Holes (3):
-    ◯ src/auth.sp:10  hash_password     : String -> HashedPassword
-    ◯ src/auth.sp:20  verify_password   : String -> HashedPassword -> Bool
+    ◯ src/auth.sp:10  hash_password     : Str -> HashedPassword
+    ◯ src/auth.sp:20  verify_password   : Str -> HashedPassword -> Bool
     ◯ src/app.sp:50   create_user       : UserInput -> Result User Error
          ⚠ blocked: depends on hash_password, verify_password
   Ready to fill: hash_password, verify_password
@@ -616,7 +616,7 @@ $ spore watch src/main.sp
 [watch] sig hash unchanged → skipping downstream
   ✓ 0 errors, 2 holes (was: 3)
     ● hash_password      [filled ✓]
-    ◯ verify_password   : String -> HashedPassword -> Bool
+    ◯ verify_password   : Str -> HashedPassword -> Bool
     ◯ create_user       ⚠ blocked: depends on verify_password
   Ready to fill: verify_password
 
@@ -640,10 +640,18 @@ $ spore watch src/main.sp
   ✓ 0 errors, 0 holes 🎉 All holes filled!
 ```
 
-#### Hole status data structures
+#### Current hole summary and future graph structures
 
 ```text
-type HoleReport:
+type HoleGraphSummary:
+    holes_total: Nat
+    filled_this_cycle: Nat
+    ready_to_fill: Nat
+    blocked: Nat
+
+// Current stable `hole_graph_update` NDJSON payload
+// Future richer watch transport (not yet the stable payload shape)
+type HoleGraphUpdate:
     total: Nat
     filled_this_cycle: List Hole
     ready_to_fill: List Hole        // dependencies satisfied, can implement now
@@ -652,13 +660,18 @@ type HoleReport:
 type Hole:
     module: ModuleId
     location: SourceLocation
-    name: String
+    name: Str
     signature: Type
 
 type BlockedHole:
     hole: Hole
     blocked_by: List ModuleId       // modules containing unfilled dependency holes
 ```
+
+Current `spore watch --json` serializes `hole_graph_update` as the compact
+`HoleGraphSummary` shape shown above. `HoleGraphUpdate` remains the target
+extension type for a later richer watch transport that can carry per-hole
+details without overloading the stable summary contract.
 
 #### Module dependency graph structures
 
@@ -747,7 +760,7 @@ LSP diagnostics are published directly from the compiler's shared diagnostics pi
       "severity": 1,
       "code": "E0301",
       "source": "spore",
-      "message": "type mismatch: expected `Token`, found `String`"
+      "message": "type mismatch: expected `Token`, found `Str`"
     }]
   }
 }
@@ -833,18 +846,18 @@ error[E0301]: type mismatch
   --> src/billing.sp:42:22
    |
 42 |     charge(card, "fifty dollars")
-   |                  ^^^^^^^^^^^^^^^ expected `Money`, found `String`
+   |                  ^^^^^^^^^^^^^^^ expected `Money`, found `Str`
    |
 help: try `Money.from_string("fifty dollars")`
 
   inference chain:
-    "fifty dollars" : String       (literal, line 42)
+    "fifty dollars" : Str          (literal, line 42)
     charge.amount : Money          (from signature, sig@b3c1e2)
-    String ≠ Money                 (nominal mismatch)
+    Str ≠ Money                    (nominal mismatch)
 
   candidates considered:
-    String -> Money via Money.from_string  ✓ (exact match)
-    String -> Money via Money.parse        ✓ (may raise ParseError)
+    Str -> Money via Money.from_string     ✓ (exact match)
+    Str -> Money via Money.parse           ✓ (may raise ParseError)
 
   effect context: [PaymentGateway]
   cost at this point: 120 / budget 500
@@ -862,7 +875,7 @@ make richer analysis payloads an explicit later layer.
 {
   "code": "E0301",
   "severity": "error",
-  "message": "type mismatch: expected `Money`, found `String`",
+  "message": "type mismatch: expected `Money`, found `Str`",
   "primary_span": {
     "file": "src/billing.sp",
     "range": {
@@ -992,11 +1005,11 @@ $ sporec explain E0301
   - Pipe operator (left-hand type ≠ right-hand function's first parameter)
 
   Example:
-      fn greet(name: String) -> String { ... }
-      greet(42)   // error: expected String, found Int
+      fn greet(name: Str) -> Str { ... }
+      greet(42)   // error: expected Str, found I64
 
   Common fixes:
-  - Use a conversion function (e.g. `Int.to_string(42)`)
+  - Use a conversion function (e.g. `I64.to_string(42)`)
   - Change the declaration to accept the actual type
   - Add a type annotation to guide inference
 
@@ -1014,7 +1027,7 @@ Target latencies (aspirational, not hard guarantees):
 | Hash computation (single module) | < 5ms | blake3 of module content |
 | Full project initial analysis (~100 modules) | < 5s | Cold start, parallel compilation |
 | End-to-end latency (file save → diagnostics) | < 200ms | Including 100ms debounce |
-| Hole report update | < 50ms | Incremental HoleReport regeneration |
+| Hole graph update | < 50ms | Incremental hole summary / `HoleGraphUpdate` regeneration |
 
 **Cache strategy:** Watch mode maintains in-memory caches for hashes, dependency graph, compilation artifacts, and hole state. Persistence to disk is not required for v0.1 but is a future option.
 
@@ -1348,7 +1361,7 @@ error[E0301]: type mismatch
   --> src/billing.sp:42:22
    |
 42 |     charge(card, "fifty dollars")
-   |                  ^^^^^^^^^^^^^^^ expected `Money`, found `String`
+   |                  ^^^^^^^^^^^^^^^ expected `Money`, found `Str`
    |
 help: try `Money.from_string("fifty dollars")`
 ```
@@ -1522,11 +1535,15 @@ Canonical enum: `spore` repo `crates/sporec-typeck/src/error.rs` (SEP tables may
 | `M0201` | visibility-violation | Accessing private or `pub(pkg)` symbol from outside scope |
 | `M0202` | re-export-visibility | Re-exporting with broader visibility than original |
 | `M0203` | orphan-impl | Implementing external trait for external type |
+| `M0204` | alias-chain | `pub alias` points to another alias instead of a concrete export |
 | `M0301` | import-not-found | Imported module or symbol does not exist |
 | `M0302` | ambiguous-import | Two imports bring same name into scope |
 | `M0303` | wildcard-import | Wildcard imports are not allowed in Spore |
+| `M0304` | import-shadowing-conflict | Import alias conflicts with module name or existing import binding |
 | `M0401` | snapshot-changed | Dependent signature hash changed; requires `--permit` |
 | `M0402` | snapshot-missing | Referenced snapshot not found in `.spore-lock` |
+| `M0501` | platform-binding-conflict | Project declares more than one Platform binding |
+| `M0502` | startup-contract-mismatch | Startup function signature does not satisfy selected Platform contract |
 
 ### System integration
 
@@ -1535,10 +1552,10 @@ Diagnostics do not exist in isolation — they connect to every major Spore subs
 #### Hole System integration
 
 - `H0101` (hole-report) is emitted as `note` severity for each unfilled hole during compilation
-- `sporec query-hole <file> ?name` returns a full `HoleReport` — a superset of
-  `H0101` with candidate ranking, binding types, and cost budget
+- `sporec query-hole <file> ?name` returns the full per-hole `HoleReport` —
+  a superset of `H0101` with candidate ranking, binding types, and cost budget
 - Partial functions (`H0201`) compile successfully — they produce diagnostics but not errors
-- The HoleReport JSON extends the diagnostic schema with a `hole_report` field
+- The per-hole HoleReport JSON extends the diagnostic schema with a `hole_report` field
 
 #### Cost System integration
 

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -42,7 +42,7 @@ The design unifies five properties that no existing language achieves simultaneo
 | **Colorless functions** | Concurrency does not introduce `async`/`await` syntax bifurcation | All developers |
 | **Structured lifetimes** | Child tasks cannot escape the parent scope | Resource management, debugging |
 | **Explicit effects** | Concurrent tasks may only use declared effects | Security audits |
-| **Bounded cost** | Compiler statically verifies `cost ≤ N` and `parallel(lane)` | Performance predictability |
+| **Bounded cost** | Compiler statically verifies four-slot `cost [c, a, i, p]` (incl. `parallel`) | Performance predictability |
 | **Simulatable execution** | Handlers are replaceable—same code compiles to simulation / deterministic test / production parallel | Agents, CI |
 
 ---
@@ -54,7 +54,7 @@ The design unifies five properties that no existing language achieves simultaneo
 Traditional concurrency models—raw threads, unbounded `goroutine` spawning, `GlobalScope.launch`—share a common flaw: **concurrent tasks form an arbitrary directed graph whose lifetime is unmanageable at compile time**. This leads to:
 
 - **Resource leaks**: A spawned task outlives its creator, holding file handles or network connections the parent assumed were released.
-- **Unanalyzable cost**: Fire-and-forget tasks are invisible to the compiler's cost model. If `cost ≤ N` is declared in the function signature but the function spawns background work that escapes the scope, the declared bound is meaningless.
+- **Unanalyzable cost**: Fire-and-forget tasks are invisible to the compiler's cost model. If a four-slot `cost [...]` budget is declared in the function signature but the function spawns background work that escapes the scope, the declared bound is meaningless.
 - **Debugging nightmares**: Stack traces of escaped tasks lose the causal chain to their spawning point, making production incidents harder to diagnose.
 
 Structured concurrency, as articulated by Nathaniel J. Smith (*"Go statement considered harmful"*, 2018), solves these problems by enforcing **tree-shaped task lifetimes**: every child task is nested inside a scope that does not exit until all children have completed (or been cancelled). In Spore this means:
@@ -80,7 +80,7 @@ Bob Nystrom's *"What Color is Your Function?"* (2015) identified how `async` spl
 ```spore
 // No async annotation needed—concurrency declared via the Spawn effect
 fn fetch_all(urls: List[Url]) -> List[Response] ! NetError
-cost ≤ urls.len * per_fetch
+cost [urls.len * per_fetch + urls.len * 10, urls.len * 2, urls.len, urls.len]
 uses [Spawn, NetConnect]
 {
     parallel_scope {
@@ -91,7 +91,7 @@ uses [Spawn, NetConnect]
 
 // Pure function: no Spawn, no IO—compiler guarantees single-threaded
 fn transform(data: List[Item]) -> List[Item]
-cost ≤ data.len * 3
+cost [data.len * 3, data.len, 0, 1]
 {
     data.map(|item| item.process())
 }
@@ -336,7 +336,7 @@ Server entrypoints that accept inbound connections declare `NetListen`; the inne
 effect HttpHandler = Spawn | NetConnect | DbRead | Clock
 
 fn handle_request(req: Request) -> Response ! DbError | Timeout
-cost ≤ 5000
+cost [5000, 800, 200, 3]
 uses [HttpHandler]
 {
     with_timeout(10.seconds) {
@@ -364,9 +364,9 @@ uses [HttpHandler]
 fn etl_pipeline(
     source: DataSource,
     sink: DataSink,
-    batch_size: Int,
+    batch_size: I64,
 ) -> EtlReport ! ExtractError | TransformError | LoadError
-cost ≤ batch_size * 200
+cost [batch_size * 200 + 4000, batch_size * 50, batch_size * 40, 6]
 uses [Spawn, NetConnect, DbRead, DbWrite]
 {
     let (raw_tx, raw_rx)     = Channel.new[RawRecord](buffer: batch_size)
@@ -550,7 +550,7 @@ effect RateLimit {
     fn release_permit() -> ()
 }
 
-handler RateLimit as token_bucket_handler(rate: Int, per: Duration) {
+handler RateLimit as token_bucket_handler(rate: I64, per: Duration) {
     fn acquire_permit() -> () ! RateLimitExceeded {
         if self.tokens > 0 {
             self.tokens -= 1;
@@ -604,14 +604,14 @@ effect ChanRecv[T] {
 Functions using channels must declare the corresponding effects:
 
 ```spore
-fn producer(tx: Sender[Int]) -> Unit ! ChannelClosed
-uses [ChanSend[Int]]
+fn producer(tx: Sender[I64]) -> Unit ! ChannelClosed
+uses [ChanSend[I64]]
 {
     (0..100).each(|i| tx.send(i))
 }
 
-fn consumer(rx: Receiver[Int]) -> List[Int] ! ChannelClosed
-uses [ChanRecv[Int]]
+fn consumer(rx: Receiver[I64]) -> List[I64] ! ChannelClosed
+uses [ChanRecv[I64]]
 {
     rx.collect()
 }
@@ -703,7 +703,7 @@ Developers need not manually allocate lanes. The compiler infers from the task t
 
 ```spore
 fn pipeline(data: Data) -> Result
-cost ≤ 5000
+cost [5000, 600, 80, 4]
 uses [Spawn, FileRead, NetConnect]
 {
     // Phase 1: 4 lanes
@@ -733,7 +733,7 @@ When the number of spawned tasks depends on runtime values, the compiler uses **
 
 ```spore
 fn fetch_all(urls: List[Url]) -> List[Response] ! NetError
-cost ≤ urls.len * per_fetch
+cost [urls.len * per_fetch + urls.len * 10, urls.len * 2, urls.len, urls.len]
 uses [Spawn, NetConnect]
 {
     parallel_scope {
@@ -753,15 +753,15 @@ $ sporec --query-cost fetch_all
 }
 ```
 
-To make the cost statically verifiable, use a **refinement type** to limit the input size:
+To make the cost easier to reason about at compile time while keeping **`List`** as the carrier type, attach an explicit **`max_items`** refinement or enforce `urls.len()` at runtime / via `parallel_scope(lanes: …)`. For the rare case where the **type** itself must expose a numeric cap (`N`), use **`Vec[..., max: N]`** (SEP-0002)—most programs should stay on **`List`**.
 
 ```spore
-fn bounded_fetch(urls: List[Url, max: 100]) -> List[Response] ! NetError
-cost ≤ 100 * per_fetch + 500
+fn bounded_fetch(urls: List[Url]) -> List[Response] ! NetError
+cost [100 * per_fetch + 500, 800, 100 * per_fetch, 100]
 uses [Spawn, NetConnect]
 {
     parallel_scope(lanes: 10) {
-        // At most 10 parallel tasks; remaining queue
+        // At most 10 parallel tasks; remaining queue — keep urls.len within policy via caller checks / refinements
         urls.each(|url| spawn { fetch(url) })
     }
 }
@@ -772,10 +772,10 @@ $ sporec --query-cost bounded_fetch
 {
   "function": "bounded_fetch",
   "cost_upper": "100 × per_fetch + 500",
-  "cost_declared": "≤ 100 * per_fetch + 500",
+  "cost_declared": "four-slot `cost [...]` on `bounded_fetch` (see SEP-0001)",
   "status": "within_bound",
   "parallel_lanes_peak": 10,
-  "note": "urls.len ≤ 100 (refinement); lanes capped at 10"
+  "note": "prefer List[T] here; lanes capped at 10; caller bounds urls.len separately"
 }
 ```
 
@@ -786,7 +786,7 @@ $ sporec --query-cost pipeline
 {
   "function": "pipeline",
   "cost_scalar": 4200,
-  "cost_declared": "≤ 5000",
+  "cost_declared": "[5000, 600, 80, 4]",
   "status": "within_bound",
   "dimensions": {
     "compute": 3800,
@@ -825,7 +825,7 @@ Holes in concurrent functions participate in cost budget analysis:
 
 ```spore
 fn concurrent_pipeline(data: Data) -> Result
-cost ≤ 3000
+cost [3000, 400, 100, 2]
 uses [Spawn, NetConnect]
 {
     parallel_scope(lanes: 2) {
@@ -1043,7 +1043,7 @@ At the application boundary (the `main` function or service entry point), handle
 
 | Spore subsystem | Interaction with the concurrency model |
 |-----------------|---------------------------------------|
-| Signature syntax | `uses [Spawn, ...]` declares concurrency effect; `cost ≤ N` bounds total cost |
+| Signature syntax | `uses [Spawn, ...]` declares concurrency effect; `cost [c, a, i, p]` bounds each dimension |
 | Cost model | Fourth dimension `parallel(lane)` defined by this SEP |
 | Effect system | `Spawn` is a built-in effect; child task effects ⊆ parent |
 | Effect annotations | `pure` excludes `Spawn`; `deterministic` + `Spawn` requires schedule-independent results |
@@ -1063,7 +1063,7 @@ The compiler reports the following concurrency-related diagnostics:
 | `spawn` outside `parallel_scope` | Error | `spawn { ... }` at top level |
 | Missing `Spawn` effect | Error | Function calls `spawn` but does not declare `uses [Spawn]` |
 | Lane budget exceeded | Error | `parallel_scope(lanes: 2)` with 5 spawns that cannot queue |
-| Cost budget exceeded due to parallelism | Error | Inferred parallel cost exceeds declared `cost ≤ N` |
+| Cost budget exceeded due to parallelism | Error | Inferred parallel dimension exceeds declared `parallel` slot of `cost [...]` |
 | Long recursion/iteration without cancellation checkpoint | Warning | CPU-bound computation > 100 iterations without `check_cancelled()` |
 | Effect widening in spawn | Error | `spawn uses [NetConnect] { ... }` when parent lacks `NetConnect` |
 | Unused `Task` (never awaited, never cancelled) | Warning | Task result is silently discarded |
@@ -1137,7 +1137,7 @@ This timeline can be rendered as a Gantt chart, flame graph, or task dependency 
 
 ### Alternative 6: Unstructured spawning with optional scoping
 
-**Rejected.** Providing both structured and unstructured spawning (as in Kotlin's `GlobalScope` vs. `coroutineScope`) creates an escape hatch that undermines cost analysis. If untracked concurrent tasks exist, the compiler cannot verify `cost ≤ N` or `parallel(lane)` bounds.
+**Rejected.** Providing both structured and unstructured spawning (as in Kotlin's `GlobalScope` vs. `coroutineScope`) creates an escape hatch that undermines cost analysis. If untracked concurrent tasks exist, the compiler cannot verify four-slot `cost [...]` bounds or lane caps.
 
 **Consequences of rejection:** Long-lived background tasks (daemon processes, connection pools) must be managed at the Platform level rather than in user code. This pushes certain patterns to Platform authors.
 
@@ -1195,8 +1195,8 @@ The concurrency model is introduced as a new language feature. There is no exist
 
 ### Interaction with existing SEPs
 
-- **SEP-0001 (Core Syntax, extended by SEP-0003 for effects):** The `uses [Spawn, ...]` clause and `cost ≤ N` declarations are extensions to the signature syntax defined in SEP-0001, with effect annotations from SEP-0003. No breaking changes to existing signatures are required; `uses` and `cost` are additive clauses.
-- **SEP-0004 (Cost Model):** This SEP adds the fourth dimension `parallel(lane)` to the cost model. Existing cost annotations (which only use `C`, `A`, `W`) remain valid; the `P` dimension defaults to `0` for functions without `Spawn`.
+- **SEP-0001 (Core Syntax, extended by SEP-0003 for effects):** The `uses [Spawn, ...]` clause and `cost [c, a, i, p]` declarations are extensions to the signature syntax defined in SEP-0001, with effect annotations from SEP-0003. No breaking changes to existing signatures are required; `uses` and `cost` are additive clauses.
+- **SEP-0004 (Cost Model):** This SEP defines the fourth dimension `parallel(lane)`. Cost declarations are always the four-slot form `cost [compute, alloc, io, parallel]`; sequential code uses `parallel = 0`.
 
 ### Migration path for developers from other languages
 
@@ -1323,7 +1323,7 @@ Concrete syntax for `effect`, `handler`, and `handle ... with` is defined in SEP
 ```spore
 fn name(params) -> ReturnType ! Errors
 where T: Constraints
-cost ≤ <N>
+cost [c_compute, c_alloc, c_io, c_parallel]
 uses [Spawn, Channel, ...]
 {
     <body>
@@ -1336,7 +1336,7 @@ uses [Spawn, Channel, ...]
 effect HttpHandler = Spawn | NetConnect | DbRead | Clock
 
 fn handle_request(req: Request) -> Response ! DbError | Timeout
-cost ≤ 5000
+cost [5000, 800, 200, 3]
 uses [HttpHandler]
 {
     with_timeout(10.seconds) {
@@ -1362,9 +1362,9 @@ uses [HttpHandler]
 fn etl_pipeline(
     source: DataSource,
     sink: DataSink,
-    batch_size: Int,
+    batch_size: I64,
 ) -> EtlReport ! ExtractError | TransformError | LoadError
-cost ≤ batch_size * 200
+cost [batch_size * 200 + 4000, batch_size * 50, batch_size * 40, 6]
 uses [Spawn, NetConnect, DbRead, DbWrite]
 {
     let (raw_tx, raw_rx)     = Channel.new[RawRecord](buffer: batch_size)

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -79,8 +79,8 @@ Bob Nystrom's *"What Color is Your Function?"* (2015) identified how `async` spl
 
 ```spore
 // No async annotation needed—concurrency declared via the Spawn effect
-fn fetch_all(urls: List[Url]) -> List[Response] ! NetError
-cost [urls.len * per_fetch + urls.len * 10, urls.len * 2, urls.len, urls.len]
+fn fetch_all[N: Index](urls: Vec[Url, max: N]) -> Vec[Response, max: N] ! NetError
+cost [N * per_fetch + N * 10, N * 2, N, N]
 uses [Spawn, NetConnect]
 {
     parallel_scope {
@@ -90,8 +90,8 @@ uses [Spawn, NetConnect]
 }
 
 // Pure function: no Spawn, no IO—compiler guarantees single-threaded
-fn transform(data: List[Item]) -> List[Item]
-cost [data.len * 3, data.len, 0, 1]
+fn transform[N: Index](data: Vec[Item, max: N]) -> Vec[Item, max: N]
+cost [N * 3, N, 0, 0]
 {
     data.map(|item| item.process())
 }
@@ -503,18 +503,19 @@ parallel_scope(on_error: .collect) {
 
 ### 4.2 Effect handlers for concurrency
 
-#### `Spawn` as an effect
+#### `spawn` and the `Spawn` effect
 
-`Spawn` is defined as a standard effect, not compiler magic:
+`spawn { ... }` is a built-in expression guarded by the standard `Spawn`
+effect. Conceptually, it performs the platform-provided `Spawn.spawn`
+operation, but the syntax and structured-scope checks are part of the language:
 
 ```spore
-// Built-in effect definition (conceptual; provided by Platform)
 effect Spawn {
     fn spawn[T](task: () -> T) -> Task[T]
 }
 ```
 
-Functions declare the effect via `uses [Spawn]`. Without this declaration, the compiler **statically rejects** any call to `spawn`.
+Functions declare the effect via `uses [Spawn]`. Without this declaration, the compiler **statically rejects** any `spawn { ... }` expression.
 
 #### Handler mechanism
 
@@ -724,13 +725,15 @@ uses [Spawn, FileRead, NetConnect]
 }
 ```
 
-#### Symbolic cost expressions for dynamic lanes
+#### Symbolic cost expressions for lane counts
 
-When the number of spawned tasks depends on runtime values, the compiler uses **symbolic cost expressions**:
+Verified lane bounds use Index parameters. Dynamic `List` lengths remain valid
+runtime data, but they are not CostExpr variables; use `Vec[..., max: N]` when
+the lane budget must be verified statically:
 
 ```spore
-fn fetch_all(urls: List[Url]) -> List[Response] ! NetError
-cost [urls.len * per_fetch + urls.len * 10, urls.len * 2, urls.len, urls.len]
+fn fetch_all[N: Index](urls: Vec[Url, max: N]) -> Vec[Response, max: N] ! NetError
+cost [N * per_fetch + N * 10, N * 2, N, N]
 uses [Spawn, NetConnect]
 {
     parallel_scope {
@@ -744,13 +747,15 @@ uses [Spawn, NetConnect]
 $ sporec --query-cost fetch_all
 {
   "function": "fetch_all",
-  "cost_symbolic": "urls.len × (5 + per_fetch) + urls.len",
-  "parallel_lanes": "urls.len",
-  "note": "lane count depends on runtime urls.len; no static upper bound"
+  "cost_symbolic": "N * (5 + per_fetch) + N",
+  "parallel_lanes": "N",
+  "note": "lane count is bounded by the Vec capacity index N"
 }
 ```
 
-To make the cost easier to reason about at compile time while keeping **`List`** as the carrier type, attach an explicit **`max_items`** refinement or enforce `urls.len()` at runtime / via `parallel_scope(lanes: …)`. For the rare case where the **type** itself must expose a numeric cap (`N`), use **`Vec[..., max: N]`** (SEP-0002)—most programs should stay on **`List`**.
+For dynamic `List` inputs, enforce runtime caps with ordinary checks or
+`parallel_scope(lanes: K)` and treat remaining work as runtime-metered rather
+than verified by CostExpr.
 
 ```spore
 fn bounded_fetch(urls: List[Url]) -> List[Response] ! NetError
@@ -758,7 +763,7 @@ cost [100 * per_fetch + 500, 800, 100 * per_fetch, 100]
 uses [Spawn, NetConnect]
 {
     parallel_scope(lanes: 10) {
-        // At most 10 parallel tasks; remaining queue — keep urls.len within policy via caller checks / refinements
+        // At most 10 parallel tasks; callers enforce any total input-count policy separately
         urls.each(|url| spawn { fetch(url) })
     }
 }
@@ -772,7 +777,7 @@ $ sporec --query-cost bounded_fetch
   "cost_declared": "four-slot `cost [...]` on `bounded_fetch` (see SEP-0001)",
   "status": "within_bound",
   "parallel_lanes_peak": 10,
-  "note": "prefer List[T] here; lanes capped at 10; caller bounds urls.len separately"
+  "note": "prefer List[T] here; lanes capped at 10; caller bounds total input count separately"
 }
 ```
 

--- a/seps/SEP-0007-concurrency-model.md
+++ b/seps/SEP-0007-concurrency-model.md
@@ -306,7 +306,7 @@ fn event_loop(
     events: Receiver[Event],
     shutdown: Receiver[Unit],
 ) -> Unit ! ChannelClosed
-uses [ChanRecv[Command], ChanRecv[Event], ChanRecv[Unit], Spawn]
+uses [Channel, Spawn]
 {
     select {
         cmd from commands => {
@@ -592,12 +592,9 @@ let (tx, rx) = Channel.new[Message](buffer: 0)
 #### Channel operations as effects
 
 ```spore
-effect ChanSend[T] {
-    fn send(value: T) -> Unit ! ChannelClosed
-}
-
-effect ChanRecv[T] {
-    fn recv() -> T ! ChannelClosed
+effect Channel {
+    fn send[T](channel: Sender[T], value: T) -> Unit ! ChannelClosed
+    fn recv[T](channel: Receiver[T]) -> T ! ChannelClosed
 }
 ```
 
@@ -605,13 +602,13 @@ Functions using channels must declare the corresponding effects:
 
 ```spore
 fn producer(tx: Sender[I64]) -> Unit ! ChannelClosed
-uses [ChanSend[I64]]
+uses [Channel]
 {
     (0..100).each(|i| tx.send(i))
 }
 
 fn consumer(rx: Receiver[I64]) -> List[I64] ! ChannelClosed
-uses [ChanRecv[I64]]
+uses [Channel]
 {
     rx.collect()
 }

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -217,7 +217,7 @@ import basic_cli.cmd
 
 fn main() -> () uses [Console, Exit] {
     println("about to exit")
-    exit(7)
+    exit(7u8)
 }
 ```
 
@@ -615,7 +615,7 @@ explicitly:
 import basic_cli.cmd
 
 fn main() -> () uses [Exit] {
-    exit(7)
+    exit(7u8)
 }
 ```
 
@@ -1570,8 +1570,8 @@ pub foreign fn env_set(key: Str, value: Str) -> () uses [Env]
 
 // basic_cli.cmd
 pub foreign fn process_run(cmd: Str, args: List[Str]) -> Str ! ExecError uses [Spawn]
-pub foreign fn process_run_status(cmd: Str, args: List[Str]) -> I64 ! ExecError uses [Spawn]
-pub foreign fn exit(code: I64) -> Never uses [Exit]
+pub foreign fn process_run_status(cmd: Str, args: List[Str]) -> Option[U8] ! ExecError uses [Spawn]
+pub foreign fn exit(code: U8) -> Never uses [Exit]
 ```
 
 **Comparison with Roc, Elm, and Koka**:
@@ -1851,19 +1851,24 @@ broader whole-program effect routing remains follow-up work.
 
 ## Diagnostics impact
 
-### New diagnostic categories
+### Canonical diagnostic categories
+
+This SEP reuses the canonical diagnostic families defined in SEP-0006 instead
+of introducing a separate `E3xxx` / `E4xxx` namespace. Older draft placeholders
+in those ranges are retired in favor of the shared `M0xxx` and `C0xxx`
+registries.
 
 | Code | Category | Example |
 |---|---|---|
-| `E3001` | Visibility violation | Accessing a private function from another module |
-| `E3002` | Circular dependency | Module A → B → A |
-| `E3003` | Effect declaration mismatch | Function calls an operation requiring `FileWrite` without declaring `uses [FileWrite]` |
-| `E3004` | Signature change detected | `sig` hash mismatch in `.spore-lock` |
-| `E3005` | Alias chain | `pub alias` pointing to another alias |
-| `E3006` | Shadowing conflict | Import alias conflicts with module name |
-| `E4201` | Platform binding conflict | Project declares more than one Platform binding |
-| `E4202` | Unsupported startup effect | Selected startup entry requires an effect not listed in the Platform's `[platform].handled-effects` metadata |
-| `E4203` | Startup contract mismatch | Startup function signature doesn't match Platform requirement |
+| `M0201` | Visibility violation | Accessing a private function from another module |
+| `M0101` | Circular dependency | Module A → B → A |
+| `C0101` | Effect declaration mismatch | Function calls an operation requiring `FileWrite` without declaring `uses [FileWrite]` |
+| `M0401` | Signature change detected | `sig` hash mismatch in `.spore-lock` |
+| `M0204` | Alias chain | `pub alias` pointing to another alias |
+| `M0304` | Shadowing conflict | Import alias conflicts with module name |
+| `M0501` | Platform binding conflict | Project declares more than one Platform binding |
+| `C0201` | Unsupported startup effect | Selected startup entry requires an effect not listed in the Platform's `[platform].handled-effects` metadata |
+| `M0502` | Startup contract mismatch | Startup function signature doesn't match Platform requirement |
 
 ### Diagnostic structure
 

--- a/seps/SEP-0008-module-package-system.md
+++ b/seps/SEP-0008-module-package-system.md
@@ -36,7 +36,12 @@ Traditional package ecosystems rely on semantic versioning (semver) to communica
 
 Spore eliminates these problems by giving every function two content hashes computed via BLAKE3:
 
-1. **Signature hash (`sig`)**: Covers the function's public contract—parameter names, parameter types, return type, error types, effects, cost bound, effects, and generic constraints. This hash changes **only** when the API changes.
+1. **Signature hash (`sig`)**: Covers the function's public contract—parameter
+   names, parameter types, return type, error types, effects, cost bound,
+   effects, and generic constraints. This hash changes **only** when the API
+   changes. For error clauses, the policy is intentionally conservative:
+   semantically equivalent canonical error sets may still hash differently when
+   their written surface spelling changes.
 2. **Implementation AST hash (`impl`)**: Covers the compiled AST of the function body. This hash changes whenever the implementation changes. Partial functions (those containing holes) have `impl = None`.
 
 This dual-hash scheme provides two independent guarantees:
@@ -87,7 +92,7 @@ import billing.types
 import billing.tax
 
 pub fn generate_invoice(order: Order) -> Invoice ! TaxError | ValidationError
-    cost ≤ 3000
+    cost [3000, order.items.len * 20 + 500, 0, 2]
     uses [PaymentGateway, AuditLog]
 {
     let tax = tax.calculate(order.items, order.region)
@@ -95,8 +100,8 @@ pub fn generate_invoice(order: Order) -> Invoice ! TaxError | ValidationError
     finalize(order.customer, line_items)
 }
 
-fn build_line_items(items: Vec<Item>, tax: TaxResult) -> Vec<LineItem>
-    cost ≤ 500
+fn build_line_items(items: List[Item], tax: TaxResult) -> List[LineItem]
+    cost [800, 500, 0, 1]
 {
     items |> map(fn(item) -> to_line_item(item, tax))
 }
@@ -446,7 +451,7 @@ Visibility applies to functions, types, and aliases:
 ```spore
 pub type Invoice { id: InvoiceId, total: Money }       // public type
 pub(pkg) type ValidatedOrder { original: Order }        // package-internal type
-type InternalCache { entries: Map<String, CacheEntry> } // private type
+type InternalCache { entries: Map<Str, CacheEntry> } // private type
 
 pub alias GenInv = billing.invoice.generate_invoice     // public alias
 pub(pkg) alias Validate = billing.invoice.validate      // package-internal alias
@@ -1177,7 +1182,7 @@ Holes by module:
 
 #### Interaction with the Cost Model
 
-Cost is a per-function property (`cost ≤ N`). There are no module-level cost budgets. When a function calls an imported function, the callee's **declared** cost bound is used for estimation:
+Cost is a per-function property (`cost [c, a, i, p]`). There are no module-level cost budgets. When a function calls an imported function, the callee's **declared** four-slot bound is used for estimation:
 
 ```text
 $ spore cost-report billing.invoice
@@ -1185,12 +1190,12 @@ $ spore cost-report billing.invoice
 Module: billing.invoice
 
   Function costs:
-    generate_invoice    cost ≤ 3000  (measured: 2800)
-    void_invoice        cost ≤ 500   (measured: 320)
+    generate_invoice    cost [3000, …, …, …]   (scalar summary measured: ~2800 op-eq.)
+    void_invoice        cost [500, …, …, …]    (scalar summary measured: ~320 op-eq.)
 
   Module aggregate:
-    max single-call cost: 3000 ops (generate_invoice)
-    total declared budget: 3500 ops
+    max single-call cost (scalar summary): 3000 op-eq. (generate_invoice)
+    total declared budget (scalar summary): 3500 op-eq.
 ```
 
 #### Interaction with the Snapshot System
@@ -1232,7 +1237,7 @@ A module containing only type definitions is valid and pure:
 // src/billing/types.sp
 pub type Invoice { id: InvoiceId, total: Money, status: InvoiceStatus }
 pub type InvoiceStatus { Draft, Sent, Paid, Void }
-pub type LineItem { description: String, quantity: Int, unit_price: Money }
+pub type LineItem { description: Str, quantity: I64, unit_price: Money }
 ```
 
 ```text
@@ -1392,12 +1397,12 @@ handler HttpClientHandler uses [NetConnect] {
 
 ```spore
 handler StatefulCache {
-    var cache: Map[String, Bytes] = Map.new()
+    var cache: Map[Str, Bytes] = Map.new()
 
-    Cache.get(key: String) -> Option[Bytes] {
+    Cache.get(key: Str) -> Option[Bytes] {
         resume(cache.get(key))
     }
-    Cache.set(key: String, value: Bytes) -> Unit {
+    Cache.set(key: Str, value: Bytes) -> Unit {
         cache.insert(key, value)
         resume(())
     }
@@ -1565,8 +1570,8 @@ pub foreign fn env_set(key: Str, value: Str) -> () uses [Env]
 
 // basic_cli.cmd
 pub foreign fn process_run(cmd: Str, args: List[Str]) -> Str ! ExecError uses [Spawn]
-pub foreign fn process_run_status(cmd: Str, args: List[Str]) -> Int ! ExecError uses [Spawn]
-pub foreign fn exit(code: Int) -> Never uses [Exit]
+pub foreign fn process_run_status(cmd: Str, args: List[Str]) -> I64 ! ExecError uses [Spawn]
+pub foreign fn exit(code: I64) -> Never uses [Exit]
 ```
 
 **Comparison with Roc, Elm, and Koka**:
@@ -2044,7 +2049,7 @@ generic_params ::= '[' IDENT (',' IDENT)* ']'
 params         ::= (param (',' param)*)?
 param          ::= IDENT ':' type
 error_clause   ::= '!' '[' type (',' type)* ']'
-cost_clause    ::= 'cost' '≤' expr
+cost_clause    ::= 'cost' '[' expr ',' expr ',' expr ',' expr ']'
 uses_clause    ::= 'uses' cap_list
 
 // Type declarations

--- a/seps/SEP-0009-standard-library.md
+++ b/seps/SEP-0009-standard-library.md
@@ -28,6 +28,12 @@ This SEP specifies the standard library that ships with every Spore implementati
 
 The stdlib is deliberately small. Spore follows the principle that the standard library should provide exactly the types and functions needed to write idiomatic Spore code, with everything else available as packages.
 
+> **Target-surface note**: This SEP still contains historical `std.*` examples
+> in places. For the approved compositional-semantics wave, the engineering-
+> facing helper naming is expected to use `spore.combine`, `spore.merge`,
+> `spore.order`, and `spore.laws`, and explicitly does **not** introduce a
+> user-facing `std.algebra` surface.
+
 ## Motivation
 
 Currently, SEPs 0001–0008 reference standard library items (e.g., `map`, `fold`, `Option[T]`, `Result[T, E]`, `List[T]`) without a single authoritative specification. This creates several problems:

--- a/seps/SEP-0009-standard-library.md
+++ b/seps/SEP-0009-standard-library.md
@@ -51,8 +51,7 @@ Currently, SEPs 0001–0008 reference standard library items (e.g., `map`, `fold
 Every Spore file implicitly has access to:
 
 ```spore
-// Primitive types (compiler-intrinsic)
-// Int, Float, Bool, String, Char, Unit, Never
+// Primitive types: I8..U64, F32, F64, Bool, Str, Unit, Never (see SEP-0002)
 
 // Algebraic types
 type Option[T] { Some(T), None }
@@ -116,17 +115,22 @@ The prelude is implicitly imported into every module. It contains:
 
 #### Primitive types
 
-| Type | Description | Default | Size |
-|------|-------------|---------|------|
-| `Int` | Canonical integer scalar (`I64` alias) | `0` | 8 bytes |
-| `Float` | Canonical floating-point scalar (`F64` alias) | `0.0` | 8 bytes |
+| Type | Description | Default | Size / notes |
+|------|-------------|---------|----------------|
+| `I8`…`I64`, `U8`…`U64` | Fixed-width integers | `0` for the chosen width | 1–8 bytes |
+| `F32`, `F64` | IEEE-754 floats | `0.0` | 4 or 8 bytes |
 | `Bool` | Boolean | `false` | 1 byte |
-| `String` | Immutable UTF-8 string | `""` | Variable |
-| `Char` | Unicode scalar value | — | 4 bytes |
+| `Str` | Immutable UTF-8 string | `""` | Variable |
 | `Unit` | Zero-valued type | `()` | 0 bytes |
 | `Never` | Bottom type (uninhabited) | — | 0 bytes |
 
+**No `Char`.** Unicode scalars are represented as `Str` values (typically length 1). Character predicates and conversions live in `stdlib/char.sp` (`is_digit`, `char_to_int`, …). This matches `spore` PR #113.
+
+**Literals.** In the reference type checker, unsuffixed integer literals default to **`I64`** and float literals to **`F64`**. Older spec examples may still say `Int` / `Float` — see SEP-0002 for the informal shorthand convention.
+
 #### Algebraic types
+
+Prelude **`List[T]`** is always **unbounded** and is the canonical sequence type. **`Vec[T, max: N]`** exists for the minority of APIs that require a compile-time `max` in the type (SEP-0002); omit it unless those generics truly buy you something `List` + `cost`/refinements cannot.
 
 ```spore
 type Option[T] {
@@ -221,14 +225,14 @@ fn flat_map[A, B](list: List[A], f: (A) -> List[B]) -> List[B]
 fn zip[A, B](a: List[A], b: List[B]) -> List[(A, B)]
     cost O(min(len(a), len(b)))
 
-fn enumerate[A](list: List[A]) -> List[(Int, A)]
+fn enumerate[A](list: List[A]) -> List[(I64, A)]
     cost O(len(list))
 ```
 
 #### List query functions
 
 ```spore
-fn len[A](list: List[A]) -> Int
+fn len[A](list: List[A]) -> I64
     cost O(1)
 
 fn is_empty[A](list: List[A]) -> Bool
@@ -272,13 +276,13 @@ fn concat[A](a: List[A], b: List[A]) -> List[A]
 fn reverse[A](list: List[A]) -> List[A]
     cost O(len(list))
 
-fn take[A](list: List[A], n: Int) -> List[A]
+fn take[A](list: List[A], n: I64) -> List[A]
     cost O(n)
 
-fn drop[A](list: List[A], n: Int) -> List[A]
+fn drop[A](list: List[A], n: I64) -> List[A]
     cost O(n)
 
-fn range(start: Int, end: Int) -> List[Int]
+fn range(start: I64, end: I64) -> List[I64]
     cost O(end - start)
 ```
 
@@ -296,11 +300,11 @@ fn sort_by[A](list: List[A], cmp: (A, A) -> Ordering) -> List[A]
 #### Conversion and display
 
 ```spore
-fn to_string[A](value: A) -> String
+fn to_string[A](value: A) -> Str
     where A: Display
     cost O(1)
 
-fn debug[A](value: A) -> String
+fn debug[A](value: A) -> Str
     where A: Debug
     cost O(1)
 ```
@@ -312,41 +316,41 @@ fn debug[A](value: A) -> String
 ```spore
 module std.math
 
-fn abs(x: Int) -> Int             cost O(1)
-fn abs_float(x: Float) -> Float   cost O(1)
-fn min(a: Int, b: Int) -> Int     cost O(1)
-fn max(a: Int, b: Int) -> Int     cost O(1)
-fn clamp(x: Int, lo: Int, hi: Int) -> Int  cost O(1)
+fn abs(x: I64) -> I64             cost O(1)
+fn abs_float(x: F64) -> F64   cost O(1)
+fn min(a: I64, b: I64) -> I64     cost O(1)
+fn max(a: I64, b: I64) -> I64     cost O(1)
+fn clamp(x: I64, lo: I64, hi: I64) -> I64  cost O(1)
 
 // Floating-point math
-fn sqrt(x: Float) -> Float        cost O(1)
-fn pow(base: Float, exp: Float) -> Float  cost O(1)
-fn log(x: Float) -> Float         cost O(1)
-fn log2(x: Float) -> Float        cost O(1)
-fn log10(x: Float) -> Float       cost O(1)
-fn exp(x: Float) -> Float         cost O(1)
+fn sqrt(x: F64) -> F64        cost O(1)
+fn pow(base: F64, exp: F64) -> F64  cost O(1)
+fn log(x: F64) -> F64         cost O(1)
+fn log2(x: F64) -> F64        cost O(1)
+fn log10(x: F64) -> F64       cost O(1)
+fn exp(x: F64) -> F64         cost O(1)
 
 // Trigonometric
-fn sin(x: Float) -> Float         cost O(1)
-fn cos(x: Float) -> Float         cost O(1)
-fn tan(x: Float) -> Float         cost O(1)
-fn asin(x: Float) -> Float        cost O(1)
-fn acos(x: Float) -> Float        cost O(1)
-fn atan(x: Float) -> Float        cost O(1)
-fn atan2(y: Float, x: Float) -> Float  cost O(1)
+fn sin(x: F64) -> F64         cost O(1)
+fn cos(x: F64) -> F64         cost O(1)
+fn tan(x: F64) -> F64         cost O(1)
+fn asin(x: F64) -> F64        cost O(1)
+fn acos(x: F64) -> F64        cost O(1)
+fn atan(x: F64) -> F64        cost O(1)
+fn atan2(y: F64, x: F64) -> F64  cost O(1)
 
 // Rounding
-fn floor(x: Float) -> Int         cost O(1)
-fn ceil(x: Float) -> Int          cost O(1)
-fn round(x: Float) -> Int         cost O(1)
-fn truncate(x: Float) -> Int      cost O(1)
+fn floor(x: F64) -> I64         cost O(1)
+fn ceil(x: F64) -> I64          cost O(1)
+fn round(x: F64) -> I64         cost O(1)
+fn truncate(x: F64) -> I64      cost O(1)
 
 // Constants
-let pi: Float = 3.14159265358979323846
-let e: Float = 2.71828182845904523536
-let infinity: Float
-let neg_infinity: Float
-let nan: Float
+let pi: F64 = 3.14159265358979323846
+let e: F64 = 2.71828182845904523536
+let infinity: F64
+let neg_infinity: F64
+let nan: F64
 ```
 
 #### `std.string`
@@ -354,33 +358,33 @@ let nan: Float
 ```spore
 module std.string
 
-fn length(s: String) -> Int                  cost O(1)
-fn is_empty(s: String) -> Bool               cost O(1)
-fn char_at(s: String, index: Int) -> Option[Char]  cost O(1)
-fn substring(s: String, start: Int, end: Int) -> String  cost O(end - start)
+fn length(s: Str) -> I32                  cost O(1)
+fn is_empty(s: Str) -> Bool               cost O(1)
+fn char_at(s: Str, index: I32) -> Option[Str]  cost O(1)
+fn substring(s: Str, start: I32, end: I32) -> Str  cost O(end - start)
 
-fn concat(a: String, b: String) -> String    cost O(len(a) + len(b))
-fn join(parts: List[String], sep: String) -> String
+fn concat(a: Str, b: Str) -> Str    cost O(len(a) + len(b))
+fn join(parts: List[Str], sep: Str) -> Str
     cost O(total_len(parts) + len(parts) * len(sep))
 
-fn split(s: String, sep: String) -> List[String]
+fn split(s: Str, sep: Str) -> List[Str]
     cost O(len(s))
 
-fn trim(s: String) -> String                 cost O(len(s))
-fn trim_start(s: String) -> String           cost O(len(s))
-fn trim_end(s: String) -> String             cost O(len(s))
+fn trim(s: Str) -> Str                 cost O(len(s))
+fn trim_start(s: Str) -> Str           cost O(len(s))
+fn trim_end(s: Str) -> Str             cost O(len(s))
 
-fn to_upper(s: String) -> String             cost O(len(s))
-fn to_lower(s: String) -> String             cost O(len(s))
+fn to_upper(s: Str) -> Str             cost O(len(s))
+fn to_lower(s: Str) -> Str             cost O(len(s))
 
-fn contains(s: String, pattern: String) -> Bool  cost O(len(s))
-fn starts_with(s: String, prefix: String) -> Bool  cost O(len(prefix))
-fn ends_with(s: String, suffix: String) -> Bool  cost O(len(suffix))
+fn contains(s: Str, pattern: Str) -> Bool  cost O(len(s))
+fn starts_with(s: Str, prefix: Str) -> Bool  cost O(len(prefix))
+fn ends_with(s: Str, suffix: Str) -> Bool  cost O(len(suffix))
 
-fn replace(s: String, from: String, to: String) -> String  cost O(len(s))
+fn replace(s: Str, from: Str, to: Str) -> Str  cost O(len(s))
 
-fn parse_int(s: String) -> Result[Int, ParseError]  cost O(len(s))
-fn parse_float(s: String) -> Result[Float, ParseError]  cost O(len(s))
+fn parse_int(s: Str) -> Result[I32, ParseError]  cost O(len(s))
+fn parse_float(s: Str) -> Result[F64, ParseError]  cost O(len(s))
 ```
 
 #### `std.collections`
@@ -417,7 +421,7 @@ fn values[K, V](m: Map[K, V]) -> List[V]
 fn entries[K, V](m: Map[K, V]) -> List[(K, V)]
     cost O(len(m))
 
-fn map_size[K, V](m: Map[K, V]) -> Int
+fn map_size[K, V](m: Map[K, V]) -> I64
     cost O(1)
 
 fn from_list[K, V](pairs: List[(K, V)]) -> Map[K, V]
@@ -441,7 +445,7 @@ fn remove_from[T](s: Set[T], item: T) -> Set[T]
 fn member[T](s: Set[T], item: T) -> Bool
     cost O(1)
 
-fn set_size[T](s: Set[T]) -> Int
+fn set_size[T](s: Set[T]) -> I64
     cost O(1)
 
 fn union[T](a: Set[T], b: Set[T]) -> Set[T]
@@ -501,13 +505,13 @@ foreign fn elapsed(start: DateTime) -> Duration
     uses [Clock]
     cost O(1)
 
-fn duration_ms(d: Duration) -> Int
+fn duration_ms(d: Duration) -> I64
     cost O(1)
 
-fn duration_secs(d: Duration) -> Float
+fn duration_secs(d: Duration) -> F64
     cost O(1)
 
-foreign fn sleep(ms: Int) -> Unit
+foreign fn sleep(ms: I64) -> Unit
     uses [Clock]
     cost @unbounded
 ```
@@ -520,21 +524,21 @@ module std.json
 type JsonValue {
     JsonNull,
     JsonBool(Bool),
-    JsonInt(Int),
-    JsonFloat(Float),
-    JsonString(String),
+    JsonInt(I64),
+    JsonFloat(F64),
+    JsonString(Str),
     JsonArray(List[JsonValue]),
-    JsonObject(Map[String, JsonValue]),
+    JsonObject(Map[Str, JsonValue]),
 }
 
-fn parse_json(s: String) -> Result[JsonValue, ParseError]
+fn parse_json(s: Str) -> Result[JsonValue, ParseError]
     cost O(len(s))
 
-fn to_json[T](value: T) -> String
+fn to_json[T](value: T) -> Str
     where T: Serialize
     cost O(size(value))
 
-fn from_json[T](s: String) -> Result[T, ParseError]
+fn from_json[T](s: Str) -> Result[T, ParseError]
     where T: Deserialize
     cost O(len(s))
 ```
@@ -544,15 +548,15 @@ fn from_json[T](s: String) -> Result[T, ParseError]
 ```spore
 module std.random
 
-foreign fn random_float() -> Float
+foreign fn random_float() -> F64
     uses [Random]
     cost O(1)
 
-foreign fn random_int(min: Int, max: Int) -> Int
+foreign fn random_int(min: I64, max: I64) -> I64
     uses [Random]
     cost O(1)
 
-foreign fn uuid() -> String
+foreign fn uuid() -> Str
     uses [Random]
     cost O(1)
 
@@ -571,39 +575,39 @@ All stdlib errors conform to a base trait:
 
 ```spore
 trait Error[T] {
-    fn message(self: T) -> String
+    fn message(self: T) -> Str
 }
 ```
 
 The standard error types:
 
 ```spore
-type PanicError { Panic(String) }
+type PanicError { Panic(Str) }
 
 type IoError {
-    NotFound(String),
-    PermissionDenied(String),
-    AlreadyExists(String),
-    Other(String),
+    NotFound(Str),
+    PermissionDenied(Str),
+    AlreadyExists(Str),
+    Other(Str),
 }
 
 type HttpError {
-    ConnectionFailed(String),
-    Timeout(String),
-    StatusError(Int, String),
-    Other(String),
+    ConnectionFailed(Str),
+    Timeout(Str),
+    StatusError(I32, Str),
+    Other(Str),
 }
 
 type ParseError {
-    InvalidFormat(String),
-    UnexpectedToken(String, Int),
-    Other(String),
+    InvalidFormat(Str),
+    UnexpectedToken(Str, I32),
+    Other(Str),
 }
 
 type JsonError {
-    InvalidJson(String, Int),
-    TypeMismatch(String),
-    MissingField(String),
+    InvalidJson(Str, I32),
+    TypeMismatch(Str),
+    MissingField(Str),
 }
 ```
 
@@ -618,12 +622,12 @@ These 13 traits have special compiler support (SEP-0002). The stdlib provides th
 | `Eq` | `eq(self, other) -> Bool` | ✅ | Equality comparison |
 | `Ord` | `compare(self, other) -> Ordering` | ✅ | Total ordering |
 | `Clone` | `clone(self) -> Self` | ✅ | Deep copy |
-| `Display` | `display(self) -> String` | ❌ | Human-readable formatting |
-| `Debug` | `debug(self) -> String` | ✅ | Debug formatting |
-| `Hash` | `hash(self) -> Int` | ✅ | Hash computation |
+| `Display` | `display(self) -> Str` | ❌ | Human-readable formatting |
+| `Debug` | `debug(self) -> Str` | ✅ | Debug formatting |
+| `Hash` | `hash(self) -> I32` | ✅ | Hash computation |
 | `Default` | `default() -> Self` | ✅ | Default value |
-| `Serialize` | `serialize(self) -> List[Int]` | ✅ | Byte serialization |
-| `Deserialize` | `deserialize(bytes: List[Int]) -> Result[Self, ParseError]` | ✅ | Byte deserialization |
+| `Serialize` | `serialize(self) -> List[I32]` | ✅ | Byte serialization |
+| `Deserialize` | `deserialize(bytes: List[I32]) -> Result[Self, ParseError]` | ✅ | Byte deserialization |
 | `Add` | `add(self, other) -> Self` | ❌ | `+` operator |
 | `Sub` | `sub(self, other) -> Self` | ❌ | `-` operator |
 | `Mul` | `mul(self, other) -> Self` | ❌ | `*` operator |
@@ -687,7 +691,7 @@ The stdlib is designed for progressive discovery:
 1. **Prelude is small**: Only essential types and iteration primitives — no import ceremony for basic programs
 2. **Module names are predictable**: `std.math`, `std.string`, `std.collections` follow standard conventions
 3. **Cost annotations are readable**: `cost O(len(list))` reads naturally
-4. **Error types are descriptive**: Enum variants like `NotFound(String)` carry context
+4. **Error types are descriptive**: Enum variants like `NotFound(Str)` carry context
 5. **No hidden effects**: Every I/O function explicitly declares its effect requirements
 
 ## Agent experience impact
@@ -788,12 +792,12 @@ This is a new specification — no backward compatibility concerns. However:
 
 2. **Concurrency primitives**: `Task[T]`, `Chan[T]`, `select` are defined in SEP-0007 — should they be re-exported via `std.concurrent` or remain as language primitives?
 
-3. **String encoding**: Should `String` expose byte-level access, or only character-level? Current spec assumes UTF-8 with character indexing.
+3. **String encoding**: Should `Str` expose byte-level access, or only scalar-oriented indexing? Current spec assumes UTF-8; there is no `Char` type (length-1 `Str` values instead).
 
-4. **Numeric tower**: Should there be `Int8`, `Int16`, `Int32`, `Int64`, `UInt*` types for low-level use, or only `Int` and `Float`?
+4. **Numeric tower**: The reference implementation already exposes fixed widths (`I8`…`U64`, `F32`, `F64`). This SEP still mixes pedagogical `Int`/`Float` in some module sketches; those should converge to explicit widths over time.
 
 5. **Iterator protocol**: Should there be a lazy `Iterator[T]` trait instead of materializing `List[T]` for all operations? This would change cost signatures significantly.
 
 6. **Error recovery**: How should `PanicError` interact with the effect system? Should `panic` require an effect?
 
-7. **FFI type mapping**: How do Spore types map to Rust/C types across the FFI boundary? (e.g., `Int` → `i64` or `BigInt`?)
+7. **FFI type mapping**: How do Spore types map to Rust/C types across the FFI boundary? (e.g., `I64` ↔ `i64`, `Str` ↔ UTF-8 buffer)

--- a/seps/SEP-0009-standard-library.md
+++ b/seps/SEP-0009-standard-library.md
@@ -20,11 +20,16 @@ superseded_by: null
 
 This SEP specifies the standard library that ships with every Spore implementation. It defines:
 
-1. **Prelude** — types and functions available without import
+1. **Prelude** — types, traits, and functions available without import
 2. **Core modules** — standard modules available via `import std.*`
 3. **Error types** — a unified error hierarchy
 4. **Platform bindings** — how I/O functions connect to selected Platform package modules
-5. **Cost contracts** — cost annotations for all stdlib functions
+5. **Cost contracts** — verified cost annotations for indexed stdlib functions
+
+Shared operation names such as `map`, `len`, `unwrap`, `contains`, and
+`from_list` are trait or inherent methods, not overloaded free functions.
+Method resolution is Rust-like: the receiver type or type namespace selects the
+implementation, and ambiguous cases use trait-qualified syntax.
 
 The stdlib is deliberately small. Spore follows the principle that the standard library should provide exactly the types and functions needed to write idiomatic Spore code, with everything else available as packages.
 
@@ -36,10 +41,12 @@ The stdlib is deliberately small. Spore follows the principle that the standard 
 
 ## Motivation
 
-Currently, SEPs 0001–0008 reference standard library items (e.g., `map`, `fold`, `Option[T]`, `Result[T, E]`, `List[T]`) without a single authoritative specification. This creates several problems:
+Currently, SEPs 0001–0008 reference standard library items (e.g.,
+`map`, `fold`, `Option[T]`, `Result[T, E]`, `List[T]`) without a
+single authoritative specification. This creates several problems:
 
 1. **Ambiguity**: Function signatures are mentioned inconsistently across SEPs
-2. **Missing cost contracts**: Most stdlib functions lack formal cost annotations
+2. **Cost-contract ambiguity**: Dynamic APIs and indexed APIs need different cost-contract rules
 3. **No error type hierarchy**: `IoError`, `HttpError`, `ParseError` are referenced but never defined
 4. **FFI boundary unclear**: Which functions are implemented natively vs. in Spore is unspecified
 5. **Agent tooling gap**: Agents cannot enumerate available functions or their contracts
@@ -56,25 +63,33 @@ Every Spore file implicitly has access to:
 // Algebraic types
 type Option[T] { Some(T), None }
 type Result[T, E] { Ok(T), Err(E) }
+type List[T] { Cons(T, List[T]), Nil }
+type Ordering { Less, Equal, Greater }
 
-// Core iteration (higher-order functions)
-fn map[A, B](list: List[A], f: (A) -> B) -> List[B]
-fn filter[A](list: List[A], p: (A) -> Bool) -> List[A]
-fn fold[A, B](list: List[A], init: B, f: (B, A) -> B) -> B
-fn each[A](list: List[A], f: (A) -> Unit) -> Unit
+// Index-admitted count
+type Count[N: Index] = I64 when self >= 0
 ```
+
+The prelude intentionally does **not** export duplicate free functions or
+signature-union overloads. Shared names are trait or inherent methods:
+`xs.map(f)`, `opt.map(f)`, `s.len()`, and `Map.from_list(pairs)` are distinct
+method resolutions, not overloaded free functions.
 
 ### What needs an import?
 
 Specialized modules require explicit imports:
 
 ```spore
-import std.math       // sqrt, sin, cos, abs, pow, ...
-import std.string     // split, trim, join, contains, ...
-import std.collections // Map, Set, sorted, grouped, ...
+import std.index       // Count helpers: add, span, ...
+import std.array       // Array[T, N] and fixed-length operations
+import std.vec         // Vec[T, max: N] and verified size-parametric operations
+import std.list        // Dynamic List operations
+import std.math        // f64_sqrt, f64_sin, i64_abs, f64_pow, ...
+import std.string      // split, trim, join, contains, ...
+import std.collections // Map, Set, Map.from_list, Set.from_list, ...
 // future: import std.io  // stabilized platform-neutral I/O facade
-import std.time       // DateTime, Duration, now(), ...
-import std.json       // parse_json, to_json
+import std.time        // DateTime, Duration, now(), ...
+import std.json        // json_parse, json_to_string
 ```
 
 ### How do I/O functions work?
@@ -128,339 +143,299 @@ The prelude is implicitly imported into every module. It contains:
 
 **Literals.** In the reference type checker, unsuffixed integer literals default to **`I64`** and floating-point literals default to **`F64`**. Standard-library signatures use explicit fixed-width names; `Int` and `Float` are not standard aliases.
 
-#### Algebraic types
+#### Algebraic and index-admitted types
 
-Prelude **`List[T]`** is always **unbounded** and is the canonical sequence type. **`Vec[T, max: N]`** exists for the minority of APIs that require a compile-time `max` in the type (SEP-0002); omit it unless those generics truly buy you something `List` + `cost`/refinements cannot.
+Prelude **`List[T]`** is dynamic and unbounded. It is the canonical sequence
+type for ordinary programs, but its runtime length is not a CostExpr variable.
+Use `Count[N]`, `Array[T, N]`, or `Vec[T, max: N]` when a static Index must
+participate in verified cost.
 
 ```spore
-type Option[T] {
-    Some(T),
-    None,
-}
-
-type Result[T, E] {
-    Ok(T),
-    Err(E),
-}
-
-type List[T] {
-    Cons(T, List[T]),
-    Nil,
-}
-
+type Option[T] { Some(T), None }
+type Result[T, E] { Ok(T), Err(E) }
+type List[T] { Cons(T, List[T]), Nil }
 type Ordering { Less, Equal, Greater }
+type Count[N: Index] = I64 when self >= 0
 ```
 
-### 4.2 Prelude functions
+### 4.2 Prelude traits and functions
 
-#### Option[T] methods
+The prelude does not export duplicate free functions. Similar operations use
+trait or inherent methods:
+
+- `opt.map(f)`, `res.map(f)`, `list.map(f)`, and `vec.map(f)` are method calls.
+- `s.len()`, `list.len()`, `map.len()`, and `set.len()` are `Len` trait calls.
+- `opt.unwrap()` and `res.unwrap()` are `Unwrap` trait calls.
+- `Map.from_list(pairs)` and `Set.from_list(items)` are type-qualified
+  associated functions.
+
+If method resolution is ambiguous after type inference, the programmer uses
+trait-qualified syntax. The standard library does not use `A | B` parameter
+signatures to simulate overloads.
 
 ```spore
-fn unwrap[T](opt: Option[T]) -> T
-    ! PanicError
-    cost [1, 0, 0, 1]
+trait Mappable {
+    type Item
+    type Mapped[U]
+    fn map[U](self, f: (Self.Item) -> U) -> Self.Mapped[U]
+}
 
-fn unwrap_or[T](opt: Option[T], default: T) -> T
-    cost [1, 0, 0, 1]
+trait Len {
+    fn len(self) -> I64
+    fn is_empty(self) -> Bool { self.len() == 0 }
+}
 
-fn map[T, U](opt: Option[T], f: (T) -> U) -> Option[U]
-    cost [cost(f), 0, 0, 1]
+trait Unwrap {
+    type Output
+    fn unwrap(self) -> Self.Output ! PanicError
+    fn unwrap_or(self, default: Self.Output) -> Self.Output
+}
 
-fn and_then[T, U](opt: Option[T], f: (T) -> Option[U]) -> Option[U]
-    cost [cost(f), 0, 0, 1]
+trait Contains[Needle] {
+    fn contains(self, needle: Needle) -> Bool
+}
 
-fn is_some[T](opt: Option[T]) -> Bool
-    cost [1, 0, 0, 1]
+impl[T] Mappable for Option[T] {
+    type Item = T
+    type Mapped[U] = Option[U]
+    fn map[U](self, f: (T) -> U) -> Option[U] cost [cost(f), 0, 0, 0]
+}
 
-fn is_none[T](opt: Option[T]) -> Bool
-    cost [1, 0, 0, 1]
+impl[T] Unwrap for Option[T] {
+    type Output = T
+    fn unwrap(self) -> T ! PanicError cost [1, 0, 0, 0]
+    fn unwrap_or(self, default: T) -> T cost [1, 0, 0, 0]
+}
+
+impl[T] Option[T] {
+    fn and_then[U](self, f: (T) -> Option[U]) -> Option[U] cost [cost(f), 0, 0, 0]
+    fn is_some(self) -> Bool cost [1, 0, 0, 0]
+    fn is_none(self) -> Bool cost [1, 0, 0, 0]
+}
+
+impl[T, E] Mappable for Result[T, E] {
+    type Item = T
+    type Mapped[U] = Result[U, E]
+    fn map[U](self, f: (T) -> U) -> Result[U, E] cost [cost(f), 0, 0, 0]
+}
+
+impl[T, E] Unwrap for Result[T, E] {
+    type Output = T
+    fn unwrap(self) -> T ! PanicError cost [1, 0, 0, 0]
+    fn unwrap_or(self, default: T) -> T cost [1, 0, 0, 0]
+}
+
+impl[T, E] Result[T, E] {
+    fn map_err[F](self, f: (E) -> F) -> Result[T, F] cost [cost(f), 0, 0, 0]
+    fn and_then[U](self, f: (T) -> Result[U, E]) -> Result[U, E] cost [cost(f), 0, 0, 0]
+    fn is_ok(self) -> Bool cost [1, 0, 0, 0]
+    fn is_err(self) -> Bool cost [1, 0, 0, 0]
+}
+
+fn to_string[A](value: A) -> Str where A: Display cost [1, 1, 0, 0]
+fn to_debug_string[A](value: A) -> Str where A: Debug cost [1, 1, 0, 0]
 ```
 
-#### Result[T, E] methods
-
-```spore
-fn unwrap[T, E](res: Result[T, E]) -> T
-    ! PanicError
-    cost [1, 0, 0, 1]
-
-fn unwrap_or[T, E](res: Result[T, E], default: T) -> T
-    cost [1, 0, 0, 1]
-
-fn map[T, U, E](res: Result[T, E], f: (T) -> U) -> Result[U, E]
-    cost [cost(f), 0, 0, 1]
-
-fn map_err[T, E, F](res: Result[T, E], f: (E) -> F) -> Result[T, F]
-    cost [cost(f), 0, 0, 1]
-
-fn and_then[T, U, E](res: Result[T, E], f: (T) -> Result[U, E]) -> Result[U, E]
-    cost [cost(f), 0, 0, 1]
-
-fn is_ok[T, E](res: Result[T, E]) -> Bool
-    cost [1, 0, 0, 1]
-
-fn is_err[T, E](res: Result[T, E]) -> Bool
-    cost [1, 0, 0, 1]
-```
-
-#### List iteration (core HOFs)
-
-These are the **primary iteration primitives** in Spore (no loops — SEP-0001):
-
-```spore
-fn map[A, B](list: List[A], f: (A) -> B) -> List[B]
-    cost [len(list) * cost(f) + len(list), len(list), 0, 1]
-
-fn filter[A](list: List[A], p: (A) -> Bool) -> List[A]
-    cost [len(list) * cost(p) + len(list), len(list), 0, 1]
-
-fn fold[A, B](list: List[A], init: B, f: (B, A) -> B) -> B
-    cost [len(list) * cost(f), 0, 0, 1]
-
-fn each[A](list: List[A], f: (A) -> Unit) -> Unit
-    cost [len(list) * cost(f), 0, 0, 1]
-
-fn flat_map[A, B](list: List[A], f: (A) -> List[B]) -> List[B]
-    cost [len(list) * cost(f) + total_output_len, total_output_len, 0, 1]
-
-fn zip[A, B](a: List[A], b: List[B]) -> List[(A, B)]
-    cost [min(len(a), len(b)), min(len(a), len(b)), 0, 1]
-
-fn enumerate[A](list: List[A]) -> List[(I64, A)]
-    cost [len(list), len(list), 0, 1]
-```
-
-#### List query functions
-
-```spore
-fn len[A](list: List[A]) -> I64
-    cost [1, 0, 0, 1]
-
-fn is_empty[A](list: List[A]) -> Bool
-    cost [1, 0, 0, 1]
-
-fn head[A](list: List[A]) -> Option[A]
-    cost [1, 0, 0, 1]
-
-fn tail[A](list: List[A]) -> Option[List[A]]
-    cost [1, 0, 0, 1]
-
-fn last[A](list: List[A]) -> Option[A]
-    cost [len(list), 0, 0, 1]
-
-fn contains[A](list: List[A], item: A) -> Bool
-    where A: Eq
-    cost [len(list), 0, 0, 1]
-
-fn find[A](list: List[A], p: (A) -> Bool) -> Option[A]
-    cost [len(list) * cost(p), 0, 0, 1]
-
-fn any[A](list: List[A], p: (A) -> Bool) -> Bool
-    cost [len(list) * cost(p), 0, 0, 1]
-
-fn all[A](list: List[A], p: (A) -> Bool) -> Bool
-    cost [len(list) * cost(p), 0, 0, 1]
-```
-
-#### List construction functions
-
-```spore
-fn append[A](list: List[A], item: A) -> List[A]
-    cost [len(list), len(list), 0, 1]
-
-fn prepend[A](item: A, list: List[A]) -> List[A]
-    cost [1, 1, 0, 1]
-
-fn concat[A](a: List[A], b: List[A]) -> List[A]
-    cost [len(a), len(a) + len(b), 0, 1]
-
-fn reverse[A](list: List[A]) -> List[A]
-    cost [len(list), len(list), 0, 1]
-
-fn take[A](list: List[A], n: I64) -> List[A]
-    cost [n, n, 0, 1]
-
-fn drop[A](list: List[A], n: I64) -> List[A]
-    cost [n, len(list), 0, 1]
-
-fn range(start: I64, end: I64) -> List[I64]
-    cost [end - start, end - start, 0, 1]
-```
-
-#### Sorting
-
-```spore
-fn sort[A](list: List[A]) -> List[A]
-    where A: Ord
-    cost [len(list) * log(len(list)), len(list), 0, 1]
-
-fn sort_by[A](list: List[A], cmp: (A, A) -> Ordering) -> List[A]
-    cost [len(list) * log(len(list)) * cost(cmp), len(list), 0, 1]
-```
-
-#### Conversion and display
-
-```spore
-fn to_string[A](value: A) -> Str
-    where A: Display
-    cost [1, 1, 0, 1]
-
-fn debug[A](value: A) -> Str
-    where A: Debug
-    cost [1, 1, 0, 1]
-```
+Dynamic `List[T]` operations live in `std.list` rather than the prelude. They
+are stable APIs, but they do not publish verified costs that depend on runtime
+length. Use `std.vec` or `std.array` for statically indexed cost.
 
 ### 4.3 Core modules
+
+#### `std.index`
+
+```spore
+fn count_zero() -> Count[0] cost [1, 0, 0, 0]
+fn count_one() -> Count[1] cost [1, 0, 0, 0]
+fn count_add[N: Index, M: Index](a: Count[N], b: Count[M]) -> Count[N + M] cost [1, 0, 0, 0]
+fn count_mul[N: Index, M: Index](a: Count[N], b: Count[M]) -> Count[N * M] cost [1, 0, 0, 0]
+fn count_max[N: Index, M: Index](a: Count[N], b: Count[M]) -> Count[max(N, M)] cost [1, 0, 0, 0]
+fn count_min[N: Index, M: Index](a: Count[N], b: Count[M]) -> Count[min(N, M)] cost [1, 0, 0, 0]
+fn count_span[Hi: Index, Lo: Index](hi: Count[Hi], lo: Count[Lo]) -> Count[span(Hi, Lo)] cost [1, 0, 0, 0]
+fn count_to_i64[N: Index](count: Count[N]) -> I64 cost [1, 0, 0, 0]
+```
+
+#### `std.array` and `std.vec`
+
+```spore
+type Array[T, N: Index]
+type Vec[T, max: N] where N: Index
+
+impl[A, N: Index] Mappable for Array[A, N] {
+    type Item = A
+    type Mapped[B] = Array[B, N]
+    fn map[B](self, f: (A) -> B) -> Array[B, N]
+        cost [N * cost(f) + N, N, 0, 0]
+}
+
+impl[A, N: Index] Array[A, N] {
+    fn fold[B](self, init: B, f: (B, A) -> B) -> B
+        cost [N * cost(f), 0, 0, 0]
+}
+
+impl[A, N: Index] Mappable for Vec[A, max: N] {
+    type Item = A
+    type Mapped[B] = Vec[B, max: N]
+    fn map[B](self, f: (A) -> B) -> Vec[B, max: N]
+        cost [N * cost(f) + N, N, 0, 0]
+}
+
+impl[A, N: Index] Vec[A, max: N] {
+    fn take[K: Index](self, count: Count[K]) -> Vec[A, max: min(N, K)]
+        cost [min(N, K), min(N, K), 0, 0]
+
+    fn concat[M: Index](self, other: Vec[A, max: M]) -> Vec[A, max: N + M]
+        cost [N + M, N + M, 0, 0]
+}
+
+fn range_count[N: Index](start: I64, count: Count[N]) -> Vec[I64, max: N]
+    cost [N, N, 0, 0]
+```
+
+#### `std.list`
+
+```spore
+impl[A] Mappable for List[A] {
+    type Item = A
+    type Mapped[B] = List[B]
+    fn map[B](self, f: (A) -> B) -> List[B]
+}
+
+impl[A] Len for List[A] {
+    fn len(self) -> I64
+}
+
+impl[A] Contains[A] for List[A] where A: Eq {
+    fn contains(self, item: A) -> Bool
+}
+
+impl[A] List[A] {
+    fn filter(self, p: (A) -> Bool) -> List[A]
+    fn fold[B](self, init: B, f: (B, A) -> B) -> B
+    fn each(self, f: (A) -> Unit) -> Unit
+    fn flat_map[B](self, f: (A) -> List[B]) -> List[B]
+    fn zip[B](self, other: List[B]) -> List[(A, B)]
+    fn enumerate(self) -> List[(I64, A)]
+    fn head(self) -> Option[A]
+    fn tail(self) -> Option[List[A]]
+    fn last(self) -> Option[A]
+    fn find(self, p: (A) -> Bool) -> Option[A]
+    fn any(self, p: (A) -> Bool) -> Bool
+    fn all(self, p: (A) -> Bool) -> Bool
+    fn append(self, item: A) -> List[A]
+    fn prepend(self, item: A) -> List[A]
+    fn concat(self, other: List[A]) -> List[A]
+    fn reverse(self) -> List[A]
+    fn take(self, n: I64) -> List[A]
+    fn drop(self, n: I64) -> List[A]
+    fn sort(self) -> List[A] where A: Ord
+    fn sort_by(self, cmp: (A, A) -> Ordering) -> List[A]
+}
+
+impl List[I64] {
+    fn range(start: I64, end: I64) -> List[I64]
+}
+```
 
 #### `std.math`
 
 ```spore
-fn abs(x: I64) -> I64                 cost [1, 0, 0, 1]
-fn abs_float(x: F64) -> F64           cost [1, 0, 0, 1]
-fn min(a: I64, b: I64) -> I64         cost [1, 0, 0, 1]
-fn max(a: I64, b: I64) -> I64         cost [1, 0, 0, 1]
-fn clamp(x: I64, lo: I64, hi: I64) -> I64
-    cost [1, 0, 0, 1]
-
-// Floating-point math
-fn sqrt(x: F64) -> F64                cost [1, 0, 0, 1]
-fn pow(base: F64, exp: F64) -> F64    cost [1, 0, 0, 1]
-fn log(x: F64) -> F64                 cost [1, 0, 0, 1]
-fn log2(x: F64) -> F64                cost [1, 0, 0, 1]
-fn log10(x: F64) -> F64               cost [1, 0, 0, 1]
-fn exp(x: F64) -> F64                 cost [1, 0, 0, 1]
-
-// Trigonometric
-fn sin(x: F64) -> F64                 cost [1, 0, 0, 1]
-fn cos(x: F64) -> F64                 cost [1, 0, 0, 1]
-fn tan(x: F64) -> F64                 cost [1, 0, 0, 1]
-fn asin(x: F64) -> F64                cost [1, 0, 0, 1]
-fn acos(x: F64) -> F64                cost [1, 0, 0, 1]
-fn atan(x: F64) -> F64                cost [1, 0, 0, 1]
-fn atan2(y: F64, x: F64) -> F64       cost [1, 0, 0, 1]
-
-// Rounding
-fn floor(x: F64) -> I64                cost [1, 0, 0, 1]
-fn ceil(x: F64) -> I64                 cost [1, 0, 0, 1]
-fn round(x: F64) -> I64                cost [1, 0, 0, 1]
-fn truncate(x: F64) -> I64             cost [1, 0, 0, 1]
-
-// Constants
-let pi: F64 = 3.14159265358979323846
-let e: F64 = 2.71828182845904523536
-let infinity: F64
-let neg_infinity: F64
-let nan: F64
+fn i64_abs(x: I64) -> I64 cost [1, 0, 0, 0]
+fn f64_abs(x: F64) -> F64 cost [1, 0, 0, 0]
+fn i64_min(a: I64, b: I64) -> I64 cost [1, 0, 0, 0]
+fn i64_max(a: I64, b: I64) -> I64 cost [1, 0, 0, 0]
+fn i64_clamp(x: I64, lo: I64, hi: I64) -> I64 cost [1, 0, 0, 0]
+fn f64_sqrt(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_pow(base: F64, exp: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_log(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_log2(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_log10(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_exp(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_sin(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_cos(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_tan(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_asin(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_acos(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_atan(x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_atan2(y: F64, x: F64) -> F64 cost [1, 0, 0, 0]
+fn f64_floor(x: F64) -> I64 cost [1, 0, 0, 0]
+fn f64_ceil(x: F64) -> I64 cost [1, 0, 0, 0]
+fn f64_round(x: F64) -> I64 cost [1, 0, 0, 0]
+fn f64_truncate(x: F64) -> I64 cost [1, 0, 0, 0]
 ```
 
 #### `std.string`
 
 ```spore
-fn length(s: Str) -> I64                    cost [1, 0, 0, 1]
-fn is_empty(s: Str) -> Bool                 cost [1, 0, 0, 1]
-fn char_at(s: Str, index: I64) -> Option[Str]
-    cost [1, 0, 0, 1]
-fn substring(s: Str, start: I64, end: I64) -> Str
-    cost [end - start, end - start, 0, 1]
+impl Len for Str {
+    fn len(self) -> I64
+}
 
-fn concat(a: Str, b: Str) -> Str      cost [len(a) + len(b), len(a) + len(b), 0, 1]
-fn join(parts: List[Str], sep: Str) -> Str
-    cost [total_len(parts) + len(parts) * len(sep), total_len(parts) + len(parts) * len(sep), 0, 1]
+impl Contains[Str] for Str {
+    fn contains(self, pattern: Str) -> Bool
+}
 
-fn split(s: Str, sep: Str) -> List[Str]
-    cost [len(s), len(s), 0, 1]
-
-fn trim(s: Str) -> Str                   cost [len(s), len(s), 0, 1]
-fn trim_start(s: Str) -> Str             cost [len(s), len(s), 0, 1]
-fn trim_end(s: Str) -> Str               cost [len(s), len(s), 0, 1]
-
-fn to_upper(s: Str) -> Str               cost [len(s), len(s), 0, 1]
-fn to_lower(s: Str) -> Str               cost [len(s), len(s), 0, 1]
-
-fn contains(s: Str, pattern: Str) -> Bool    cost [len(s), 0, 0, 1]
-fn starts_with(s: Str, prefix: Str) -> Bool  cost [len(prefix), 0, 0, 1]
-fn ends_with(s: Str, suffix: Str) -> Bool    cost [len(suffix), 0, 0, 1]
-
-fn replace(s: Str, from: Str, to: Str) -> Str
-    cost [len(s), len(s), 0, 1]
-
-fn parse_int(s: Str) -> Result[I64, ParseError]    cost [len(s), 0, 0, 1]
-fn parse_float(s: Str) -> Result[F64, ParseError]  cost [len(s), 0, 0, 1]
+impl Str {
+    fn char_at(self, index: I64) -> Option[Str]
+    fn substring(self, start: I64, end: I64) -> Str
+    fn substring_count[N: Index](self, start: I64, count: Count[N]) -> Str
+        cost [N, N, 0, 0]
+    fn concat(self, other: Str) -> Str
+    fn join(parts: List[Str], sep: Str) -> Str
+    fn split(self, sep: Str) -> List[Str]
+    fn trim(self) -> Str
+    fn trim_start(self) -> Str
+    fn trim_end(self) -> Str
+    fn to_upper(self) -> Str
+    fn to_lower(self) -> Str
+    fn starts_with(self, prefix: Str) -> Bool
+    fn ends_with(self, suffix: Str) -> Bool
+    fn replace(self, from: Str, to: Str) -> Str
+    fn parse_i64(self) -> Result[I64, ParseError]
+    fn parse_f64(self) -> Result[F64, ParseError]
+}
 ```
 
 #### `std.collections`
 
 ```spore
-// ── Map[K, V] ──────────────────────────────────────────────────────
-
 type Map[K, V]  // Immutable hash map (K must implement Hash + Eq)
+type Set[T]     // Immutable hash set (T must implement Hash + Eq)
 
-fn empty_map[K, V]() -> Map[K, V]
-    where K: Hash + Eq
-    cost [1, 0, 0, 1]
+impl[K, V] Len for Map[K, V] {
+    fn len(self) -> I64
+}
 
-fn get[K, V](m: Map[K, V], key: K) -> Option[V]
-    cost [1, 0, 0, 1]
+impl[K, V] Map[K, V] where K: Hash + Eq {
+    fn empty() -> Map[K, V] cost [1, 0, 0, 0]
+    fn from_list(pairs: List[(K, V)]) -> Map[K, V]
+    fn get(self, key: K) -> Option[V] cost [1, 0, 0, 0]
+    fn insert(self, key: K, value: V) -> Map[K, V]
+    fn remove(self, key: K) -> Map[K, V]
+    fn contains_key(self, key: K) -> Bool cost [1, 0, 0, 0]
+    fn keys(self) -> List[K]
+    fn values(self) -> List[V]
+    fn entries(self) -> List[(K, V)]
+}
 
-fn insert[K, V](m: Map[K, V], key: K, value: V) -> Map[K, V]
-    cost [1, 1, 0, 1]  // amortized
+impl[T] Len for Set[T] {
+    fn len(self) -> I64
+}
 
-fn remove[K, V](m: Map[K, V], key: K) -> Map[K, V]
-    cost [1, 1, 0, 1]  // amortized
+impl[T] Contains[T] for Set[T] where T: Hash + Eq {
+    fn contains(self, item: T) -> Bool cost [1, 0, 0, 0]
+}
 
-fn contains_key[K, V](m: Map[K, V], key: K) -> Bool
-    cost [1, 0, 0, 1]
-
-fn keys[K, V](m: Map[K, V]) -> List[K]
-    cost [len(m), len(m), 0, 1]
-
-fn values[K, V](m: Map[K, V]) -> List[V]
-    cost [len(m), len(m), 0, 1]
-
-fn entries[K, V](m: Map[K, V]) -> List[(K, V)]
-    cost [len(m), len(m), 0, 1]
-
-fn map_size[K, V](m: Map[K, V]) -> I64
-    cost [1, 0, 0, 1]
-
-fn from_list[K, V](pairs: List[(K, V)]) -> Map[K, V]
-    where K: Hash + Eq
-    cost [len(pairs), len(pairs), 0, 1]
-
-// ── Set[T] ─────────────────────────────────────────────────────────
-
-type Set[T]  // Immutable hash set (T must implement Hash + Eq)
-
-fn empty_set[T]() -> Set[T]
-    where T: Hash + Eq
-    cost [1, 0, 0, 1]
-
-fn add[T](s: Set[T], item: T) -> Set[T]
-    cost [1, 1, 0, 1]  // amortized
-
-fn remove_from[T](s: Set[T], item: T) -> Set[T]
-    cost [1, 1, 0, 1]  // amortized
-
-fn member[T](s: Set[T], item: T) -> Bool
-    cost [1, 0, 0, 1]
-
-fn set_size[T](s: Set[T]) -> I64
-    cost [1, 0, 0, 1]
-
-fn union[T](a: Set[T], b: Set[T]) -> Set[T]
-    cost [len(a) + len(b), len(a) + len(b), 0, 1]
-
-fn intersection[T](a: Set[T], b: Set[T]) -> Set[T]
-    cost [min(len(a), len(b)), min(len(a), len(b)), 0, 1]
-
-fn difference[T](a: Set[T], b: Set[T]) -> Set[T]
-    cost [len(a), len(a), 0, 1]
-
-fn to_list[T](s: Set[T]) -> List[T]
-    cost [len(s), len(s), 0, 1]
-
-fn from_list[T](items: List[T]) -> Set[T]
-    where T: Hash + Eq
-    cost [len(items), len(items), 0, 1]
+impl[T] Set[T] where T: Hash + Eq {
+    fn empty() -> Set[T] cost [1, 0, 0, 0]
+    fn from_list(items: List[T]) -> Set[T]
+    fn add(self, item: T) -> Set[T]
+    fn remove(self, item: T) -> Set[T]
+    fn union(self, other: Set[T]) -> Set[T]
+    fn intersection(self, other: Set[T]) -> Set[T]
+    fn difference(self, other: Set[T]) -> Set[T]
+    fn to_list(self) -> List[T]
+}
 ```
 
 #### `std.io` (future standardization layer)
@@ -501,17 +476,17 @@ type Duration   // Time interval
 
 foreign fn now() -> DateTime
     uses [Clock]
-    cost [1, 0, 1, 1]
+    cost [1, 0, 1, 0]
 
 foreign fn elapsed(start: DateTime) -> Duration
     uses [Clock]
-    cost [1, 0, 1, 1]
+    cost [1, 0, 1, 0]
 
 fn duration_ms(d: Duration) -> I64
-    cost [1, 0, 0, 1]
+    cost [1, 0, 0, 0]
 
 fn duration_secs(d: Duration) -> F64
-    cost [1, 0, 0, 1]
+    cost [1, 0, 0, 0]
 
 foreign fn sleep(ms: I64) -> Unit
     uses [Clock]
@@ -531,40 +506,40 @@ type JsonValue {
     JsonObject(Map[Str, JsonValue]),
 }
 
-fn parse_json(s: Str) -> Result[JsonValue, ParseError]
-    cost [len(s), len(s), 0, 1]
+fn json_parse(s: Str) -> Result[JsonValue, ParseError]
 
-fn to_json[T](value: T) -> Str
+fn json_to_string[T](value: T) -> Str
     where T: Serialize
-    cost [size(value), size(value), 0, 1]
 
-fn from_json[T](s: Str) -> Result[T, ParseError]
+fn json_from_string[T](s: Str) -> Result[T, ParseError]
     where T: Deserialize
-    cost [len(s), len(s), 0, 1]
 ```
+
+These JSON APIs operate on dynamic `Str` and dynamic serialized values, so this
+SEP does not publish verified `cost [...]` clauses for them. Indexed wrappers
+may be added later if a platform needs static payload-size budgets.
 
 #### `std.random` (platform-provided)
 
 ```spore
 foreign fn random_float() -> F64
     uses [Random]
-    cost [1, 0, 1, 1]
+    cost [1, 0, 1, 0]
 
 foreign fn random_int(min: I64, max: I64) -> I64
     uses [Random]
-    cost [1, 0, 1, 1]
+    cost [1, 0, 1, 0]
 
 foreign fn uuid() -> Str
     uses [Random]
-    cost [1, 16, 1, 1]
+    cost [1, 16, 1, 0]
 
-fn shuffle[A](list: List[A]) -> List[A]
+fn random_shuffle[A](list: List[A]) -> List[A]
     uses [Random]
-    cost [len(list), len(list), 1, 1]
 
-fn sample[A](list: List[A]) -> Option[A]
+fn random_sample[A](list: List[A]) -> Option[A]
     uses [Random]
-    cost [1, 0, 1, 1]
+    cost [1, 0, 1, 0]
 ```
 
 ### 4.4 Error type hierarchy
@@ -666,21 +641,23 @@ Key properties:
 4. **Some operations** may propagate structured runtime outcomes before host conversion (for example `Exit` in project mode).
 5. **Future stdlib wrappers** may layer above this, but they are not required for the current implementation.
 
-### 4.7 Cost expression helpers
+### 4.7 Cost expression inputs
 
-The cost annotation language (SEP-0004) uses these stdlib-provided size functions:
+The cost annotation language (SEP-0004) does not call ordinary stdlib functions
+inside `cost [...]`. Verified costs mention only Index parameters and
+`cost(f)` summaries:
 
-| Function | Description | Returns |
-|----------|-------------|---------|
-| `len(list)` | Length of a list | `I64` |
-| `len(s)` | Length of a string | `I64` |
-| `len(m)` | Number of entries in a map | `I64` |
-| `len(s)` | Number of elements in a set | `I64` |
-| `size(value)` | Serialized size of a value | `I64` |
-| `depth(tree)` | Depth of a tree structure | `I64` |
-| `nodes(tree)` | Number of nodes in a tree | `I64` |
+| Source | Example | Notes |
+|--------|---------|-------|
+| Index parameter | `N: Index` | Compile-time non-negative size symbol |
+| Indexed count | `Count[N]` | Runtime count whose static Index is `N` |
+| Indexed container | `Array[T, N]`, `Vec[T, max: N]` | Exposes `N` to CostExpr |
+| Index operation | `max(N, M)`, `min(N, M)`, `span(Hi, Lo)` | Pure IndexExpr, not runtime function calls |
+| Function summary | `cost(f)` | Substituted when `f` is concrete at the call site |
 
-These functions are only valid inside cost annotations and are evaluated at compile time via the type checker's cost analysis pass.
+Dynamic methods such as `list.len()`, `s.len()`, `map.len()`, or `set.len()`
+return runtime integers. They are useful program APIs, but they are not
+CostExpr variables.
 
 ## Human experience impact
 
@@ -688,7 +665,7 @@ The stdlib is designed for progressive discovery:
 
 1. **Prelude is small**: Only essential types and iteration primitives — no import ceremony for basic programs
 2. **Module names are predictable**: imports like `std.math`, `std.string`, and `std.collections` follow standard conventions
-3. **Cost annotations are readable**: four-slot forms like `cost [len(list), len(list), 0, 1]` stay copy-pasteable
+3. **Cost annotations are readable**: four-slot forms like `cost [N * cost(f) + N, N, 0, 0]` stay copy-pasteable
 4. **Error types are descriptive**: Enum variants like `NotFound(Str)` carry context
 5. **No hidden effects**: Every I/O function explicitly declares its effect requirements
 
@@ -696,7 +673,7 @@ The stdlib is designed for progressive discovery:
 
 Agents benefit from:
 
-1. **Complete enumeration**: All stdlib functions are listed with signatures, enabling auto-completion
+1. **Complete enumeration**: All stdlib functions and methods are listed with signatures, enabling auto-completion
 2. **Cost contracts**: Agents can reason about algorithmic complexity when filling holes
 3. **Effect requirements**: Agents can verify that generated code satisfies effect constraints
 4. **Structured errors**: Error type hierarchy enables pattern-matching on failure modes
@@ -709,13 +686,15 @@ The stdlib is represented in the module system as:
 ```json
 {
   "module": "std.prelude",
-  "functions": [
+  "methods": [
     {
+      "owner": "Vec[A, max: N]",
+      "trait": "Mappable",
       "name": "map",
-      "type_params": ["A", "B"],
-      "params": [{"name": "list", "type": "List[A]"}, {"name": "f", "type": "(A) -> B"}],
-      "return_type": "List[B]",
-      "cost": "len(list) * cost(f) + O(len(list))",
+      "type_params": ["A", "B", "N: Index"],
+      "params": [{"name": "self", "type": "Vec[A, max: N]"}, {"name": "f", "type": "(A) -> B"}],
+      "return_type": "Vec[B, max: N]",
+      "cost": "N * cost(f) + N",
       "effects": []
     }
   ],

--- a/seps/SEP-0009-standard-library.md
+++ b/seps/SEP-0009-standard-library.md
@@ -90,7 +90,7 @@ import basic_cli.cmd
 
 fn main() -> () uses [Console, Exit] {
     println("hello")
-    exit(0)
+    exit(0u8)
 }
 ```
 
@@ -126,7 +126,7 @@ The prelude is implicitly imported into every module. It contains:
 
 **No `Char`.** Unicode scalars are represented as `Str` values (typically length 1). Character predicates and conversions live in `stdlib/char.sp` (`is_digit`, `char_to_int`, …). This matches `spore` PR #113.
 
-**Literals.** In the reference type checker, unsuffixed integer literals default to **`I64`** and float literals to **`F64`**. Older spec examples may still say `Int` / `Float` — see SEP-0002 for the informal shorthand convention.
+**Literals.** In the reference type checker, unsuffixed integer literals default to **`I64`** and floating-point literals default to **`F64`**. Standard-library signatures use explicit fixed-width names; `Int` and `Float` are not standard aliases.
 
 #### Algebraic types
 
@@ -158,22 +158,22 @@ type Ordering { Less, Equal, Greater }
 ```spore
 fn unwrap[T](opt: Option[T]) -> T
     ! PanicError
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn unwrap_or[T](opt: Option[T], default: T) -> T
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn map[T, U](opt: Option[T], f: (T) -> U) -> Option[U]
-    cost cost(f)
+    cost [cost(f), 0, 0, 1]
 
 fn and_then[T, U](opt: Option[T], f: (T) -> Option[U]) -> Option[U]
-    cost cost(f)
+    cost [cost(f), 0, 0, 1]
 
 fn is_some[T](opt: Option[T]) -> Bool
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn is_none[T](opt: Option[T]) -> Bool
-    cost O(1)
+    cost [1, 0, 0, 1]
 ```
 
 #### Result[T, E] methods
@@ -181,25 +181,25 @@ fn is_none[T](opt: Option[T]) -> Bool
 ```spore
 fn unwrap[T, E](res: Result[T, E]) -> T
     ! PanicError
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn unwrap_or[T, E](res: Result[T, E], default: T) -> T
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn map[T, U, E](res: Result[T, E], f: (T) -> U) -> Result[U, E]
-    cost cost(f)
+    cost [cost(f), 0, 0, 1]
 
 fn map_err[T, E, F](res: Result[T, E], f: (E) -> F) -> Result[T, F]
-    cost cost(f)
+    cost [cost(f), 0, 0, 1]
 
 fn and_then[T, U, E](res: Result[T, E], f: (T) -> Result[U, E]) -> Result[U, E]
-    cost cost(f)
+    cost [cost(f), 0, 0, 1]
 
 fn is_ok[T, E](res: Result[T, E]) -> Bool
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn is_err[T, E](res: Result[T, E]) -> Bool
-    cost O(1)
+    cost [1, 0, 0, 1]
 ```
 
 #### List iteration (core HOFs)
@@ -208,82 +208,82 @@ These are the **primary iteration primitives** in Spore (no loops — SEP-0001):
 
 ```spore
 fn map[A, B](list: List[A], f: (A) -> B) -> List[B]
-    cost len(list) * cost(f) + O(len(list))
+    cost [len(list) * cost(f) + len(list), len(list), 0, 1]
 
 fn filter[A](list: List[A], p: (A) -> Bool) -> List[A]
-    cost len(list) * cost(p) + O(len(list))
+    cost [len(list) * cost(p) + len(list), len(list), 0, 1]
 
 fn fold[A, B](list: List[A], init: B, f: (B, A) -> B) -> B
-    cost len(list) * cost(f)
+    cost [len(list) * cost(f), 0, 0, 1]
 
 fn each[A](list: List[A], f: (A) -> Unit) -> Unit
-    cost len(list) * cost(f)
+    cost [len(list) * cost(f), 0, 0, 1]
 
 fn flat_map[A, B](list: List[A], f: (A) -> List[B]) -> List[B]
-    cost len(list) * cost(f) + O(total_output_len)
+    cost [len(list) * cost(f) + total_output_len, total_output_len, 0, 1]
 
 fn zip[A, B](a: List[A], b: List[B]) -> List[(A, B)]
-    cost O(min(len(a), len(b)))
+    cost [min(len(a), len(b)), min(len(a), len(b)), 0, 1]
 
 fn enumerate[A](list: List[A]) -> List[(I64, A)]
-    cost O(len(list))
+    cost [len(list), len(list), 0, 1]
 ```
 
 #### List query functions
 
 ```spore
 fn len[A](list: List[A]) -> I64
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn is_empty[A](list: List[A]) -> Bool
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn head[A](list: List[A]) -> Option[A]
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn tail[A](list: List[A]) -> Option[List[A]]
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn last[A](list: List[A]) -> Option[A]
-    cost O(len(list))
+    cost [len(list), 0, 0, 1]
 
 fn contains[A](list: List[A], item: A) -> Bool
     where A: Eq
-    cost O(len(list))
+    cost [len(list), 0, 0, 1]
 
 fn find[A](list: List[A], p: (A) -> Bool) -> Option[A]
-    cost O(len(list)) * cost(p)
+    cost [len(list) * cost(p), 0, 0, 1]
 
 fn any[A](list: List[A], p: (A) -> Bool) -> Bool
-    cost O(len(list)) * cost(p)
+    cost [len(list) * cost(p), 0, 0, 1]
 
 fn all[A](list: List[A], p: (A) -> Bool) -> Bool
-    cost O(len(list)) * cost(p)
+    cost [len(list) * cost(p), 0, 0, 1]
 ```
 
 #### List construction functions
 
 ```spore
 fn append[A](list: List[A], item: A) -> List[A]
-    cost O(len(list))
+    cost [len(list), len(list), 0, 1]
 
 fn prepend[A](item: A, list: List[A]) -> List[A]
-    cost O(1)
+    cost [1, 1, 0, 1]
 
 fn concat[A](a: List[A], b: List[A]) -> List[A]
-    cost O(len(a))
+    cost [len(a), len(a) + len(b), 0, 1]
 
 fn reverse[A](list: List[A]) -> List[A]
-    cost O(len(list))
+    cost [len(list), len(list), 0, 1]
 
 fn take[A](list: List[A], n: I64) -> List[A]
-    cost O(n)
+    cost [n, n, 0, 1]
 
 fn drop[A](list: List[A], n: I64) -> List[A]
-    cost O(n)
+    cost [n, len(list), 0, 1]
 
 fn range(start: I64, end: I64) -> List[I64]
-    cost O(end - start)
+    cost [end - start, end - start, 0, 1]
 ```
 
 #### Sorting
@@ -291,10 +291,10 @@ fn range(start: I64, end: I64) -> List[I64]
 ```spore
 fn sort[A](list: List[A]) -> List[A]
     where A: Ord
-    cost O(len(list) * log(len(list)))
+    cost [len(list) * log(len(list)), len(list), 0, 1]
 
 fn sort_by[A](list: List[A], cmp: (A, A) -> Ordering) -> List[A]
-    cost O(len(list) * log(len(list))) * cost(cmp)
+    cost [len(list) * log(len(list)) * cost(cmp), len(list), 0, 1]
 ```
 
 #### Conversion and display
@@ -302,11 +302,11 @@ fn sort_by[A](list: List[A], cmp: (A, A) -> Ordering) -> List[A]
 ```spore
 fn to_string[A](value: A) -> Str
     where A: Display
-    cost O(1)
+    cost [1, 1, 0, 1]
 
 fn debug[A](value: A) -> Str
     where A: Debug
-    cost O(1)
+    cost [1, 1, 0, 1]
 ```
 
 ### 4.3 Core modules
@@ -314,36 +314,35 @@ fn debug[A](value: A) -> Str
 #### `std.math`
 
 ```spore
-module std.math
-
-fn abs(x: I64) -> I64             cost O(1)
-fn abs_float(x: F64) -> F64   cost O(1)
-fn min(a: I64, b: I64) -> I64     cost O(1)
-fn max(a: I64, b: I64) -> I64     cost O(1)
-fn clamp(x: I64, lo: I64, hi: I64) -> I64  cost O(1)
+fn abs(x: I64) -> I64                 cost [1, 0, 0, 1]
+fn abs_float(x: F64) -> F64           cost [1, 0, 0, 1]
+fn min(a: I64, b: I64) -> I64         cost [1, 0, 0, 1]
+fn max(a: I64, b: I64) -> I64         cost [1, 0, 0, 1]
+fn clamp(x: I64, lo: I64, hi: I64) -> I64
+    cost [1, 0, 0, 1]
 
 // Floating-point math
-fn sqrt(x: F64) -> F64        cost O(1)
-fn pow(base: F64, exp: F64) -> F64  cost O(1)
-fn log(x: F64) -> F64         cost O(1)
-fn log2(x: F64) -> F64        cost O(1)
-fn log10(x: F64) -> F64       cost O(1)
-fn exp(x: F64) -> F64         cost O(1)
+fn sqrt(x: F64) -> F64                cost [1, 0, 0, 1]
+fn pow(base: F64, exp: F64) -> F64    cost [1, 0, 0, 1]
+fn log(x: F64) -> F64                 cost [1, 0, 0, 1]
+fn log2(x: F64) -> F64                cost [1, 0, 0, 1]
+fn log10(x: F64) -> F64               cost [1, 0, 0, 1]
+fn exp(x: F64) -> F64                 cost [1, 0, 0, 1]
 
 // Trigonometric
-fn sin(x: F64) -> F64         cost O(1)
-fn cos(x: F64) -> F64         cost O(1)
-fn tan(x: F64) -> F64         cost O(1)
-fn asin(x: F64) -> F64        cost O(1)
-fn acos(x: F64) -> F64        cost O(1)
-fn atan(x: F64) -> F64        cost O(1)
-fn atan2(y: F64, x: F64) -> F64  cost O(1)
+fn sin(x: F64) -> F64                 cost [1, 0, 0, 1]
+fn cos(x: F64) -> F64                 cost [1, 0, 0, 1]
+fn tan(x: F64) -> F64                 cost [1, 0, 0, 1]
+fn asin(x: F64) -> F64                cost [1, 0, 0, 1]
+fn acos(x: F64) -> F64                cost [1, 0, 0, 1]
+fn atan(x: F64) -> F64                cost [1, 0, 0, 1]
+fn atan2(y: F64, x: F64) -> F64       cost [1, 0, 0, 1]
 
 // Rounding
-fn floor(x: F64) -> I64         cost O(1)
-fn ceil(x: F64) -> I64          cost O(1)
-fn round(x: F64) -> I64         cost O(1)
-fn truncate(x: F64) -> I64      cost O(1)
+fn floor(x: F64) -> I64                cost [1, 0, 0, 1]
+fn ceil(x: F64) -> I64                 cost [1, 0, 0, 1]
+fn round(x: F64) -> I64                cost [1, 0, 0, 1]
+fn truncate(x: F64) -> I64             cost [1, 0, 0, 1]
 
 // Constants
 let pi: F64 = 3.14159265358979323846
@@ -356,77 +355,76 @@ let nan: F64
 #### `std.string`
 
 ```spore
-module std.string
+fn length(s: Str) -> I64                    cost [1, 0, 0, 1]
+fn is_empty(s: Str) -> Bool                 cost [1, 0, 0, 1]
+fn char_at(s: Str, index: I64) -> Option[Str]
+    cost [1, 0, 0, 1]
+fn substring(s: Str, start: I64, end: I64) -> Str
+    cost [end - start, end - start, 0, 1]
 
-fn length(s: Str) -> I32                  cost O(1)
-fn is_empty(s: Str) -> Bool               cost O(1)
-fn char_at(s: Str, index: I32) -> Option[Str]  cost O(1)
-fn substring(s: Str, start: I32, end: I32) -> Str  cost O(end - start)
-
-fn concat(a: Str, b: Str) -> Str    cost O(len(a) + len(b))
+fn concat(a: Str, b: Str) -> Str      cost [len(a) + len(b), len(a) + len(b), 0, 1]
 fn join(parts: List[Str], sep: Str) -> Str
-    cost O(total_len(parts) + len(parts) * len(sep))
+    cost [total_len(parts) + len(parts) * len(sep), total_len(parts) + len(parts) * len(sep), 0, 1]
 
 fn split(s: Str, sep: Str) -> List[Str]
-    cost O(len(s))
+    cost [len(s), len(s), 0, 1]
 
-fn trim(s: Str) -> Str                 cost O(len(s))
-fn trim_start(s: Str) -> Str           cost O(len(s))
-fn trim_end(s: Str) -> Str             cost O(len(s))
+fn trim(s: Str) -> Str                   cost [len(s), len(s), 0, 1]
+fn trim_start(s: Str) -> Str             cost [len(s), len(s), 0, 1]
+fn trim_end(s: Str) -> Str               cost [len(s), len(s), 0, 1]
 
-fn to_upper(s: Str) -> Str             cost O(len(s))
-fn to_lower(s: Str) -> Str             cost O(len(s))
+fn to_upper(s: Str) -> Str               cost [len(s), len(s), 0, 1]
+fn to_lower(s: Str) -> Str               cost [len(s), len(s), 0, 1]
 
-fn contains(s: Str, pattern: Str) -> Bool  cost O(len(s))
-fn starts_with(s: Str, prefix: Str) -> Bool  cost O(len(prefix))
-fn ends_with(s: Str, suffix: Str) -> Bool  cost O(len(suffix))
+fn contains(s: Str, pattern: Str) -> Bool    cost [len(s), 0, 0, 1]
+fn starts_with(s: Str, prefix: Str) -> Bool  cost [len(prefix), 0, 0, 1]
+fn ends_with(s: Str, suffix: Str) -> Bool    cost [len(suffix), 0, 0, 1]
 
-fn replace(s: Str, from: Str, to: Str) -> Str  cost O(len(s))
+fn replace(s: Str, from: Str, to: Str) -> Str
+    cost [len(s), len(s), 0, 1]
 
-fn parse_int(s: Str) -> Result[I32, ParseError]  cost O(len(s))
-fn parse_float(s: Str) -> Result[F64, ParseError]  cost O(len(s))
+fn parse_int(s: Str) -> Result[I64, ParseError]    cost [len(s), 0, 0, 1]
+fn parse_float(s: Str) -> Result[F64, ParseError]  cost [len(s), 0, 0, 1]
 ```
 
 #### `std.collections`
 
 ```spore
-module std.collections
-
 // ── Map[K, V] ──────────────────────────────────────────────────────
 
 type Map[K, V]  // Immutable hash map (K must implement Hash + Eq)
 
 fn empty_map[K, V]() -> Map[K, V]
     where K: Hash + Eq
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn get[K, V](m: Map[K, V], key: K) -> Option[V]
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn insert[K, V](m: Map[K, V], key: K, value: V) -> Map[K, V]
-    cost O(1)  // amortized
+    cost [1, 1, 0, 1]  // amortized
 
 fn remove[K, V](m: Map[K, V], key: K) -> Map[K, V]
-    cost O(1)  // amortized
+    cost [1, 1, 0, 1]  // amortized
 
 fn contains_key[K, V](m: Map[K, V], key: K) -> Bool
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn keys[K, V](m: Map[K, V]) -> List[K]
-    cost O(len(m))
+    cost [len(m), len(m), 0, 1]
 
 fn values[K, V](m: Map[K, V]) -> List[V]
-    cost O(len(m))
+    cost [len(m), len(m), 0, 1]
 
 fn entries[K, V](m: Map[K, V]) -> List[(K, V)]
-    cost O(len(m))
+    cost [len(m), len(m), 0, 1]
 
 fn map_size[K, V](m: Map[K, V]) -> I64
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn from_list[K, V](pairs: List[(K, V)]) -> Map[K, V]
     where K: Hash + Eq
-    cost O(len(pairs))
+    cost [len(pairs), len(pairs), 0, 1]
 
 // ── Set[T] ─────────────────────────────────────────────────────────
 
@@ -434,35 +432,35 @@ type Set[T]  // Immutable hash set (T must implement Hash + Eq)
 
 fn empty_set[T]() -> Set[T]
     where T: Hash + Eq
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn add[T](s: Set[T], item: T) -> Set[T]
-    cost O(1)  // amortized
+    cost [1, 1, 0, 1]  // amortized
 
 fn remove_from[T](s: Set[T], item: T) -> Set[T]
-    cost O(1)  // amortized
+    cost [1, 1, 0, 1]  // amortized
 
 fn member[T](s: Set[T], item: T) -> Bool
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn set_size[T](s: Set[T]) -> I64
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn union[T](a: Set[T], b: Set[T]) -> Set[T]
-    cost O(len(a) + len(b))
+    cost [len(a) + len(b), len(a) + len(b), 0, 1]
 
 fn intersection[T](a: Set[T], b: Set[T]) -> Set[T]
-    cost O(min(len(a), len(b)))
+    cost [min(len(a), len(b)), min(len(a), len(b)), 0, 1]
 
 fn difference[T](a: Set[T], b: Set[T]) -> Set[T]
-    cost O(len(a))
+    cost [len(a), len(a), 0, 1]
 
 fn to_list[T](s: Set[T]) -> List[T]
-    cost O(len(s))
+    cost [len(s), len(s), 0, 1]
 
 fn from_list[T](items: List[T]) -> Set[T]
     where T: Hash + Eq
-    cost O(len(items))
+    cost [len(items), len(items), 0, 1]
 ```
 
 #### `std.io` (future standardization layer)
@@ -480,6 +478,12 @@ manifest-backed projects import Platform package modules directly. For
 | `basic_cli.env` | `env_get`, `env_set` | `Env` |
 | `basic_cli.cmd` | `process_run`, `process_run_status`, `exit` | `Spawn`, `Exit` |
 
+```spore
+pub foreign fn process_run(cmd: Str, args: List[Str]) -> Str ! ExecError uses [Spawn]
+pub foreign fn process_run_status(cmd: Str, args: List[Str]) -> Option[U8] ! ExecError uses [Spawn]
+pub foreign fn exit(code: U8) -> Never uses [Exit]
+```
+
 `basic_cli.cmd.exit(code)` is the currently shipped explicit process-termination
 surface. In project mode it works together with SEP-0008's startup contract
 (`main() -> ()`), and the runtime converts the resulting structured outcome into
@@ -492,24 +496,22 @@ design sketches rather than as the current contract.
 #### `std.time` (platform-provided)
 
 ```spore
-module std.time
-
 type DateTime   // Opaque timestamp
 type Duration   // Time interval
 
 foreign fn now() -> DateTime
     uses [Clock]
-    cost O(1)
+    cost [1, 0, 1, 1]
 
 foreign fn elapsed(start: DateTime) -> Duration
     uses [Clock]
-    cost O(1)
+    cost [1, 0, 1, 1]
 
 fn duration_ms(d: Duration) -> I64
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 fn duration_secs(d: Duration) -> F64
-    cost O(1)
+    cost [1, 0, 0, 1]
 
 foreign fn sleep(ms: I64) -> Unit
     uses [Clock]
@@ -519,8 +521,6 @@ foreign fn sleep(ms: I64) -> Unit
 #### `std.json`
 
 ```spore
-module std.json
-
 type JsonValue {
     JsonNull,
     JsonBool(Bool),
@@ -532,41 +532,39 @@ type JsonValue {
 }
 
 fn parse_json(s: Str) -> Result[JsonValue, ParseError]
-    cost O(len(s))
+    cost [len(s), len(s), 0, 1]
 
 fn to_json[T](value: T) -> Str
     where T: Serialize
-    cost O(size(value))
+    cost [size(value), size(value), 0, 1]
 
 fn from_json[T](s: Str) -> Result[T, ParseError]
     where T: Deserialize
-    cost O(len(s))
+    cost [len(s), len(s), 0, 1]
 ```
 
 #### `std.random` (platform-provided)
 
 ```spore
-module std.random
-
 foreign fn random_float() -> F64
     uses [Random]
-    cost O(1)
+    cost [1, 0, 1, 1]
 
 foreign fn random_int(min: I64, max: I64) -> I64
     uses [Random]
-    cost O(1)
+    cost [1, 0, 1, 1]
 
 foreign fn uuid() -> Str
     uses [Random]
-    cost O(1)
+    cost [1, 16, 1, 1]
 
 fn shuffle[A](list: List[A]) -> List[A]
     uses [Random]
-    cost O(len(list))
+    cost [len(list), len(list), 1, 1]
 
 fn sample[A](list: List[A]) -> Option[A]
     uses [Random]
-    cost O(1)
+    cost [1, 0, 1, 1]
 ```
 
 ### 4.4 Error type hierarchy
@@ -594,18 +592,18 @@ type IoError {
 type HttpError {
     ConnectionFailed(Str),
     Timeout(Str),
-    StatusError(I32, Str),
+    StatusError(U16, Str),
     Other(Str),
 }
 
 type ParseError {
     InvalidFormat(Str),
-    UnexpectedToken(Str, I32),
+    UnexpectedToken(Str, I64),
     Other(Str),
 }
 
 type JsonError {
-    InvalidJson(Str, I32),
+    InvalidJson(Str, I64),
     TypeMismatch(Str),
     MissingField(Str),
 }
@@ -624,10 +622,10 @@ These 13 traits have special compiler support (SEP-0002). The stdlib provides th
 | `Clone` | `clone(self) -> Self` | ✅ | Deep copy |
 | `Display` | `display(self) -> Str` | ❌ | Human-readable formatting |
 | `Debug` | `debug(self) -> Str` | ✅ | Debug formatting |
-| `Hash` | `hash(self) -> I32` | ✅ | Hash computation |
+| `Hash` | `hash(self) -> U64` | ✅ | Hash computation |
 | `Default` | `default() -> Self` | ✅ | Default value |
-| `Serialize` | `serialize(self) -> List[I32]` | ✅ | Byte serialization |
-| `Deserialize` | `deserialize(bytes: List[I32]) -> Result[Self, ParseError]` | ✅ | Byte deserialization |
+| `Serialize` | `serialize(self) -> List[U8]` | ✅ | Byte serialization |
+| `Deserialize` | `deserialize(bytes: List[U8]) -> Result[Self, ParseError]` | ✅ | Byte deserialization |
 | `Add` | `add(self, other) -> Self` | ❌ | `+` operator |
 | `Sub` | `sub(self, other) -> Self` | ❌ | `-` operator |
 | `Mul` | `mul(self, other) -> Self` | ❌ | `*` operator |
@@ -642,7 +640,7 @@ The current runtime stack for platform-backed I/O looks like this:
 │ User Code                                    │
 │ fn main() -> () uses [Console, Exit] {       │
 │   println("done")                            │
-│   exit(0)                                    │
+│   exit(0u8)                                  │
 │ }                                            │
 ├──────────────────────────────────────────────┤
 │ Platform package modules                     │
@@ -674,13 +672,13 @@ The cost annotation language (SEP-0004) uses these stdlib-provided size function
 
 | Function | Description | Returns |
 |----------|-------------|---------|
-| `len(list)` | Length of a list | `Int` |
-| `len(s)` | Length of a string | `Int` |
-| `len(m)` | Number of entries in a map | `Int` |
-| `len(s)` | Number of elements in a set | `Int` |
-| `size(value)` | Serialized size of a value | `Int` |
-| `depth(tree)` | Depth of a tree structure | `Int` |
-| `nodes(tree)` | Number of nodes in a tree | `Int` |
+| `len(list)` | Length of a list | `I64` |
+| `len(s)` | Length of a string | `I64` |
+| `len(m)` | Number of entries in a map | `I64` |
+| `len(s)` | Number of elements in a set | `I64` |
+| `size(value)` | Serialized size of a value | `I64` |
+| `depth(tree)` | Depth of a tree structure | `I64` |
+| `nodes(tree)` | Number of nodes in a tree | `I64` |
 
 These functions are only valid inside cost annotations and are evaluated at compile time via the type checker's cost analysis pass.
 
@@ -689,8 +687,8 @@ These functions are only valid inside cost annotations and are evaluated at comp
 The stdlib is designed for progressive discovery:
 
 1. **Prelude is small**: Only essential types and iteration primitives — no import ceremony for basic programs
-2. **Module names are predictable**: `std.math`, `std.string`, `std.collections` follow standard conventions
-3. **Cost annotations are readable**: `cost O(len(list))` reads naturally
+2. **Module names are predictable**: imports like `std.math`, `std.string`, and `std.collections` follow standard conventions
+3. **Cost annotations are readable**: four-slot forms like `cost [len(list), len(list), 0, 1]` stay copy-pasteable
 4. **Error types are descriptive**: Enum variants like `NotFound(Str)` carry context
 5. **No hidden effects**: Every I/O function explicitly declares its effect requirements
 
@@ -794,7 +792,7 @@ This is a new specification — no backward compatibility concerns. However:
 
 3. **String encoding**: Should `Str` expose byte-level access, or only scalar-oriented indexing? Current spec assumes UTF-8; there is no `Char` type (length-1 `Str` values instead).
 
-4. **Numeric tower**: The reference implementation already exposes fixed widths (`I8`…`U64`, `F32`, `F64`). This SEP still mixes pedagogical `Int`/`Float` in some module sketches; those should converge to explicit widths over time.
+4. **Numeric tower**: The reference implementation exposes fixed widths (`I8`…`U64`, `F32`, `F64`). Stdlib APIs should choose explicit widths at each boundary rather than relying on abstract scalar aliases.
 
 5. **Iterator protocol**: Should there be a lazy `Iterator[T]` trait instead of materializing `List[T]` for all operations? This would change cost signatures significantly.
 

--- a/templates/informational.md
+++ b/templates/informational.md
@@ -7,7 +7,7 @@ authors:
   - Your Name
 created: YYYY-MM-DD
 requires: []
-discussion: "https://github.com/spore-lang/spore-evolution/discussions/123"
+discussion: "https://github.com/spore-lang/spore-evolution/discussions"
 pr: null
 superseded_by: null
 ---

--- a/templates/process.md
+++ b/templates/process.md
@@ -7,7 +7,7 @@ authors:
   - Your Name
 created: YYYY-MM-DD
 requires: []
-discussion: "https://github.com/spore-lang/spore-evolution/discussions/123"
+discussion: "https://github.com/spore-lang/spore-evolution/discussions"
 pr: null
 superseded_by: null
 ---

--- a/templates/standards-track.md
+++ b/templates/standards-track.md
@@ -7,7 +7,7 @@ authors:
   - Your Name
 created: YYYY-MM-DD
 requires: []
-discussion: "https://github.com/spore-lang/spore-evolution/discussions/123"
+discussion: "https://github.com/spore-lang/spore-evolution/discussions"
 pr: null
 superseded_by: null
 ---


### PR DESCRIPTION
## Proposal summary

- align the compositional semantics slice across the glossary and SEP-0001 through SEP-0009, including fixed-width scalar names, cost-vector notation, and current foundations terminology
- tighten the effect, concurrency, compiler, and module docs around spawn purity, channel effects, watch or hole-graph payloads, platform exit contracts, and shared diagnostic families
- keep the hole-report payload on the v0.x lineage and refresh standard-library or platform examples so the PR reflects the current consistency and foundations pass

## Linked discussion

Canonical discussion cluster:
- https://github.com/spore-lang/spore-evolution/discussions/3
- https://github.com/spore-lang/spore-evolution/discussions/4
- https://github.com/spore-lang/spore-evolution/discussions/5

## Checklist

- [x] I opened or linked a public Discussion or Issue for the pitch before submitting this draft SEP.
- [x] I linked the canonical discussion thread.
- [x] I used the correct SEP template for this proposal type.
- [x] I updated front matter metadata and required sections.

## Notes for reviewers

Validation run locally:
- uvx prek run --all-files
- uv run scripts/check_sep_index.py
- uv run scripts/check_contract_schemas.py
- uv run scripts/validate_sep_documents.py
- git diff --check

This PR now reflects the recent consistency and foundations pass in addition to the original compositional semantics slice, so the title and summary were expanded to match the actual touched scope.